### PR TITLE
Matching partial body params

### DIFF
--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -147,7 +147,7 @@ module WebMock
         when :xml then
           Crack::XML.parse(body) == @pattern
         else
-          Addressable::URI.parse('?' + body).query_values == @pattern
+          hash_contains?(Addressable::URI.parse('?' + body).query_values, @pattern)
         end
       else
         empty_string?(@pattern) && empty_string?(body) ||
@@ -161,6 +161,10 @@ module WebMock
     end
 
     private
+    
+    def hash_contains?(haystack, needle)
+      needle.select{|k, v| haystack[k] != v}.empty?
+    end
 
     def empty_string?(string)
       string.nil? || string == ""

--- a/spec/request_pattern_spec.rb
+++ b/spec/request_pattern_spec.rb
@@ -214,7 +214,12 @@ describe WebMock::RequestPattern do
               should match(WebMock::RequestSignature.new(:post, "www.example.com", :body => 'a=1&c[d][]=e&b=five&c[d][]=f'))
           end
 
-          it "should not match when hash doesn't match url encoded body" do
+          it "should match if body is a superset of pattern hash" do
+            WebMock::RequestPattern.new(:post, "www.example.com", :body => {:a => "1"}).
+              should match(WebMock::RequestSignature.new(:post, "www.example.com", :body => 'a=1&c[d][]=e&c[d][]=f&b=five'))
+          end
+
+          it "should not match when hash is not completely contained by url encoded body" do
            WebMock::RequestPattern.new(:post, 'www.example.com', :body => body_hash).
               should_not match(WebMock::RequestSignature.new(:post, "www.example.com", :body => 'c[d][]=f&a=1&c[d][]=e'))
           end


### PR DESCRIPTION
The current implementation of matching the body as a hash seems flawed in that it only matches when the pattern contains the entirety of the body hash.  For example:

```
#connection class
post(SERVICE_URI, :body => {:username => "testname", :password => "testpassword"})

#spec
WebMock.should have_requested(:post, SERVICE_URI).with(:body => {"password" => "testpassword"})
```

The spec in this case fails in the current implementation, as it doesn't completely specify the hash that was passed into the post.  I can't think of any situations where my proposed method of specifying partial matches should reasonably fail—and if that is the desired functionality, it would seem that one should specify that instead of letting a magic default in a mocking library allow your test to pass.  Using this patch the above specification would indeed pass.
