### PR TITLE
Add allow option to allow other domains than "localhost"

### DIFF
--- a/lib/webmock/config.rb
+++ b/lib/webmock/config.rb
@@ -4,5 +4,6 @@ module WebMock
     
     attr_accessor :allow_net_connect
     attr_accessor :allow_localhost
+    attr_accessor :allow
   end
 end

--- a/lib/webmock/webmock.rb
+++ b/lib/webmock/webmock.rb
@@ -37,14 +37,16 @@ module WebMock
   def disable_net_connect!(options = {})
     Config.instance.allow_net_connect = false
     Config.instance.allow_localhost = options[:allow_localhost]
+    Config.instance.allow = options[:allow]
   end
 
   def net_connect_allowed?(uri = nil)
     if uri.is_a?(String)
       uri = WebMock::Util::URI.normalize_uri(uri)
     end
-    Config.instance.allow_net_connect || 
-      (Config.instance.allow_localhost && uri.is_a?(Addressable::URI) && (uri.host == 'localhost' || uri.host == '127.0.0.1'))
+    Config.instance.allow_net_connect ||
+      (Config.instance.allow_localhost && uri.is_a?(Addressable::URI) && (uri.host == 'localhost' || uri.host == '127.0.0.1')) ||
+      Config.instance.allow && Config.instance.allow.include?(uri.host)
   end
 
   def registered_request?(request_signature)

--- a/spec/webmock_spec.rb
+++ b/spec/webmock_spec.rb
@@ -99,6 +99,29 @@ describe "WebMock", :shared => true do
         }.should raise_error(connection_refused_exception_class)
       end
     end
+    
+   describe "is not allowed with exception for allowed domains" do
+      before(:each) do
+        WebMock.disable_net_connect!(:allow => ["cms.local"])
+      end
+
+      it "should return stubbed response if request was stubbed" do
+        stub_http_request(:get, "www.example.com").to_return(:body => "abc")
+        http_request(:get, "http://www.example.com/").body.should == "abc"
+      end
+
+      it "should raise exception if request was not stubbed" do
+        lambda {
+          http_request(:get, "http://www.example.com/")
+        }.should raise_error(WebMock::NetConnectNotAllowedError, client_specific_request_string("Real HTTP connections are disabled. Unregistered request: GET http://www.example.com/"))
+      end
+
+      it "should allow a real request to cms.local" do
+        lambda {
+          http_request(:get, "http://cms.local:12345/")
+        }.should raise_error(connection_refused_exception_class)
+      end
+    end
   end
 
   describe "when matching requests" do


### PR DESCRIPTION
Today we came across a situation where we needed to allow access to a local site (cms.local) but not access to any other site. It seemed like WebMock didn't have an option to do this, so we've (myself + radar) have added this and think you and users of webmock may find this useful. Tests included.
