### PR TITLE
new httpclient version does not support #body

### DIFF
--- a/lib/webmock/http_lib_adapters/httpclient.rb
+++ b/lib/webmock/http_lib_adapters/httpclient.rb
@@ -119,7 +119,7 @@ if defined?(::HTTPClient)
     request_signature = WebMock::RequestSignature.new(
       req.header.request_method.downcase.to_sym,
       uri.to_s,
-      :body => req.body.content,
+      :body => req.content,
       :headers => headers
     )
   end


### PR DESCRIPTION
new httpclient version does not support #body to get the body object anymore. #content seems to be available in both new and older versions.
