### PR TITLE
Curb::Easy#http_post & Curb::Easy#http_put w/o arguments

### DIFF
--- a/lib/webmock/http_lib_adapters/curb.rb
+++ b/lib/webmock/http_lib_adapters/curb.rb
@@ -117,9 +117,9 @@ if defined?(Curl)
         alias_method "http_#{verb}", "http_#{verb}_with_webmock"
       end
 
-      def http_put_with_webmock data
+      def http_put_with_webmock data = nil
         @webmock_method = :put
-        @put_data = data
+        @put_data = data if data
         curb_or_webmock do
           http_put_without_webmock(data)
         end
@@ -127,9 +127,9 @@ if defined?(Curl)
       alias_method :http_put_without_webmock, :http_put
       alias_method :http_put, :http_put_with_webmock
 
-      def http_post_with_webmock data
+      def http_post_with_webmock data = nil
         @webmock_method = :post
-        @post_body = data
+        @post_body = data if data
         curb_or_webmock do
           http_post_without_webmock(data)
         end

--- a/spec/curb_spec.rb
+++ b/spec/curb_spec.rb
@@ -153,6 +153,24 @@ unless RUBY_PLATFORM =~ /java/
     describe "using #http_* methods for requests" do
       it_should_behave_like "Curb"
       include CurbSpecHelper::NamedHttp
+
+      it "should work with blank arguments for post" do
+        stub_http_request(:post, "www.example.com").with(:body => "01234")
+        c = Curl::Easy.new
+        c.url = "http://www.example.com"
+        c.post_body = "01234"
+        c.http_post
+        c.response_code.should == 200
+      end
+
+      it "should work with blank arguments for put" do
+        stub_http_request(:put, "www.example.com").with(:body => "01234")
+        c = Curl::Easy.new
+        c.url = "http://www.example.com"
+        c.put_data = "01234"
+        c.http_put
+        c.response_code.should == 200
+      end
     end
 
     describe "using #perform for requests" do


### PR DESCRIPTION
It's not quite clear from the curb docs, but it's possible to use Curb::Easy#http_post & Curb::Easy#http_put methods without arguments (by setting post_body or put_data beforehand). In the current webmock implementation the data argument is mandatory and this patch makes it optional as it is in curb.
