### PR TITLE
Improve HTTPClient versions compatibility.

### DIFF
--- a/lib/webmock/http_lib_adapters/httpclient.rb
+++ b/lib/webmock/http_lib_adapters/httpclient.rb
@@ -119,7 +119,7 @@ if defined?(::HTTPClient)
     request_signature = WebMock::RequestSignature.new(
       req.header.request_method.downcase.to_sym,
       uri.to_s,
-      :body => req.body.content,
+      :body => req.content,
       :headers => headers
     )
   end


### PR DESCRIPTION
Thanks for supporting HTTPClient.

httpclient changed Message#body method as an alias of Message#content
from 2.2.0. This change keeps both httpclient 2.2.0 and < 2.2.0
compatibility.

Sorry for this trouble (my bad), but I want this change to be pulled.
