### PR TITLE
webmock patron specs try to remove a system directory

### DIFF
--- a/spec/patron_spec.rb
+++ b/spec/patron_spec.rb
@@ -21,7 +21,7 @@ unless RUBY_PLATFORM =~ /java/
       describe "file requests" do
 
         before(:each) do
-          @dir_path = Dir.tmpdir
+          @dir_path = Dir.mktmpdir('webmock-')
           @file_path = File.join(@dir_path, "webmock_temp_test_file")
           FileUtils.rm_rf(@file_path) if File.exists?(@file_path)
         end


### PR DESCRIPTION
Dir.tmpdir should not be removed. This commit creates a unique temporary directory that is safe to remove afterwards.
