### PR TITLE
Fix double resume FiberError when stubbing .to_timeout with em-synchrony

### DIFF
--- a/lib/webmock/http_lib_adapters/em_http_request.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request.rb
@@ -12,8 +12,10 @@ if defined?(EventMachine::HttpRequest)
         def setup(response, uri, error = nil)
           @last_effective_url = @uri = uri
           if error
-            on_error(error)
-            fail(self)
+            EM.next_tick do
+              on_error(error)
+              fail(self)
+            end
           else
             EM.next_tick do
               receive_data(response)


### PR DESCRIPTION
Hi,

The current implementation of errors/timeout for the em-http adaptor causes a double resume FiberError when used with em-synchrony. 

See this [gist](https://gist.github.com/982909) to replicate the problem.

Adding EM.next_tick to the error/timeout throwing fixes the problem for me and doesn't affect the existing tests. I had a brief attempt at writing specs to prove this further, but it would require writing a suite for EM Synchrony which is possibly more effort than its worth at the moment.
