### PR TITLE
Small patch to make mocked EventMachine::HttpRequest a bit more complete

### DIFF
--- a/lib/webmock/http_lib_adapters/em_http_request.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request.rb
@@ -10,7 +10,7 @@ if defined?(EventMachine::HttpRequest)
       class WebMockHttpClient < EventMachine::HttpClient
 
         def setup(response, uri, error = nil)
-          @uri = uri
+          @last_effective_url = @uri = uri
           if error
             on_error(error)
             fail(self)

--- a/spec/em_http_request_spec.rb
+++ b/spec/em_http_request_spec.rb
@@ -30,5 +30,26 @@ unless RUBY_PLATFORM =~ /java/
       http_request(:get, "http://www.example.com/?x=3", :query => "a[]=b&a[]=c").body.should == "abc"
     end
 
+    describe "mocking EM::HttpClient API" do
+      before { stub_http_request(:get, "www.example.com/") }
+      subject do
+        client = nil
+        EM.run do
+          client = EventMachine::HttpRequest.new('http://www.example.com/').get
+          client.callback { EM.stop }
+          client.errback { failed }
+        end
+        client
+      end
+
+      it 'should support #uri' do
+        subject.uri.should == Addressable::URI.parse('http://www.example.com/')
+      end
+
+      it 'should support #last_effective_url' do
+        subject.last_effective_url.should == Addressable::URI.parse('http://www.example.com/')
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Hi, thanks for creating WebMock - it's very handy!

I ran into a small issue mocking some em-http-request code: our code was calling `last_effective_url` on the returned HttpClient, but the WebMockHttpRequest::WebMockHttpClient mocked version of that method always returns nil.  This patch makes it instead just make it return the URI that was passed in, which is a reasonable behaviour for mocking a simple request (one without redirects etc).

Would be great if you could include this in the next release of the gem, so we don't have to vendor our patched version :)
## Cheers,

Sam Stokes
Rapportive
