### PR TITLE
Silence warnings.

### DIFF
--- a/lib/webmock/http_lib_adapters/curb.rb
+++ b/lib/webmock/http_lib_adapters/curb.rb
@@ -90,16 +90,16 @@ if defined?(Curl)
       end
 
       def invoke_curb_callbacks
-        @on_progress.call(0.0,1.0,0.0,1.0) if @on_progress
-        @on_header.call(self.header_str) if @on_header
-        @on_body.call(self.body_str) if @on_body
-        @on_complete.call(self) if @on_complete
+        @on_progress.call(0.0,1.0,0.0,1.0) if defined?(@on_progress)
+        @on_header.call(self.header_str) if defined?(@on_header)
+        @on_body.call(self.body_str) if defined?(@on_body)
+        @on_complete.call(self) if defined?(@on_complete)
 
         case response_code
         when 200..299
-          @on_success.call(self) if @on_success
+          @on_success.call(self) if defined?(@on_success)
         when 500..599
-          @on_failure.call(self, self.response_code) if @on_failure
+          @on_failure.call(self, self.response_code) if defined?(@on_failure)
         end
       end
 
@@ -198,31 +198,31 @@ if defined?(Curl)
       alias_method :head=, :head_with_webmock=
 
       def body_str_with_webmock
-        @body_str || body_str_without_webmock
+        defined?(@body_str) ? @body_str : body_str_without_webmock
       end
       alias :body_str_without_webmock :body_str
       alias :body_str :body_str_with_webmock
 
       def response_code_with_webmock
-        @response_code || response_code_without_webmock
+        defined?(@response_code) ? @response_code : response_code_without_webmock
       end
       alias :response_code_without_webmock :response_code
       alias :response_code :response_code_with_webmock
 
       def header_str_with_webmock
-        @header_str || header_str_without_webmock
+        defined?(@header_str) ? @header_str : header_str_without_webmock
       end
       alias :header_str_without_webmock :header_str
       alias :header_str :header_str_with_webmock
 
       def last_effective_url_with_webmock
-        @last_effective_url || last_effective_url_without_webmock
+        defined?(@last_effective_url) ? @last_effective_url : last_effective_url_without_webmock
       end
       alias :last_effective_url_without_webmock :last_effective_url
       alias :last_effective_url :last_effective_url_with_webmock
 
       def content_type_with_webmock
-        @content_type || content_type_without_webmock
+        defined?(@content_type) ? @content_type : content_type_without_webmock
       end
       alias :content_type_without_webmock :content_type
       alias :content_type :content_type_with_webmock
@@ -231,35 +231,43 @@ if defined?(Curl)
         class_eval <<-METHOD, __FILE__, __LINE__
           def on_#{callback}_with_webmock &block
             @on_#{callback} = block
-            on_#{callback}_without_webmock &block
+            on_#{callback}_without_webmock(&block)
           end
         METHOD
         alias_method "on_#{callback}_without_webmock", "on_#{callback}"
         alias_method "on_#{callback}", "on_#{callback}_with_webmock"
       end
 
-      %w[ http_get http_head http_delete perform ].each do |method|
-        class_eval <<-METHOD, __FILE__, __LINE__
-          def self.#{method}(url, &block)
-            c = new
-            c.url = url
-            block.call(c) if block
-            c.send("#{method}")
-            c
-          end
-        METHOD
-      end
+      class << self
+        %w[ http_get http_head http_delete perform ].each do |method|
+          class_eval <<-METHOD, __FILE__, __LINE__
+            undef :#{method} if method_defined? :#{method}
 
-      %w[ put post ].each do |verb|
-        class_eval <<-METHOD, __FILE__, __LINE__
-          def self.http_#{verb}(url, data, &block)
-            c = new
-            c.url = url
-            block.call(c) if block
-            c.send("http_#{verb}", data)
-            c
-          end
-        METHOD
+            def #{method}(url, &block)
+              c = new
+              c.url = url
+              block.call(c) if block
+              c.send("#{method}")
+              c
+            end
+          METHOD
+        end
+
+        %w[ put post ].each do |verb|
+          method = "http_#{verb}"
+
+          class_eval <<-METHOD, __FILE__, __LINE__
+            undef :#{method} if method_defined? :#{method}
+
+            def #{method}(url, data, &block)
+              c = new
+              c.url = url
+              block.call(c) if block
+              c.send("#{method}", data)
+              c
+            end
+          METHOD
+        end
       end
 
       module WebmockHelper

--- a/lib/webmock/http_lib_adapters/httpclient.rb
+++ b/lib/webmock/http_lib_adapters/httpclient.rb
@@ -103,10 +103,10 @@ if defined?(::HTTPClient)
     auth = www_auth.basic_auth
     auth.challenge(req.header.request_uri, nil)
 
-    headers = req.header.all.inject({}) do |headers, header|
-      headers[header[0]] ||= [];
-      headers[header[0]] << header[1]
-      headers
+    headers = req.header.all.inject({}) do |hash, header|
+      hash[header[0]] ||= [];
+      hash[header[0]] << header[1]
+      hash
     end
 
     if (auth_cred = auth.get(req)) && auth.scheme == 'Basic'

--- a/lib/webmock/http_lib_adapters/net_http_response.rb
+++ b/lib/webmock/http_lib_adapters/net_http_response.rb
@@ -15,7 +15,7 @@ module WebMock
   module Net
     module HTTPResponse
       def read_body(dest = nil, &block)
-        return super if @__read_body_previously_called
+        return super if defined?(@__read_body_previously_called)
         return @body if dest.nil? && block.nil?
         raise ArgumentError.new("both arg and block given for HTTP method") if dest && block
         return nil if @body.nil?

--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -3,6 +3,8 @@ module WebMock
   class RequestPattern
 
     def initialize(method, uri, options = {})
+      @body_pattern, @headers_pattern, @with_block = nil
+
       @method_pattern = MethodPattern.new(method)
       @uri_pattern = create_uri_pattern(uri)
       assign_options(options)
@@ -74,6 +76,10 @@ module WebMock
   end
 
   class URIRegexpPattern  < URIPattern
+    def initialize(*args)
+      super
+      @query_params = nil
+    end
 
     def matches?(uri)
       WebMock::Util::URI.variations_of_uri_as_strings(uri).any? { |u| u.match(@pattern) } &&
@@ -89,7 +95,6 @@ module WebMock
     def add_query_params(query_params)
       @query_params = query_params.is_a?(Hash) ? query_params : Addressable::URI.parse('?' + query_params).query_values
     end
-
   end
 
   class URIStringPattern < URIPattern

--- a/lib/webmock/util/headers.rb
+++ b/lib/webmock/util/headers.rb
@@ -24,7 +24,7 @@ module WebMock
         str << headers.map do |k,v|
           v = case v
             when Regexp then v.inspect
-            when Array then "["+v.map{|v| "'#{v.to_s}'"}.join(", ")+"]"
+            when Array then "["+v.map{|s| "'#{s.to_s}'"}.join(", ")+"]"
             else "'#{v.to_s}'"
           end
           "'#{k}'=>#{v}"

--- a/spec/curb_spec.rb
+++ b/spec/curb_spec.rb
@@ -13,7 +13,7 @@ unless RUBY_PLATFORM =~ /java/
       it "should stub them" do
         stub_http_request(:put, "www.example.com").with(:body => "01234")
         http_request(:put, "http://www.example.com", :body => "01234").
-          status.should == "200"
+          status.should be == "200"
       end
     end
   end
@@ -39,7 +39,7 @@ unless RUBY_PLATFORM =~ /java/
           test = c.body_str
         end
         @curl.http_get
-        test.should == body
+        test.should be == body
       end
 
       it "should call on_failure with 5xx response" do
@@ -52,7 +52,7 @@ unless RUBY_PLATFORM =~ /java/
           test = code
         end
         @curl.http_get
-        test.should == response_code
+        test.should be == response_code
       end
 
       it "should call on_body when response body is read" do
@@ -65,7 +65,7 @@ unless RUBY_PLATFORM =~ /java/
           test = data
         end
         @curl.http_get
-        test.should == body
+        test.should be == body
       end
 
       it "should call on_header when response headers are read" do
@@ -89,7 +89,7 @@ unless RUBY_PLATFORM =~ /java/
           test = curl.body_str
         end
         @curl.http_get
-        test.should == body
+        test.should be == body
       end
 
       it "should call on_progress when portion of response body is read" do
@@ -97,12 +97,12 @@ unless RUBY_PLATFORM =~ /java/
 
         test = nil
         @curl.on_progress do |*args|
-          args.length.should == 4
-          args.each {|arg| arg.is_a?(Float).should == true }
+          args.length.should be == 4
+          args.each {|arg| arg.is_a?(Float).should be == true }
           test = true
         end
         @curl.http_get
-        test.should == true
+        test.should be == true
       end
 
       it "should call callbacks in correct order on successful request" do
@@ -116,7 +116,7 @@ unless RUBY_PLATFORM =~ /java/
         @curl.on_progress {|*args| order << :on_progress }
         @curl.http_get
 
-        order.should == [:on_progress,:on_header,:on_body,:on_complete,:on_success]
+        order.should be == [:on_progress,:on_header,:on_body,:on_complete,:on_success]
       end
 
       it "should call callbacks in correct order on successful request" do
@@ -130,7 +130,7 @@ unless RUBY_PLATFORM =~ /java/
         @curl.on_progress {|*args| order << :on_progress }
         @curl.http_get
 
-        order.should == [:on_progress,:on_header,:on_body,:on_complete,:on_failure]
+        order.should be == [:on_progress,:on_header,:on_body,:on_complete,:on_failure]
       end
     end
 
@@ -150,7 +150,7 @@ unless RUBY_PLATFORM =~ /java/
                       :headers => { 'Location' => 'http://www.example.com' })
 
           @curl.http_get
-          @curl.last_effective_url.should == 'http://example.com'
+          @curl.last_effective_url.should be == 'http://example.com'
         end
       end
 
@@ -160,7 +160,7 @@ unless RUBY_PLATFORM =~ /java/
         it 'should be the same as #url when no location header is present' do
           stub_request(:any, "example.com")
           @curl.http_get
-          @curl.last_effective_url.should == 'http://example.com'
+          @curl.last_effective_url.should be == 'http://example.com'
         end
 
         it 'should be the value of the location header when present' do
@@ -169,7 +169,7 @@ unless RUBY_PLATFORM =~ /java/
           stub_request(:any, 'www.example.com')
 
           @curl.http_get
-          @curl.last_effective_url.should == 'http://www.example.com'
+          @curl.last_effective_url.should be == 'http://www.example.com'
         end
 
         it 'should work with more than one redirect' do
@@ -180,7 +180,7 @@ unless RUBY_PLATFORM =~ /java/
           stub_request(:any, 'blog.example.com')
 
           @curl.http_get
-          @curl.last_effective_url.should == 'http://blog.example.com'
+          @curl.last_effective_url.should be == 'http://blog.example.com'
         end
 
         it 'should maintain the original url' do
@@ -189,7 +189,7 @@ unless RUBY_PLATFORM =~ /java/
           stub_request(:any, 'www.example.com')
 
           @curl.http_get
-          @curl.url.should == 'http://example.com'
+          @curl.url.should be == 'http://example.com'
         end
 
         it 'should have the redirected-to attrs (body, response code)' do
@@ -200,8 +200,8 @@ unless RUBY_PLATFORM =~ /java/
           stub_request(:any, 'www.example.com').to_return(:body => 'request B')
 
           @curl.http_get
-          @curl.body_str.should == 'request B'
-          @curl.response_code.should == 200
+          @curl.body_str.should be == 'request B'
+          @curl.response_code.should be == 200
         end
 
         it 'should follow more than one redirect' do
@@ -212,8 +212,8 @@ unless RUBY_PLATFORM =~ /java/
           stub_request(:any, 'blog.example.com').to_return(:body => 'blog post')
 
           @curl.http_get
-          @curl.url.should == 'http://example.com'
-          @curl.body_str.should == 'blog post'
+          @curl.url.should be == 'http://example.com'
+          @curl.body_str.should be == 'blog post'
         end
       end
     end
@@ -234,7 +234,7 @@ unless RUBY_PLATFORM =~ /java/
                       :headers  => { 'Content-Type' => content_type })
 
           @curl.http_get
-          @curl.content_type.should == content_type
+          @curl.content_type.should be == content_type
         end
       end
 
@@ -264,7 +264,7 @@ unless RUBY_PLATFORM =~ /java/
         c = Curl::Easy.new
         c.url = "http://www.example.com"
         c.http(:GET)
-        c.body_str.should == "abc"
+        c.body_str.should be == "abc"
       end
     end
 
@@ -278,7 +278,7 @@ unless RUBY_PLATFORM =~ /java/
         c.url = "http://www.example.com"
         c.post_body = "01234"
         c.http_post
-        c.response_code.should == 200
+        c.response_code.should be == 200
       end
 
       it "should work with blank arguments for put" do
@@ -287,7 +287,7 @@ unless RUBY_PLATFORM =~ /java/
         c.url = "http://www.example.com"
         c.put_data = "01234"
         c.http_put
-        c.response_code.should == 200
+        c.response_code.should be == 200
       end
     end
 

--- a/spec/em_http_request_spec.rb
+++ b/spec/em_http_request_spec.rb
@@ -17,22 +17,22 @@ unless RUBY_PLATFORM =~ /java/
         http = EventMachine::HttpRequest.new('http://www.example.com/').get
         http.stream { |chunk| response = chunk; EM.stop  }
       }
-      response.should == "abc"
+      response.should be == "abc"
     end
 
     it "should work with responses that use chunked transfer encoding" do
       stub_http_request(:get, "www.example.com").to_return(:body => "abc", :headers => { 'Transfer-Encoding' => 'chunked' })
-      http_request(:get, "http://www.example.com").body.should == "abc"
+      http_request(:get, "http://www.example.com").body.should be == "abc"
     end
 
     it "should work with optional query params" do
       stub_http_request(:get, "www.example.com/?x=3&a[]=b&a[]=c").to_return(:body => "abc")
-      http_request(:get, "http://www.example.com/?x=3", :query => {"a" => ["b", "c"]}).body.should == "abc"
+      http_request(:get, "http://www.example.com/?x=3", :query => {"a" => ["b", "c"]}).body.should be == "abc"
     end
 
     it "should work with optional query params declared as string" do
       stub_http_request(:get, "www.example.com/?x=3&a[]=b&a[]=c").to_return(:body => "abc")
-      http_request(:get, "http://www.example.com/?x=3", :query => "a[]=b&a[]=c").body.should == "abc"
+      http_request(:get, "http://www.example.com/?x=3", :query => "a[]=b&a[]=c").body.should be == "abc"
     end
 
     describe "mocking EM::HttpClient API" do
@@ -48,11 +48,11 @@ unless RUBY_PLATFORM =~ /java/
       end
 
       it 'should support #uri' do
-        subject.uri.should == Addressable::URI.parse('http://www.example.com/')
+        subject.uri.should be == Addressable::URI.parse('http://www.example.com/')
       end
 
       it 'should support #last_effective_url' do
-        subject.last_effective_url.should == Addressable::URI.parse('http://www.example.com/')
+        subject.last_effective_url.should be == Addressable::URI.parse('http://www.example.com/')
       end
     end
 

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -10,7 +10,7 @@ describe "errors" do
         expected =  "Real HTTP connections are disabled. Unregistered request: aaa" +
                "\n\nYou can stub this request with the following snippet:\n\n" +
                "bbb\n\n============================================================"
-        WebMock::NetConnectNotAllowedError.new(request_signature).message.should == expected
+        WebMock::NetConnectNotAllowedError.new(request_signature).message.should be == expected
       end
     end
   end

--- a/spec/httpclient_spec.rb
+++ b/spec/httpclient_spec.rb
@@ -19,14 +19,14 @@ describe "Webmock with HTTPClient" do
     http_request(:get, "http://www.example.com/") do |body|
       response_body = body
     end
-    response_body.should == "abc"
+    response_body.should be == "abc"
   end
 
    it "should match requests if headers are the same  but in different order" do
      stub_http_request(:get, "www.example.com").with(:headers => {"a" => ["b", "c"]} )
      http_request(
        :get, "http://www.example.com/",
-       :headers => {"a" => ["c", "b"]}).status.should == "200"
+       :headers => {"a" => ["c", "b"]}).status.should be == "200"
    end
 
 

--- a/spec/httpclient_spec_helper.rb
+++ b/spec/httpclient_spec_helper.rb
@@ -17,13 +17,13 @@ module HTTPClientSpecHelper
     else
       response = c.request(*params, &block)
     end
-    headers = response.header.all.inject({}) do |headers, header|
-      if !headers.has_key?(header[0])
-        headers[header[0]] = header[1]
+    headers = response.header.all.inject({}) do |hash, header|
+      if !hash.has_key?(header[0])
+        hash[header[0]] = header[1]
       else
-        headers[header[0]] = [headers[header[0]], header[1]].join(', ')
+        hash[header[0]] = [hash[header[0]], header[1]].join(', ')
       end
-      headers
+      hash
     end
     OpenStruct.new({
       :body => HTTPClientSpecHelper.async_mode ? response.content.read : response.content,

--- a/spec/net_http_spec.rb
+++ b/spec/net_http_spec.rb
@@ -11,13 +11,13 @@ describe "Webmock with Net:HTTP" do
 
   it "should work with block provided" do
     stub_http_request(:get, "www.example.com").to_return(:body => "abc"*100000)
-    Net::HTTP.start("www.example.com") { |query| query.get("/") }.body.should == "abc"*100000
+    Net::HTTP.start("www.example.com") { |query| query.get("/") }.body.should be == "abc"*100000
   end
 
   it "should handle multiple values for the same response header" do
     stub_http_request(:get, "www.example.com").to_return(:headers => { 'Set-Cookie' => ['foo=bar', 'bar=bazz'] })
     response = Net::HTTP.get_response(URI.parse("http://www.example.com/"))
-    response.get_fields('Set-Cookie').should == ['bar=bazz', 'foo=bar']
+    response.get_fields('Set-Cookie').should be == ['bar=bazz', 'foo=bar']
   end
 
   it "should yield block on response" do
@@ -26,21 +26,21 @@ describe "Webmock with Net:HTTP" do
     http_request(:get, "http://www.example.com/") do |response|
       response_body = response.body
     end
-    response_body.should == "abc"
+    response_body.should be == "abc"
   end
 
   it "should handle Net::HTTP::Post#body" do
     stub_http_request(:post, "www.example.com").with(:body => "my_params").to_return(:body => "abc")
     req = Net::HTTP::Post.new("/")
     req.body = "my_params"
-    Net::HTTP.start("www.example.com") { |http| http.request(req)}.body.should == "abc"
+    Net::HTTP.start("www.example.com") { |http| http.request(req)}.body.should be == "abc"
   end
 
   it "should handle Net::HTTP::Post#body_stream" do
     stub_http_request(:post, "www.example.com").with(:body => "my_params").to_return(:body => "abc")
     req = Net::HTTP::Post.new("/")
     req.body_stream = StringIO.new("my_params")
-    Net::HTTP.start("www.example.com") { |http| http.request(req)}.body.should == "abc"
+    Net::HTTP.start("www.example.com") { |http| http.request(req)}.body.should be == "abc"
   end
 
   it "should behave like Net::HTTP and raise error if both request body and body argument are set" do
@@ -156,19 +156,19 @@ describe "Webmock with Net:HTTP" do
       end
       response_body.should =~ expected_body_regex
 
-      @callback_response.body.should == response_body
+      @callback_response.body.should be == response_body
     end
 
     it "should support the after_request callback on a request with a returning block" do
       response_body = perform_get_with_returning_block
       response_body.should =~ expected_body_regex
       @callback_response.should be_instance_of(WebMock::Response)
-      @callback_response.body.should == response_body
+      @callback_response.body.should be == response_body
     end
 
     it "should only invoke the after_request callback once, even for a recursive post request" do
       Net::HTTP.new('example.com', 80).post('/', nil)
-      @callback_invocation_count.should == 1
+      @callback_invocation_count.should be == 1
     end
   end
 

--- a/spec/net_http_spec_helper.rb
+++ b/spec/net_http_spec_helper.rb
@@ -8,13 +8,13 @@ module NetHTTPSpecHelper
     response = nil
     clazz = Net::HTTP.const_get("#{method.to_s.capitalize}")
     req = clazz.new("#{uri.path}#{uri.query ? '?' : ''}#{uri.query}", nil)
-    options[:headers].each do |k,v|
-      if v.is_a?(Array)
-        v.each_with_index do |v,i|
-          i == 0 ? (req[k] = v) : req.add_field(k, v)
+    options[:headers].each do |key,val|
+      if val.is_a?(Array)
+        val.each_with_index do |v,i|
+          i == 0 ? (req[key] = v) : req.add_field(key, v)
         end
       else
-        req[k] = v
+        req[key] = val
       end
     end if options[:headers]
 
@@ -26,8 +26,8 @@ module NetHTTPSpecHelper
       http.ssl_timeout = 10 unless RUBY_VERSION == "1.9.1"
     end
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-    response = http.start {|http|
-      http.request(req, options[:body], &block)
+    response = http.start {|h|
+      h.request(req, options[:body], &block)
     }
     headers = {}
     response.each_header {|name, value| headers[name] = value}

--- a/spec/patron_spec.rb
+++ b/spec/patron_spec.rb
@@ -33,7 +33,7 @@ unless RUBY_PLATFORM =~ /java/
         it "should work with get_file" do
           stub_http_request(:get, "www.example.com").to_return(:body => "abc")
           @sess.get_file("/", @file_path)
-          File.read(@file_path).should == "abc"
+          File.read(@file_path).should be == "abc"
         end
 
         it "should raise same error as Patron if file is not readable for get request" do

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -51,7 +51,7 @@ describe "The library itself" do
   it "can still be built" do
     Dir.chdir(File.expand_path('../../', __FILE__)) do
       `gem build webmock.gemspec`
-      $?.should == 0
+      $?.should be == 0
 
       # clean up the .gem generated
       system("rm webmock-#{WebMock.version}.gem")

--- a/spec/request_execution_verifier_spec.rb
+++ b/spec/request_execution_verifier_spec.rb
@@ -17,7 +17,7 @@ describe WebMock::RequestExecutionVerifier do
       @verifier.expected_times_executed = 2
       expected_text = "The request www.example.com was expected to execute 2 times but it executed 0 times"
       expected_text << @executed_requests_info
-      @verifier.failure_message.should == expected_text
+      @verifier.failure_message.should be == expected_text
     end
 
     it "should report failure message correctly when executed times is one" do
@@ -25,7 +25,7 @@ describe WebMock::RequestExecutionVerifier do
       @verifier.expected_times_executed = 1
       expected_text = "The request www.example.com was expected to execute 1 time but it executed 1 time"
       expected_text << @executed_requests_info
-      @verifier.failure_message.should == expected_text
+      @verifier.failure_message.should be == expected_text
     end
 
   end
@@ -37,14 +37,14 @@ describe WebMock::RequestExecutionVerifier do
       @verifier.expected_times_executed = 2
       expected_text = "The request www.example.com was not expected to execute 2 times but it executed 2 times"
       expected_text << @executed_requests_info
-      @verifier.negative_failure_message.should == expected_text
+      @verifier.negative_failure_message.should be == expected_text
     end
 
     it "should report failure message when not expected request but it executed" do
       @verifier.times_executed = 1
       expected_text = "The request www.example.com was expected to execute 0 times but it executed 1 time"
       expected_text << @executed_requests_info
-      @verifier.negative_failure_message.should == expected_text
+      @verifier.negative_failure_message.should be == expected_text
     end
 
   end

--- a/spec/request_pattern_spec.rb
+++ b/spec/request_pattern_spec.rb
@@ -4,18 +4,18 @@ describe WebMock::RequestPattern do
 
   it "should report string describing itself" do
     WebMock::RequestPattern.new(:get, "www.example.com",
-      :body => "abc", :headers => {'A' => 'a', 'B' => 'b'}).to_s.should ==
+      :body => "abc", :headers => {'A' => 'a', 'B' => 'b'}).to_s.should be ==
     "GET http://www.example.com/ with body \"abc\" with headers {'A'=>'a', 'B'=>'b'}"
   end
 
   it "should report string describing itself with block" do
     WebMock::RequestPattern.new(:get, "www.example.com",
-      :body => "abc", :headers => {'A' => 'a', 'B' => 'b'}).with {|req| true}.to_s.should ==
+      :body => "abc", :headers => {'A' => 'a', 'B' => 'b'}).with {|req| true}.to_s.should be ==
     "GET http://www.example.com/ with body \"abc\" with headers {'A'=>'a', 'B'=>'b'} with given block"
   end
 
   it "should report string describing itself with query params" do
-    WebMock::RequestPattern.new(:get, /.*example.*/, :query => {'a' => ['b', 'c']}).to_s.should ==
+    WebMock::RequestPattern.new(:get, /.*example.*/, :query => {'a' => ['b', 'c']}).to_s.should be ==
     "GET /.*example.*/ with query params {\"a\"=>[\"b\", \"c\"]}"
   end
 
@@ -26,12 +26,12 @@ describe WebMock::RequestPattern do
 
     it "should have assigned body pattern" do
       @request_pattern.with(:body => "abc")
-      @request_pattern.to_s.should ==WebMock::RequestPattern.new(:get, "www.example.com", :body => "abc").to_s
+      @request_pattern.to_s.should be ==WebMock::RequestPattern.new(:get, "www.example.com", :body => "abc").to_s
     end
 
     it "should have assigned normalized headers pattern" do
       @request_pattern.with(:headers => {'A' => 'a'})
-      @request_pattern.to_s.should ==WebMock::RequestPattern.new(:get, "www.example.com", :headers => {'A' => 'a'}).to_s
+      @request_pattern.to_s.should be ==WebMock::RequestPattern.new(:get, "www.example.com", :headers => {'A' => 'a'}).to_s
     end
 
   end

--- a/spec/request_registry_spec.rb
+++ b/spec/request_registry_spec.rb
@@ -14,9 +14,9 @@ describe WebMock::RequestRegistry do
     end
 
     it "should clean list of executed requests" do
-      WebMock::RequestRegistry.instance.times_executed(@request_pattern).should == 1
+      WebMock::RequestRegistry.instance.times_executed(@request_pattern).should be == 1
       WebMock::RequestRegistry.instance.reset!
-      WebMock::RequestRegistry.instance.times_executed(@request_pattern).should == 0
+      WebMock::RequestRegistry.instance.times_executed(@request_pattern).should be == 0
     end
 
   end
@@ -33,15 +33,15 @@ describe WebMock::RequestRegistry do
     end
 
     it "should report 0 if no request matching pattern was requested" do
-      WebMock::RequestRegistry.instance.times_executed(WebMock::RequestPattern.new(:get, "www.example.net")).should == 0
+      WebMock::RequestRegistry.instance.times_executed(WebMock::RequestPattern.new(:get, "www.example.net")).should be == 0
     end
 
     it "should report number of times matching pattern was requested" do
-      WebMock::RequestRegistry.instance.times_executed(WebMock::RequestPattern.new(:get, "www.example.com")).should == 2
+      WebMock::RequestRegistry.instance.times_executed(WebMock::RequestPattern.new(:get, "www.example.com")).should be == 2
     end
 
     it "should report number of times all matching pattern were requested" do
-      WebMock::RequestRegistry.instance.times_executed(WebMock::RequestPattern.new(:get, /.*example.*/)).should == 3
+      WebMock::RequestRegistry.instance.times_executed(WebMock::RequestPattern.new(:get, /.*example.*/)).should be == 3
     end
   end
 
@@ -50,7 +50,7 @@ describe WebMock::RequestRegistry do
       WebMock::RequestRegistry.instance.requested_signatures.put(WebMock::RequestSignature.new(:get, "www.example.com"))
       WebMock::RequestRegistry.instance.requested_signatures.put(WebMock::RequestSignature.new(:get, "www.example.com"))
       WebMock::RequestRegistry.instance.requested_signatures.
-        get(WebMock::RequestSignature.new(:get, "www.example.com")).should == 2
+        get(WebMock::RequestSignature.new(:get, "www.example.com")).should be == 2
     end
   end
 
@@ -63,12 +63,12 @@ describe WebMock::RequestRegistry do
       ].each do |s|
         WebMock::RequestRegistry.instance.requested_signatures.put(s)
       end
-      WebMock::RequestRegistry.instance.to_s.should ==
+      WebMock::RequestRegistry.instance.to_s.should be ==
       "GET http://www.example.com/ was made 2 times\nPUT http://www.example.org/ was made 1 time\n"
     end
 
     it "should output info if no requests were executed" do
-      WebMock::RequestRegistry.instance.to_s.should == "No requests were made."
+      WebMock::RequestRegistry.instance.to_s.should be == "No requests were made."
     end
   end
 

--- a/spec/request_signature_spec.rb
+++ b/spec/request_signature_spec.rb
@@ -7,30 +7,30 @@ describe WebMock::RequestSignature do
     it "should have assigned normalized uri" do
       WebMock::Util::URI.should_receive(:normalize_uri).and_return("www.example.kom")
       signature = WebMock::RequestSignature.new(:get, "www.example.com")
-      signature.uri.should == "www.example.kom"
+      signature.uri.should be == "www.example.kom"
     end
 
     it "should have assigned uri without normalization if uri is URI" do
       WebMock::Util::URI.should_not_receive(:normalize_uri)
       uri = Addressable::URI.parse("www.example.com")
       signature = WebMock::RequestSignature.new(:get, uri)
-      signature.uri.should == uri
+      signature.uri.should be == uri
     end
 
     it "should have assigned normalized headers" do
       WebMock::Util::Headers.should_receive(:normalize_headers).with('A' => 'a').and_return('B' => 'b')
-      WebMock::RequestSignature.new(:get, "www.example.com", :headers => {'A' => 'a'}).headers.should == {'B' => 'b'}
+      WebMock::RequestSignature.new(:get, "www.example.com", :headers => {'A' => 'a'}).headers.should be == {'B' => 'b'}
     end
 
     it "should have assigned body" do
-      WebMock::RequestSignature.new(:get, "www.example.com", :body => "abc").body.should == "abc"
+      WebMock::RequestSignature.new(:get, "www.example.com", :body => "abc").body.should be == "abc"
     end
 
   end
 
   it "should report string describing itself" do
     WebMock::RequestSignature.new(:get, "www.example.com",
-      :body => "abc", :headers => {'A' => 'a', 'B' => 'b'}).to_s.should ==
+      :body => "abc", :headers => {'A' => 'a', 'B' => 'b'}).to_s.should be ==
     "GET http://www.example.com/ with body 'abc' with headers {'A'=>'a', 'B'=>'b'}"
   end
 
@@ -40,7 +40,7 @@ describe WebMock::RequestSignature do
         :body => "abc", :headers => {'A' => 'a', 'B' => 'b'})
       signature2 = WebMock::RequestSignature.new(:get, "www.example.com",
         :body => "abc", :headers => {'A' => 'a', 'B' => 'b'})
-      signature1.hash.should == signature2.hash
+      signature1.hash.should be == signature2.hash
     end
 
     it "should report different hash for two signatures with different method" do

--- a/spec/request_stub_spec.rb
+++ b/spec/request_stub_spec.rb
@@ -7,7 +7,7 @@ describe WebMock::RequestStub do
   end
 
   it "should have request pattern with method and uri" do
-    @request_stub.request_pattern.to_s.should == "GET http://www.example.com/"
+    @request_stub.request_pattern.to_s.should be == "GET http://www.example.com/"
   end
 
   it "should have response" do
@@ -18,12 +18,12 @@ describe WebMock::RequestStub do
 
     it "should assign body to request pattern" do
       @request_stub.with(:body => "abc")
-      @request_stub.request_pattern.to_s.should == WebMock::RequestPattern.new(:get, "www.example.com", :body => "abc").to_s
+      @request_stub.request_pattern.to_s.should be == WebMock::RequestPattern.new(:get, "www.example.com", :body => "abc").to_s
     end
 
     it "should assign normalized headers to request pattern" do
       @request_stub.with(:headers => {'A' => 'a'})
-      @request_stub.request_pattern.to_s.should ==
+      @request_stub.request_pattern.to_s.should be ==
         WebMock::RequestPattern.new(:get, "www.example.com", :headers => {'A' => 'a'}).to_s
     end
 
@@ -38,20 +38,20 @@ describe WebMock::RequestStub do
 
     it "should assign response with provided options" do
       @request_stub.to_return(:body => "abc", :status => 500)
-      @request_stub.response.body.should == "abc"
-      @request_stub.response.status.should == [500, ""]
+      @request_stub.response.body.should be == "abc"
+      @request_stub.response.status.should be == [500, ""]
     end
 
     it "should assign responses with provided options" do
       @request_stub.to_return([{:body => "abc"}, {:body => "def"}])
-      [@request_stub.response.body, @request_stub.response.body].should == ["abc", "def"]
+      [@request_stub.response.body, @request_stub.response.body].should be == ["abc", "def"]
     end
 
   end
 
   describe "then" do
     it "should return stub without any modifications, acting as syntactic sugar" do
-      @request_stub.then.should == @request_stub
+      @request_stub.then.should be == @request_stub
     end
   end
 
@@ -59,27 +59,27 @@ describe WebMock::RequestStub do
 
     it "should return responses in a sequence passed as array" do
       @request_stub.to_return([{:body => "abc"}, {:body => "def"}])
-      @request_stub.response.body.should == "abc"
-      @request_stub.response.body.should == "def"
+      @request_stub.response.body.should be == "abc"
+      @request_stub.response.body.should be == "def"
     end
 
     it "should repeat returning last response" do
       @request_stub.to_return([{:body => "abc"}, {:body => "def"}])
       @request_stub.response
       @request_stub.response
-      @request_stub.response.body.should == "def"
+      @request_stub.response.body.should be == "def"
     end
 
     it "should return responses in a sequence passed as comma separated params" do
       @request_stub.to_return({:body => "abc"}, {:body => "def"})
-      @request_stub.response.body.should == "abc"
-      @request_stub.response.body.should == "def"
+      @request_stub.response.body.should be == "abc"
+      @request_stub.response.body.should be == "def"
     end
 
     it "should return responses declared in multiple to_return declarations" do
       @request_stub.to_return({:body => "abc"}).to_return({:body => "def"})
-      @request_stub.response.body.should == "abc"
-      @request_stub.response.body.should == "def"
+      @request_stub.response.body.should be == "abc"
+      @request_stub.response.body.should be == "def"
     end
 
   end
@@ -95,7 +95,7 @@ describe WebMock::RequestStub do
 
     it "should assign sequence of responses with response with exception to be thrown" do
       @request_stub.to_return(:body => "abc").then.to_raise(ArgumentError)
-      @request_stub.response.body.should == "abc"
+      @request_stub.response.body.should be == "abc"
       lambda {
         @request_stub.response.raise_error_if_any
       }.should raise_error(ArgumentError, "Exception from WebMock")
@@ -132,7 +132,7 @@ describe WebMock::RequestStub do
 
      it "should assign sequence of responses with response with timeout" do
        @request_stub.to_return(:body => "abc").then.to_timeout
-       @request_stub.response.body.should == "abc"
+       @request_stub.response.body.should be == "abc"
        @request_stub.response.should_timeout.should be_true
      end
 
@@ -140,7 +140,7 @@ describe WebMock::RequestStub do
        @request_stub.to_timeout.then.to_timeout.then.to_return(:body => "abc")
        @request_stub.response.should_timeout.should be_true
        @request_stub.response.should_timeout.should be_true
-       @request_stub.response.body.should == "abc"
+       @request_stub.response.body.should be == "abc"
      end
 
    end
@@ -156,29 +156,29 @@ describe WebMock::RequestStub do
 
     it "should repeat returning last declared response declared number of times" do
       @request_stub.to_return({:body => "abc"}).times(2).then.to_return({:body => "def"})
-      @request_stub.response.body.should == "abc"
-      @request_stub.response.body.should == "abc"
-      @request_stub.response.body.should == "def"
+      @request_stub.response.body.should be == "abc"
+      @request_stub.response.body.should be == "abc"
+      @request_stub.response.body.should be == "def"
     end
 
     it "should repeat raising last declared exception declared number of times" do
       @request_stub.to_return({:body => "abc"}).times(2).then.to_return({:body => "def"})
-      @request_stub.response.body.should == "abc"
-      @request_stub.response.body.should == "abc"
-      @request_stub.response.body.should == "def"
+      @request_stub.response.body.should be == "abc"
+      @request_stub.response.body.should be == "abc"
+      @request_stub.response.body.should be == "def"
     end
 
     it "should repeat returning last declared sequence of responses declared number of times" do
       @request_stub.to_return({:body => "abc"}, {:body => "def"}).times(2).then.to_return({:body => "ghj"})
-      @request_stub.response.body.should == "abc"
-      @request_stub.response.body.should == "def"
-      @request_stub.response.body.should == "abc"
-      @request_stub.response.body.should == "def"
-      @request_stub.response.body.should == "ghj"
+      @request_stub.response.body.should be == "abc"
+      @request_stub.response.body.should be == "def"
+      @request_stub.response.body.should be == "abc"
+      @request_stub.response.body.should be == "def"
+      @request_stub.response.body.should be == "ghj"
     end
 
     it "should return self" do
-      @request_stub.to_return({:body => "abc"}).times(1).should == @request_stub
+      @request_stub.to_return({:body => "abc"}).times(1).should be == @request_stub
     end
 
     it "should raise error if argument is not integer" do

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -7,14 +7,14 @@ describe WebMock::ResponseFactory do
     it "should create response with options passed as arguments" do
       options = {:body => "abc", :headers => {:a => :b}}
       WebMock::Response.should_receive(:new).with(options).and_return(@response = mock(WebMock::Response))
-      WebMock::ResponseFactory.response_for(options).should == @response
+      WebMock::ResponseFactory.response_for(options).should be == @response
     end
 
 
     it "should create dynamic response for argument responding to call" do
       callable = mock(:call => {:body => "abc"})
       WebMock::DynamicResponse.should_receive(:new).with(callable).and_return(@response = mock(WebMock::Response))
-      WebMock::ResponseFactory.response_for(callable).should == @response
+      WebMock::ResponseFactory.response_for(callable).should be == @response
     end
 
   end
@@ -29,23 +29,23 @@ describe WebMock::Response do
   it "should report normalized headers" do
     WebMock::Util::Headers.should_receive(:normalize_headers).with('A' => 'a').and_return('B' => 'b')
     @response = WebMock::Response.new(:headers => {'A' => 'a'})
-    @response.headers.should == {'B' => 'b'}
+    @response.headers.should be == {'B' => 'b'}
   end
 
   describe "status" do
 
     it "should have 200 code and empty message by default" do
-      @response.status.should == [200, ""]
+      @response.status.should be == [200, ""]
     end
 
     it "should return assigned status" do
       @response = WebMock::Response.new(:status => 500)
-      @response.status.should == [500, ""]
+      @response.status.should be == [500, ""]
     end
 
     it "should return assigned message" do
       @response = WebMock::Response.new(:status => [500, "Internal Server Error"])
-      @response.status.should == [500, "Internal Server Error"]
+      @response.status.should be == [500, "Internal Server Error"]
     end
 
   end
@@ -96,28 +96,28 @@ describe WebMock::Response do
   describe "body" do
 
     it "should return empty body by default" do
-      @response.body.should == ''
+      @response.body.should be == ''
     end
 
     it "should report body if assigned" do
       @response = WebMock::Response.new(:body => "abc")
-      @response.body.should == "abc"
+      @response.body.should be == "abc"
     end
 
     it "should report string even if existing file path was provided" do
       @response = WebMock::Response.new(:body => __FILE__)
-      @response.body.should == __FILE__
+      @response.body.should be == __FILE__
     end
 
     it "should report content of a IO object if provided" do
       @response = WebMock::Response.new(:body => File.new(__FILE__))
-      @response.body.should == File.new(__FILE__).read
+      @response.body.should be == File.new(__FILE__).read
     end
 
     it "should report many times content of a IO object if provided" do
       @response = WebMock::Response.new(:body => File.new(__FILE__))
-      @response.body.should == File.new(__FILE__).read
-      @response.body.should == File.new(__FILE__).read
+      @response.body.should be == File.new(__FILE__).read
+      @response.body.should be == File.new(__FILE__).read
     end
 
   end
@@ -132,11 +132,11 @@ describe WebMock::Response do
 
 
       it "should read status" do
-        @response.status.should == [202, "OK"]
+        @response.status.should be == [202, "OK"]
       end
 
       it "should read headers" do
-        @response.headers.should == {
+        @response.headers.should be == {
           "Date"=>"Sat, 23 Jan 2010 01:01:05 GMT",
           "Content-Type"=>"text/html; charset=UTF-8",
           "Content-Length"=>"419",
@@ -146,7 +146,7 @@ describe WebMock::Response do
       end
 
       it "should read body" do
-        @response.body.size.should == 419
+        @response.body.size.should be == 419
       end
 
       it "should close IO" do
@@ -162,11 +162,11 @@ describe WebMock::Response do
       end
 
       it "should read status" do
-        @response.status.should == [202, "OK"]
+        @response.status.should be == [202, "OK"]
       end
 
       it "should read headers" do
-        @response.headers.should == {
+        @response.headers.should be == {
           "Date"=>"Sat, 23 Jan 2010 01:01:05 GMT",
           "Content-Type"=>"text/html; charset=UTF-8",
           "Content-Length"=>"419",
@@ -176,13 +176,13 @@ describe WebMock::Response do
       end
 
       it "should read body" do
-        @response.body.size.should == 419
+        @response.body.size.should be == 419
       end
 
       it "should work with transfer-encoding set to chunked" do
         @input.gsub!("Content-Length: 419", "Transfer-Encoding: chunked")
         @response = WebMock::Response.new(@input)
-        @response.body.size.should == 419
+        @response.body.size.should be == 419
       end
 
     end
@@ -195,17 +195,17 @@ describe WebMock::Response do
 
       it "should have evaluated body" do
         @response = WebMock::Response.new(:body => lambda {|request| request.body})
-        @response.evaluate(@request_signature).body.should == "abc"
+        @response.evaluate(@request_signature).body.should be == "abc"
       end
 
       it "should have evaluated headers" do
         @response = WebMock::Response.new(:headers => lambda {|request| request.headers})
-        @response.evaluate(@request_signature).headers.should == {'A' => 'a'}
+        @response.evaluate(@request_signature).headers.should be == {'A' => 'a'}
       end
 
       it "should have evaluated status" do
         @response = WebMock::Response.new(:status => lambda {|request| 302})
-        @response.evaluate(@request_signature).status.should == [302, ""]
+        @response.evaluate(@request_signature).status.should be == [302, ""]
       end
 
     end
@@ -226,16 +226,16 @@ describe WebMock::Response do
           }
         })
         evaluated_response = response.evaluate(request_signature)
-        evaluated_response.body.should == "abc"
-        evaluated_response.headers.should == {'A' => 'a'}
-        evaluated_response.status.should == [302, ""]
+        evaluated_response.body.should be == "abc"
+        evaluated_response.headers.should be == {'A' => 'a'}
+        evaluated_response.status.should be == [302, ""]
       end
 
       it "should be equal to static response after evaluation" do
         request_signature = WebMock::RequestSignature.new(:post, "www.example.com", :body => "abc")
         response = WebMock::DynamicResponse.new(lambda {|request| {:body => request.body}})
         evaluated_response = response.evaluate(request_signature)
-        evaluated_response.should == WebMock::Response.new(:body => "abc")
+        evaluated_response.should be == WebMock::Response.new(:body => "abc")
       end
 
       describe "when raw response is evaluated" do
@@ -249,14 +249,14 @@ describe WebMock::Response do
         describe "as a file" do
           it "should return response" do
             response = WebMock::DynamicResponse.new(lambda {|request| @files[request.uri.host.to_s] })
-            response.evaluate(@request_signature).body.size.should == 419
+            response.evaluate(@request_signature).body.size.should be == 419
           end
         end
 
         describe "as a string" do
           it "should return response" do
             response = WebMock::DynamicResponse.new(lambda {|request| @files[request.uri.host.to_s].read })
-            response.evaluate(@request_signature).body.size.should == 419
+            response.evaluate(@request_signature).body.size.should be == 419
           end
         end
       end

--- a/spec/stub_registry_spec.rb
+++ b/spec/stub_registry_spec.rb
@@ -15,25 +15,25 @@ describe WebMock::StubRegistry do
     end
 
     it "should clean request stubs" do
-      WebMock::StubRegistry.instance.registered_request?(@request_signature).should == @request_stub
+      WebMock::StubRegistry.instance.registered_request?(@request_signature).should be == @request_stub
       WebMock::StubRegistry.instance.reset!
-      WebMock::StubRegistry.instance.registered_request?(@request_signature).should == nil
+      WebMock::StubRegistry.instance.registered_request?(@request_signature).should be == nil
     end
   end
 
   describe "registering and reporting registered requests" do
 
     it "should return registered stub" do
-      WebMock::StubRegistry.instance.register_request_stub(@request_stub).should == @request_stub
+      WebMock::StubRegistry.instance.register_request_stub(@request_stub).should be == @request_stub
     end
 
     it "should report if request stub is not registered" do
-      WebMock::StubRegistry.instance.registered_request?(@request_signature).should == nil
+      WebMock::StubRegistry.instance.registered_request?(@request_signature).should be == nil
     end
 
     it "should register and report registered stib" do
       WebMock::StubRegistry.instance.register_request_stub(@request_stub)
-      WebMock::StubRegistry.instance.registered_request?(@request_signature).should == @request_stub
+      WebMock::StubRegistry.instance.registered_request?(@request_signature).should be == @request_stub
     end
 
 
@@ -45,14 +45,14 @@ describe WebMock::StubRegistry do
       @request_stub.to_return(:body => "abc")
       WebMock::StubRegistry.instance.register_request_stub(@request_stub)
       WebMock::StubRegistry.instance.response_for_request(@request_signature).
-        should == WebMock::Response.new(:body => "abc")
+        should be == WebMock::Response.new(:body => "abc")
     end
 
     it "should report evaluated response" do
       @request_stub.to_return {|request| {:body => request.method.to_s} }
       WebMock::StubRegistry.instance.register_request_stub(@request_stub)
       response1 = WebMock::StubRegistry.instance.response_for_request(@request_signature)
-      response1.should == WebMock::Response.new(:body => "get")
+      response1.should be == WebMock::Response.new(:body => "get")
     end
 
     it "should report clone of theresponse" do
@@ -64,7 +64,7 @@ describe WebMock::StubRegistry do
     end
 
     it "should report nothing if no response for request is registered" do
-      WebMock::StubRegistry.instance.response_for_request(@request_signature).should == nil
+      WebMock::StubRegistry.instance.response_for_request(@request_signature).should be == nil
     end
 
     it "should always return last registered matching response" do
@@ -78,7 +78,7 @@ describe WebMock::StubRegistry do
       WebMock::StubRegistry.instance.register_request_stub(@request_stub2)
       WebMock::StubRegistry.instance.register_request_stub(@request_stub3)
       WebMock::StubRegistry.instance.response_for_request(@request_signature).
-        should == WebMock::Response.new(:body => "def")
+        should be == WebMock::Response.new(:body => "def")
     end
 
   end

--- a/spec/stub_request_snippet_spec.rb
+++ b/spec/stub_request_snippet_spec.rb
@@ -8,7 +8,7 @@ describe WebMock::StubRequestSnippet do
 
     it "should print stub request snippet with url with params and method and empty successful response" do
       expected = %Q(stub_request(:get, "http://www.example.com/?a=b&c=d").\n  to_return(:status => 200, :body => "", :headers => {}))
-      WebMock::StubRequestSnippet.new(@request_signature).to_s.should == expected
+      WebMock::StubRequestSnippet.new(@request_signature).to_s.should be == expected
     end
 
     it "should print stub request snippet with body if available" do
@@ -16,7 +16,7 @@ describe WebMock::StubRequestSnippet do
       expected = %Q(stub_request(:get, "http://www.example.com/?a=b&c=d").)+
       "\n  with(:body => \"abcdef\")." +
       "\n  to_return(:status => 200, :body => \"\", :headers => {})"
-      WebMock::StubRequestSnippet.new(@request_signature).to_s.should == expected
+      WebMock::StubRequestSnippet.new(@request_signature).to_s.should be == expected
     end
 
     it "should print stub request snippet with multiline body" do
@@ -24,7 +24,7 @@ describe WebMock::StubRequestSnippet do
       expected = %Q(stub_request(:get, "http://www.example.com/?a=b&c=d").)+
       "\n  with(:body => \"abc\\ndef\")." +
       "\n  to_return(:status => 200, :body => \"\", :headers => {})"
-      WebMock::StubRequestSnippet.new(@request_signature).to_s.should == expected
+      WebMock::StubRequestSnippet.new(@request_signature).to_s.should be == expected
     end
 
     it "should print stub request snippet with headers if any" do
@@ -32,7 +32,7 @@ describe WebMock::StubRequestSnippet do
       expected = 'stub_request(:get, "http://www.example.com/?a=b&c=d").'+
       "\n  with(:headers => {\'A\'=>\'a\', \'B\'=>\'b\'})." +
       "\n  to_return(:status => 200, :body => \"\", :headers => {})"
-      WebMock::StubRequestSnippet.new(@request_signature).to_s.should == expected
+      WebMock::StubRequestSnippet.new(@request_signature).to_s.should be == expected
     end
 
     it "should print stub request snippet with body and headers" do
@@ -41,7 +41,7 @@ describe WebMock::StubRequestSnippet do
       expected = 'stub_request(:get, "http://www.example.com/?a=b&c=d").'+
       "\n  with(:body => \"abcdef\", \n       :headers => {\'A\'=>\'a\', \'B\'=>\'b\'})." +
       "\n  to_return(:status => 200, :body => \"\", :headers => {})"
-      WebMock::StubRequestSnippet.new(@request_signature).to_s.should == expected
+      WebMock::StubRequestSnippet.new(@request_signature).to_s.should be == expected
     end
   end
 end

--- a/spec/util/hash_counter_spec.rb
+++ b/spec/util/hash_counter_spec.rb
@@ -3,22 +3,22 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe WebMock::Util::HashCounter do
 
   it "should return 0 for non existing key" do
-    WebMock::Util::HashCounter.new.get(:abc).should == 0
+    WebMock::Util::HashCounter.new.get(:abc).should be == 0
   end
 
   it "should increase the returned value on every put with the same key" do
     counter = WebMock::Util::HashCounter.new
     counter.put(:abc)
-    counter.get(:abc).should == 1
+    counter.get(:abc).should be == 1
     counter.put(:abc)
-    counter.get(:abc).should == 2
+    counter.get(:abc).should be == 2
   end
 
   it "should only increase value for given key provided to put" do
     counter = WebMock::Util::HashCounter.new
     counter.put(:abc)
-    counter.get(:abc).should == 1
-    counter.get(:def).should == 0
+    counter.get(:abc).should be == 1
+    counter.get(:def).should be == 0
   end
 
   describe "each" do
@@ -33,7 +33,7 @@ describe WebMock::Util::HashCounter do
 
       elements = []
       counter.each {|k,v| elements << [k,v]}
-      elements.should == [[:c, 1], [:b, 2], [:a, 2], [:d, 1]]
+      elements.should be == [[:c, 1], [:b, 2], [:a, 2], [:d, 1]]
     end
   end
 end

--- a/spec/util/hash_keys_stringifier_spec.rb
+++ b/spec/util/hash_keys_stringifier_spec.rb
@@ -21,7 +21,7 @@ describe WebMock::Util::HashKeysStringifier do
         ]
       }
     }
-    WebMock::Util::HashKeysStringifier.stringify_keys!(hash).should == stringified
+    WebMock::Util::HashKeysStringifier.stringify_keys!(hash).should be == stringified
   end
 
 end

--- a/spec/util/headers_spec.rb
+++ b/spec/util/headers_spec.rb
@@ -5,21 +5,21 @@ describe WebMock::Util::Headers do
   it "should decode_userinfo_from_header handles basic auth" do
     authorization_header = "Basic dXNlcm5hbWU6c2VjcmV0"
     userinfo = WebMock::Util::Headers.decode_userinfo_from_header(authorization_header)
-    userinfo.should == "username:secret"
+    userinfo.should be == "username:secret"
   end
 
   describe "sorted_headers_string" do
 
     it "should return nice string for hash with string values" do
-      WebMock::Util::Headers.sorted_headers_string({"a" => "b"}).should == "{'A'=>'b'}"
+      WebMock::Util::Headers.sorted_headers_string({"a" => "b"}).should be == "{'A'=>'b'}"
     end
 
     it "should return nice string for hash with array values" do
-      WebMock::Util::Headers.sorted_headers_string({"a" => ["b", "c"]}).should == "{'A'=>['b', 'c']}"
+      WebMock::Util::Headers.sorted_headers_string({"a" => ["b", "c"]}).should be == "{'A'=>['b', 'c']}"
     end
 
     it "should return nice string for hash with array values and string values" do
-      WebMock::Util::Headers.sorted_headers_string({"a" => ["b", "c"], "d" => "e"}).should == "{'A'=>['b', 'c'], 'D'=>'e'}"
+      WebMock::Util::Headers.sorted_headers_string({"a" => ["b", "c"], "d" => "e"}).should be == "{'A'=>['b', 'c'], 'D'=>'e'}"
     end
 
 

--- a/spec/util/uri_spec.rb
+++ b/spec/util/uri_spec.rb
@@ -81,37 +81,37 @@ describe WebMock::Util::URI do
 
     it "should find all variations of the same uri for all variations of uri with params and path" do
       URIS_WITH_PATH_AND_PARAMS.each do |uri|
-        WebMock::Util::URI.variations_of_uri_as_strings(uri).sort.should == URIS_WITH_PATH_AND_PARAMS
+        WebMock::Util::URI.variations_of_uri_as_strings(uri).sort.should be == URIS_WITH_PATH_AND_PARAMS
       end
     end
 
     it "should find all variations of the same uri for all variations of uri with params but without path" do
       URIS_WITHOUT_PATH_BUT_WITH_PARAMS.each do |uri|
-        WebMock::Util::URI.variations_of_uri_as_strings(uri).sort.should == URIS_WITHOUT_PATH_BUT_WITH_PARAMS
+        WebMock::Util::URI.variations_of_uri_as_strings(uri).sort.should be == URIS_WITHOUT_PATH_BUT_WITH_PARAMS
       end
     end
 
     it "should find all variations of the same uri for all variations of uri without params or path" do
       URIS_WITHOUT_PATH_OR_PARAMS.each do |uri|
-        WebMock::Util::URI.variations_of_uri_as_strings(uri).sort.should == URIS_WITHOUT_PATH_OR_PARAMS
+        WebMock::Util::URI.variations_of_uri_as_strings(uri).sort.should be == URIS_WITHOUT_PATH_OR_PARAMS
       end
     end
 
     it "should find all variations of the same uri for all variations of uri with auth" do
       URIS_WITH_AUTH.each do |uri|
-        WebMock::Util::URI.variations_of_uri_as_strings(uri).sort.should == URIS_WITH_AUTH
+        WebMock::Util::URI.variations_of_uri_as_strings(uri).sort.should be == URIS_WITH_AUTH
       end
     end
 
     it "should find all variations of the same uri for all variations of uri with different port" do
       URIS_WITH_DIFFERENT_PORT.each do |uri|
-        WebMock::Util::URI.variations_of_uri_as_strings(uri).sort.should == URIS_WITH_DIFFERENT_PORT
+        WebMock::Util::URI.variations_of_uri_as_strings(uri).sort.should be == URIS_WITH_DIFFERENT_PORT
       end
     end
 
     it "should find all variations of the same uri for all variations of https uris" do
       URIS_FOR_HTTPS.each do |uri|
-        WebMock::Util::URI.variations_of_uri_as_strings(uri).sort.should == URIS_FOR_HTTPS
+        WebMock::Util::URI.variations_of_uri_as_strings(uri).sort.should be == URIS_FOR_HTTPS
       end
     end
 
@@ -122,7 +122,7 @@ describe WebMock::Util::URI do
     it "should successfully compare all variations of the same uri with path and params" do
       URIS_WITH_PATH_AND_PARAMS.each do |uri_a|
         URIS_WITH_PATH_AND_PARAMS.each do |uri_b|
-          WebMock::Util::URI.normalize_uri(uri_a).should ===  WebMock::Util::URI.normalize_uri(uri_b)
+          WebMock::Util::URI.normalize_uri(uri_a).should be ===  WebMock::Util::URI.normalize_uri(uri_b)
         end
       end
     end
@@ -130,7 +130,7 @@ describe WebMock::Util::URI do
     it "should successfully compare all variations of the same uri with path but with params" do
       URIS_WITHOUT_PATH_BUT_WITH_PARAMS.each do |uri_a|
         URIS_WITHOUT_PATH_BUT_WITH_PARAMS.each do |uri_b|
-          WebMock::Util::URI.normalize_uri(uri_a).should ===  WebMock::Util::URI.normalize_uri(uri_b)
+          WebMock::Util::URI.normalize_uri(uri_a).should be ===  WebMock::Util::URI.normalize_uri(uri_b)
         end
       end
     end
@@ -138,7 +138,7 @@ describe WebMock::Util::URI do
     it "should successfully compare all variations of the same uri without path or params" do
       URIS_WITHOUT_PATH_OR_PARAMS.each do |uri_a|
         URIS_WITHOUT_PATH_OR_PARAMS.each do |uri_b|
-          WebMock::Util::URI.normalize_uri(uri_a).should ===  WebMock::Util::URI.normalize_uri(uri_b)
+          WebMock::Util::URI.normalize_uri(uri_a).should be ===  WebMock::Util::URI.normalize_uri(uri_b)
         end
       end
     end
@@ -146,7 +146,7 @@ describe WebMock::Util::URI do
     it "should successfully compare all variations of the same uri with authority" do
       URIS_WITH_AUTH.each do |uri_a|
         URIS_WITH_AUTH.each do |uri_b|
-          WebMock::Util::URI.normalize_uri(uri_a).should ===  WebMock::Util::URI.normalize_uri(uri_b)
+          WebMock::Util::URI.normalize_uri(uri_a).should be ===  WebMock::Util::URI.normalize_uri(uri_b)
         end
       end
     end
@@ -154,7 +154,7 @@ describe WebMock::Util::URI do
     it "should successfully compare all variations of the same uri custom port" do
       URIS_WITH_DIFFERENT_PORT.each do |uri_a|
         URIS_WITH_DIFFERENT_PORT.each do |uri_b|
-          WebMock::Util::URI.normalize_uri(uri_a).should ===  WebMock::Util::URI.normalize_uri(uri_b)
+          WebMock::Util::URI.normalize_uri(uri_a).should be ===  WebMock::Util::URI.normalize_uri(uri_b)
         end
       end
     end
@@ -162,7 +162,7 @@ describe WebMock::Util::URI do
     it "should successfully compare all variations of the same https uri" do
       URIS_FOR_HTTPS.each do |uri_a|
         URIS_FOR_HTTPS.each do |uri_b|
-          WebMock::Util::URI.normalize_uri(uri_a).should ===  WebMock::Util::URI.normalize_uri(uri_b)
+          WebMock::Util::URI.normalize_uri(uri_a).should be ===  WebMock::Util::URI.normalize_uri(uri_b)
         end
       end
     end
@@ -179,45 +179,45 @@ describe WebMock::Util::URI do
     it "should strip_default_port_from_uri strips 80 from http with path" do
       uri = "http://example.com:80/foo/bar"
       stripped_uri = WebMock::Util::URI.strip_default_port_from_uri_string(uri)
-      stripped_uri.should ==  "http://example.com/foo/bar"
+      stripped_uri.should be ==  "http://example.com/foo/bar"
     end
 
     it "should strip_default_port_from_uri strips 80 from http without path" do
       uri = "http://example.com:80"
       stripped_uri = WebMock::Util::URI.strip_default_port_from_uri_string(uri)
-      stripped_uri.should ==  "http://example.com"
+      stripped_uri.should be ==  "http://example.com"
     end
 
     it "should strip_default_port_from_uri strips 443 from https without path" do
       uri = "https://example.com:443"
       stripped_uri = WebMock::Util::URI.strip_default_port_from_uri_string(uri)
-      stripped_uri.should ==  "https://example.com"
+      stripped_uri.should be ==  "https://example.com"
     end
 
     it "should strip_default_port_from_uri strips 443 from https" do
       uri = "https://example.com:443/foo/bar"
       stripped_uri = WebMock::Util::URI.strip_default_port_from_uri_string(uri)
-      stripped_uri.should == "https://example.com/foo/bar"
+      stripped_uri.should be == "https://example.com/foo/bar"
     end
 
     it "should strip_default_port_from_uri does not strip 8080 from http" do
       uri = "http://example.com:8080/foo/bar"
-      WebMock::Util::URI.strip_default_port_from_uri_string(uri).should == uri
+      WebMock::Util::URI.strip_default_port_from_uri_string(uri).should be == uri
     end
 
     it "should strip_default_port_from_uri does not strip 443 from http" do
       uri = "http://example.com:443/foo/bar"
-      WebMock::Util::URI.strip_default_port_from_uri_string(uri).should == uri
+      WebMock::Util::URI.strip_default_port_from_uri_string(uri).should be == uri
     end
 
     it "should strip_default_port_from_uri does not strip 80 from query string" do
       uri = "http://example.com/?a=:80&b=c"
-      WebMock::Util::URI.strip_default_port_from_uri_string(uri).should == uri
+      WebMock::Util::URI.strip_default_port_from_uri_string(uri).should be == uri
     end
 
     it "should strip_default_port_from_uri does not modify strings that do not start with http or https" do
       uri = "httpz://example.com:80/"
-      WebMock::Util::URI.strip_default_port_from_uri_string(uri).should == uri
+      WebMock::Util::URI.strip_default_port_from_uri_string(uri).should be == uri
     end
 
   end
@@ -227,17 +227,17 @@ describe WebMock::Util::URI do
 
     it "should encode unsafe chars in userinfo does not encode userinfo safe punctuation" do
       userinfo = "user;&=+$,:secret"
-      WebMock::Util::URI.encode_unsafe_chars_in_userinfo(userinfo).should == userinfo
+      WebMock::Util::URI.encode_unsafe_chars_in_userinfo(userinfo).should be == userinfo
     end
 
     it "should encode unsafe chars in userinfo does not encode rfc 3986 unreserved characters" do
       userinfo = "-.!~*'()abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789:secret"
-      WebMock::Util::URI.encode_unsafe_chars_in_userinfo(userinfo).should == userinfo
+      WebMock::Util::URI.encode_unsafe_chars_in_userinfo(userinfo).should be == userinfo
     end
 
     it "should encode unsafe chars in userinfo does encode other characters" do
       userinfo, safe_userinfo = 'us#rn@me:sec//ret?"', 'us%23rn%40me:sec%2F%2Fret%3F%22'
-      WebMock::Util::URI.encode_unsafe_chars_in_userinfo(userinfo).should == safe_userinfo
+      WebMock::Util::URI.encode_unsafe_chars_in_userinfo(userinfo).should be == safe_userinfo
     end
 
   end

--- a/spec/webmock_shared.rb
+++ b/spec/webmock_shared.rb
@@ -11,7 +11,7 @@ class MyException < StandardError; end;
 
 describe "WebMock version" do
   it "should report version" do
-    WebMock.version.should == WebMock::VERSION
+    WebMock.version.should be == WebMock::VERSION
   end
 end
 
@@ -30,7 +30,7 @@ shared_examples_for "WebMock" do
 
       it "should make a real web request if request is not stubbed" do
         setup_expectations_for_real_example_com_request
-        http_request(:get, "http://www.example.com/").status.should == "302"
+        http_request(:get, "http://www.example.com/").status.should be == "302"
       end
 
       it "should make a real https request if request is not stubbed" do
@@ -48,7 +48,7 @@ shared_examples_for "WebMock" do
 
       it "should return stubbed response if request was stubbed" do
         stub_http_request(:get, "www.example.com").to_return(:body => "abc")
-        http_request(:get, "http://www.example.com/").body.should == "abc"
+        http_request(:get, "http://www.example.com/").body.should be == "abc"
       end
     end
 
@@ -59,12 +59,12 @@ shared_examples_for "WebMock" do
 
       it "should return stubbed response if request was stubbed" do
         stub_http_request(:get, "www.example.com").to_return(:body => "abc")
-        http_request(:get, "http://www.example.com/").body.should == "abc"
+        http_request(:get, "http://www.example.com/").body.should be == "abc"
       end
 
       it "should return stubbed response if request with path was stubbed" do
         stub_http_request(:get, "www.example.com/hello_world").to_return(:body => "abc")
-        http_request(:get, "http://www.example.com/hello_world").body.should == "abc"
+        http_request(:get, "http://www.example.com/hello_world").body.should be == "abc"
       end
 
       it "should raise exception if request was not stubbed" do
@@ -81,7 +81,7 @@ shared_examples_for "WebMock" do
 
       it "should return stubbed response if request was stubbed" do
         stub_http_request(:get, "www.example.com").to_return(:body => "abc")
-        http_request(:get, "http://www.example.com/").body.should == "abc"
+        http_request(:get, "http://www.example.com/").body.should be == "abc"
       end
 
       it "should raise exception if request was not stubbed" do
@@ -119,7 +119,7 @@ shared_examples_for "WebMock" do
       context "when the host is not allowed" do
         it "should return stubbed response if request was stubbed" do
           stub_http_request(:get, "www.example.com").to_return(:body => "abc")
-          http_request(:get, "http://www.example.com/").body.should == "abc"
+          http_request(:get, "http://www.example.com/").body.should be == "abc"
         end
 
         it "should raise exception if request was not stubbed" do
@@ -132,7 +132,7 @@ shared_examples_for "WebMock" do
       context "when the host with port is not allowed" do
         it "should return stubbed response if request was stubbed" do
           stub_http_request(:get, "http://localhost:2345").to_return(:body => "abc")
-          http_request(:get, "http://localhost:2345/").body.should == "abc"
+          http_request(:get, "http://localhost:2345/").body.should be == "abc"
         end
 
         it "should raise exception if request was not stubbed" do
@@ -150,13 +150,13 @@ shared_examples_for "WebMock" do
         end
 
         it "should allow a real request to allowed host", :net_connect => true do
-          http_request(:get, "http://www.example.org/").status.should == "302"
+          http_request(:get, "http://www.example.org/").status.should be == "302"
         end
       end
 
       context "when the host with port is allowed" do
         it "should allow a real request to allowed host", :net_connect => true do
-          http_request(:get, "http://#{host_with_port}/").status.should == "200"
+          http_request(:get, "http://#{host_with_port}/").status.should be == "200"
         end
       end
     end
@@ -168,17 +168,17 @@ shared_examples_for "WebMock" do
 
       it "should match the request by uri with non escaped params if request have escaped parameters" do
         stub_http_request(:get, "www.example.com/hello/?#{NOT_ESCAPED_PARAMS}").to_return(:body => "abc")
-        http_request(:get, "http://www.example.com/hello/?#{ESCAPED_PARAMS}").body.should == "abc"
+        http_request(:get, "http://www.example.com/hello/?#{ESCAPED_PARAMS}").body.should be == "abc"
       end
 
       it "should match the request by uri with escaped parameters even if request has non escaped params" do
         stub_http_request(:get, "www.example.com/hello/?#{ESCAPED_PARAMS}").to_return(:body => "abc")
-        http_request(:get, "http://www.example.com/hello/?#{NOT_ESCAPED_PARAMS}").body.should == "abc"
+        http_request(:get, "http://www.example.com/hello/?#{NOT_ESCAPED_PARAMS}").body.should be == "abc"
       end
 
       it "should match the request by regexp matching non escaped params uri if request params are escaped" do
         stub_http_request(:get, /.*x=ab c.*/).to_return(:body => "abc")
-        http_request(:get, "http://www.example.com/hello/?#{ESCAPED_PARAMS}").body.should == "abc"
+        http_request(:get, "http://www.example.com/hello/?#{ESCAPED_PARAMS}").body.should be == "abc"
       end
 
     end
@@ -187,17 +187,17 @@ shared_examples_for "WebMock" do
 
       it "should match the request by query params declared as a hash" do
         stub_http_request(:get, "www.example.com").with(:query => {"a" => ["b", "c"]}).to_return(:body => "abc")
-        http_request(:get, "http://www.example.com/?a[]=b&a[]=c").body.should == "abc"
+        http_request(:get, "http://www.example.com/?a[]=b&a[]=c").body.should be == "abc"
       end
 
       it "should match the request by query declared as a string" do
         stub_http_request(:get, "www.example.com").with(:query => "a[]=b&a[]=c").to_return(:body => "abc")
-        http_request(:get, "http://www.example.com/?a[]=b&a[]=c").body.should == "abc"
+        http_request(:get, "http://www.example.com/?a[]=b&a[]=c").body.should be == "abc"
       end
 
       it "should match the request by query params declared both in uri and query option" do
         stub_http_request(:get, "www.example.com/?x=3").with(:query => {"a" => ["b", "c"]}).to_return(:body => "abc")
-        http_request(:get, "http://www.example.com/?x=3&a[]=b&a[]=c").body.should == "abc"
+        http_request(:get, "http://www.example.com/?x=3&a[]=b&a[]=c").body.should be == "abc"
       end
 
     end
@@ -206,12 +206,12 @@ shared_examples_for "WebMock" do
 
       it "should match the request by method if registered" do
         stub_http_request(:get, "www.example.com")
-        http_request(:get, "http://www.example.com/").status.should == "200"
+        http_request(:get, "http://www.example.com/").status.should be == "200"
       end
 
       it "should not match requests if method is different" do
         stub_http_request(:get, "www.example.com")
-        http_request(:get, "http://www.example.com/").status.should == "200"
+        http_request(:get, "http://www.example.com/").status.should be == "200"
         lambda {
           http_request(:delete, "http://www.example.com/")
         }.should raise_error(WebMock::NetConnectNotAllowedError, %r(Real HTTP connections are disabled. Unregistered request: DELETE http://www.example.com/)
@@ -226,14 +226,14 @@ shared_examples_for "WebMock" do
         stub_http_request(:post, "www.example.com").with(:body => "abc")
         http_request(
           :post, "http://www.example.com/",
-          :body => "abc").status.should == "200"
+          :body => "abc").status.should be == "200"
       end
 
       it "should match requests if body is not set in the stub" do
         stub_http_request(:post, "www.example.com")
         http_request(
           :post, "http://www.example.com/",
-          :body => "abc").status.should == "200"
+          :body => "abc").status.should be == "200"
       end
 
       it "should not match requests if body is different" do
@@ -249,7 +249,7 @@ shared_examples_for "WebMock" do
           stub_http_request(:post, "www.example.com").with(:body => /\d+abc$/)
           http_request(
             :post, "http://www.example.com/",
-            :body => "123abc").status.should == "200"
+            :body => "123abc").status.should be == "200"
         end
 
         it "should not match requests if body doesn't match regexp" do
@@ -272,20 +272,20 @@ shared_examples_for "WebMock" do
           it "should match request if hash matches body" do
             http_request(
               :post, "http://www.example.com/",
-              :body => 'a=1&c[d][]=e&c[d][]=f&b=five').status.should == "200"
+              :body => 'a=1&c[d][]=e&c[d][]=f&b=five').status.should be == "200"
           end
 
           it "should match request if hash matches body in different order of params" do
             http_request(
               :post, "http://www.example.com/",
-              :body => 'a=1&c[d][]=e&b=five&c[d][]=f').status.should == "200"
+              :body => 'a=1&c[d][]=e&b=five&c[d][]=f').status.should be == "200"
           end
 
           it "should not match if hash doesn't match url encoded body" do
             lambda {
               http_request(
                 :post, "http://www.example.com/",
-                :body => 'c[d][]=f&a=1&c[d][]=e').status.should == "200"
+                :body => 'c[d][]=f&a=1&c[d][]=e').status.should be == "200"
             }.should raise_error(WebMock::NetConnectNotAllowedError, %r(Real HTTP connections are disabled. Unregistered request: POST http://www.example.com/ with body 'c\[d\]\[\]=f&a=1&c\[d\]\[\]=e'))
           end
 
@@ -297,13 +297,13 @@ shared_examples_for "WebMock" do
           it "should match if hash matches body" do
             http_request(
               :post, "http://www.example.com/", :headers => {'Content-Type' => 'application/json'},
-              :body => "{\"a\":\"1\",\"c\":{\"d\":[\"e\",\"f\"]},\"b\":\"five\"}").status.should == "200"
+              :body => "{\"a\":\"1\",\"c\":{\"d\":[\"e\",\"f\"]},\"b\":\"five\"}").status.should be == "200"
           end
 
           it "should match if hash matches body in different form" do
             http_request(
               :post, "http://www.example.com/", :headers => {'Content-Type' => 'application/json'},
-              :body => "{\"a\":\"1\",\"b\":\"five\",\"c\":{\"d\":[\"e\",\"f\"]}}").status.should == "200"
+              :body => "{\"a\":\"1\",\"b\":\"five\",\"c\":{\"d\":[\"e\",\"f\"]}}").status.should be == "200"
           end
 
         end
@@ -318,13 +318,13 @@ shared_examples_for "WebMock" do
           it "should match if hash matches body" do
             http_request(
               :post, "http://www.example.com/", :headers => {'Content-Type' => 'application/xml'},
-              :body => "<opt a=\"1\" b=\"five\">\n  <c>\n    <d>e</d>\n    <d>f</d>\n  </c>\n</opt>\n").status.should == "200"
+              :body => "<opt a=\"1\" b=\"five\">\n  <c>\n    <d>e</d>\n    <d>f</d>\n  </c>\n</opt>\n").status.should be == "200"
           end
 
           it "should match if hash matches body in different form" do
             http_request(
               :post, "http://www.example.com/", :headers => {'Content-Type' => 'application/xml'},
-              :body => "<opt b=\"five\" a=\"1\">\n  <c>\n    <d>e</d>\n    <d>f</d>\n  </c>\n</opt>\n").status.should == "200"
+              :body => "<opt b=\"five\" a=\"1\">\n  <c>\n    <d>e</d>\n    <d>f</d>\n  </c>\n</opt>\n").status.should be == "200"
           end
 
         end
@@ -339,14 +339,14 @@ shared_examples_for "WebMock" do
         stub_http_request(:get, "www.example.com").with(:headers => SAMPLE_HEADERS )
         http_request(
           :get, "http://www.example.com/",
-          :headers => SAMPLE_HEADERS).status.should == "200"
+          :headers => SAMPLE_HEADERS).status.should be == "200"
       end
 
       it "should match requests if headers are the same and declared as array" do
         stub_http_request(:get, "www.example.com").with(:headers => {"a" => ["b"]} )
         http_request(
           :get, "http://www.example.com/",
-          :headers => {"a" => "b"}).status.should == "200"
+          :headers => {"a" => "b"}).status.should be == "200"
       end
 
       describe "when multiple headers with the same key are used" do
@@ -355,14 +355,14 @@ shared_examples_for "WebMock" do
           stub_http_request(:get, "www.example.com").with(:headers => {"a" => ["b", "c"]} )
           http_request(
             :get, "http://www.example.com/",
-            :headers => {"a" => ["b", "c"]}).status.should == "200"
+            :headers => {"a" => ["b", "c"]}).status.should be == "200"
         end
 
         it "should match requests if headers are the same  but in different order" do
           stub_http_request(:get, "www.example.com").with(:headers => {"a" => ["b", "c"]} )
           http_request(
             :get, "http://www.example.com/",
-            :headers => {"a" => ["c", "b"]}).status.should == "200"
+            :headers => {"a" => ["c", "b"]}).status.should be == "200"
         end
 
         it "should not match requests if headers are different" do
@@ -381,7 +381,7 @@ shared_examples_for "WebMock" do
         stub_http_request(:get, "www.example.com")
         http_request(
           :get, "http://www.example.com/",
-          :headers => SAMPLE_HEADERS).status.should == "200"
+          :headers => SAMPLE_HEADERS).status.should be == "200"
       end
 
       it "should not match requests if headers are different" do
@@ -410,7 +410,7 @@ shared_examples_for "WebMock" do
           stub_http_request(:get, "www.example.com").with(:headers => { :user_agent => /^MyAppName$/ })
           http_request(
             :get, "http://www.example.com/",
-            :headers => { 'user-agent' => 'MyAppName' }).status.should == "200"
+            :headers => { 'user-agent' => 'MyAppName' }).status.should be == "200"
         end
 
         it "should not match requests if headers values do not match regular expression" do
@@ -430,27 +430,27 @@ shared_examples_for "WebMock" do
 
       it "should match if credentials are the same" do
         stub_http_request(:get, "user:pass@www.example.com")
-        http_request(:get, "http://user:pass@www.example.com/").status.should == "200"
+        http_request(:get, "http://user:pass@www.example.com/").status.should be == "200"
       end
 
       it "should not match if credentials are different" do
         stub_http_request(:get, "user:pass@www.example.com")
         lambda {
-          http_request(:get, "http://user:pazz@www.example.com/").status.should == "200"
+          http_request(:get, "http://user:pazz@www.example.com/").status.should be == "200"
         }.should raise_error(WebMock::NetConnectNotAllowedError, %r(Real HTTP connections are disabled. Unregistered request: GET http://user:pazz@www.example.com/))
       end
 
       it "should not match if credentials are stubbed but not provided in the request" do
         stub_http_request(:get, "user:pass@www.example.com")
         lambda {
-          http_request(:get, "http://www.example.com/").status.should == "200"
+          http_request(:get, "http://www.example.com/").status.should be == "200"
         }.should raise_error(WebMock::NetConnectNotAllowedError, %r(Real HTTP connections are disabled. Unregistered request: GET http://www.example.com/))
       end
 
       it "should not match if credentials are not stubbed but exist in the request" do
         stub_http_request(:get, "www.example.com")
         lambda {
-          http_request(:get, "http://user:pazz@www.example.com/").status.should == "200"
+          http_request(:get, "http://user:pazz@www.example.com/").status.should be == "200"
         }.should raise_error(WebMock::NetConnectNotAllowedError, %r(Real HTTP connections are disabled. Unregistered request: GET http://user:pazz@www.example.com/))
       end
 
@@ -460,7 +460,7 @@ shared_examples_for "WebMock" do
 
       it "should match if block returns true" do
         stub_http_request(:get, "www.example.com").with { |request| true }
-        http_request(:get, "http://www.example.com/").status.should == "200"
+        http_request(:get, "http://www.example.com/").status.should be == "200"
       end
 
       it "should not match if block returns false" do
@@ -474,7 +474,7 @@ shared_examples_for "WebMock" do
         stub_http_request(:post, "www.example.com").with { |request| request.body == "wadus" }
         http_request(
           :post, "http://www.example.com/",
-          :body => "wadus").status.should == "200"
+          :body => "wadus").status.should be == "200"
         lambda {
           http_request(:post, "http://www.example.com/", :body => "jander")
         }.should raise_error(WebMock::NetConnectNotAllowedError, %r(Real HTTP connections are disabled. Unregistered request: POST http://www.example.com/ with body 'jander'))
@@ -509,7 +509,7 @@ shared_examples_for "WebMock" do
 
       it "should raise exception if declared in a stubbed response after returning declared response" do
         stub_http_request(:get, "www.example.com").to_return(:body => "abc").then.to_raise(MyException)
-          http_request(:get, "http://www.example.com/").body.should == "abc"
+          http_request(:get, "http://www.example.com/").body.should be == "abc"
           lambda {
             http_request(:get, "http://www.example.com/")
           }.should raise_error(MyException, "Exception from WebMock")
@@ -529,7 +529,7 @@ shared_examples_for "WebMock" do
 
         it "should raise exception if declared in a stubbed response after returning declared response" do
           stub_http_request(:get, "www.example.com").to_return(:body => "abc").then.to_timeout
-          http_request(:get, "http://www.example.com/").body.should == "abc"
+          http_request(:get, "http://www.example.com/").body.should be == "abc"
           lambda {
             http_request(:get, "http://www.example.com/")
           }.should raise_error(client_timeout_exception_class)
@@ -541,50 +541,50 @@ shared_examples_for "WebMock" do
 
         it "should return declared body" do
           stub_http_request(:get, "www.example.com").to_return(:body => "abc")
-          http_request(:get, "http://www.example.com/").body.should == "abc"
+          http_request(:get, "http://www.example.com/").body.should be == "abc"
         end
 
         it "should return declared headers" do
           stub_http_request(:get, "www.example.com").to_return(:headers => SAMPLE_HEADERS)
           response = http_request(:get, "http://www.example.com/")
-          response.headers["Content-Length"].should == "8888"
+          response.headers["Content-Length"].should be == "8888"
         end
 
         it "should return declared headers when there are multiple headers with the same key" do
           stub_http_request(:get, "www.example.com").to_return(:headers => {"a" => ["b", "c"]})
           response = http_request(:get, "http://www.example.com/")
-          response.headers["A"].should == "b, c"
+          response.headers["A"].should be == "b, c"
         end
 
         it "should return declared status code" do
           stub_http_request(:get, "www.example.com").to_return(:status => 500)
-          http_request(:get, "http://www.example.com/").status.should == "500"
+          http_request(:get, "http://www.example.com/").status.should be == "500"
         end
 
         it "should return declared status message" do
           stub_http_request(:get, "www.example.com").to_return(:status => [500, "Internal Server Error"])
-          http_request(:get, "http://www.example.com/").message.should == "Internal Server Error"
+          http_request(:get, "http://www.example.com/").message.should be == "Internal Server Error"
         end
 
         it "should return default status code" do
           stub_http_request(:get, "www.example.com")
-          http_request(:get, "http://www.example.com/").status.should == "200"
+          http_request(:get, "http://www.example.com/").status.should be == "200"
         end
 
         it "should return default empty message" do
           stub_http_request(:get, "www.example.com")
-          http_request(:get, "http://www.example.com/").message.should == ""
+          http_request(:get, "http://www.example.com/").message.should be == ""
         end
 
         it "should return body declared as IO" do
           stub_http_request(:get, "www.example.com").to_return(:body => File.new(__FILE__))
-          http_request(:get, "http://www.example.com/").body.should == File.new(__FILE__).read
+          http_request(:get, "http://www.example.com/").body.should be == File.new(__FILE__).read
         end
 
         it "should return body declared as IO if requested many times" do
           stub_http_request(:get, "www.example.com").to_return(:body => File.new(__FILE__))
           2.times do
-            http_request(:get, "http://www.example.com/").body.should == File.new(__FILE__).read
+            http_request(:get, "http://www.example.com/").body.should be == File.new(__FILE__).read
           end
         end
 
@@ -597,12 +597,12 @@ shared_examples_for "WebMock" do
 
           it "should return evaluated response body" do
             stub_http_request(:post, "www.example.com").to_return(:body => lambda { |request| request.body })
-            http_request(:post, "http://www.example.com/", :body => "echo").body.should == "echo"
+            http_request(:post, "http://www.example.com/", :body => "echo").body.should be == "echo"
           end
 
           it "should return evaluated response headers" do
             stub_http_request(:post, "www.example.com").to_return(:headers => lambda { |request| request.headers })
-            http_request(:post, "http://www.example.com/", :body => "abc", :headers => {'A' => 'B'}).headers['A'].should == 'B'
+            http_request(:post, "http://www.example.com/", :body => "abc", :headers => {'A' => 'B'}).headers['A'].should be == 'B'
           end
 
         end
@@ -610,6 +610,8 @@ shared_examples_for "WebMock" do
         describe "dynamic responses" do
 
           class Responder
+            undef :call if method_defined?(:call)
+
             def call(request)
               {:body => request.body}
             end
@@ -619,26 +621,26 @@ shared_examples_for "WebMock" do
             stub_http_request(:post, "www.example.com").to_return(lambda { |request|
               {:body => request.body}
             })
-            http_request(:post, "http://www.example.com/", :body => "echo").body.should == "echo"
+            http_request(:post, "http://www.example.com/", :body => "echo").body.should be == "echo"
           end
 
           it "should return evaluated response headers" do
             stub_http_request(:get, "www.example.com").to_return(lambda { |request|
               {:headers => request.headers}
             })
-            http_request(:get, "http://www.example.com/", :headers => {'A' => 'B'}).headers['A'].should == 'B'
+            http_request(:get, "http://www.example.com/", :headers => {'A' => 'B'}).headers['A'].should be == 'B'
           end
 
           it "should create dynamic responses from blocks" do
             stub_http_request(:post, "www.example.com").to_return do |request|
               {:body => request.body}
             end
-            http_request(:post, "http://www.example.com/", :body => "echo").body.should == "echo"
+            http_request(:post, "http://www.example.com/", :body => "echo").body.should be == "echo"
           end
 
           it "should create dynamic responses from objects responding to call" do
             stub_http_request(:post, "www.example.com").to_return(Responder.new)
-            http_request(:post, "http://www.example.com/", :body => "echo").body.should == "echo"
+            http_request(:post, "http://www.example.com/", :body => "echo").body.should be == "echo"
           end
 
         end
@@ -653,7 +655,7 @@ shared_examples_for "WebMock" do
           end
 
           it "should return recorded headers" do
-            @response.headers.should == {
+            @response.headers.should be == {
               "Date"=>"Sat, 23 Jan 2010 01:01:05 GMT",
               "Content-Type"=>"text/html; charset=UTF-8",
               "Content-Length"=>"419",
@@ -663,15 +665,15 @@ shared_examples_for "WebMock" do
           end
 
           it "should return recorded body" do
-            @response.body.size.should == 419
+            @response.body.size.should be == 419
           end
 
           it "should return recorded status" do
-            @response.status.should == "202"
+            @response.status.should be == "202"
           end
 
           it "should return recorded status message" do
-            @response.message.should == "OK"
+            @response.message.should be == "OK"
           end
 
           it "should ensure file is closed" do
@@ -689,7 +691,7 @@ shared_examples_for "WebMock" do
           end
 
           it "should return recorded headers" do
-            @response.headers.should == {
+            @response.headers.should be == {
               "Date"=>"Sat, 23 Jan 2010 01:01:05 GMT",
               "Content-Type"=>"text/html; charset=UTF-8",
               "Content-Length"=>"419",
@@ -699,15 +701,15 @@ shared_examples_for "WebMock" do
           end
 
           it "should return recorded body" do
-            @response.body.size.should == 419
+            @response.body.size.should be == 419
           end
 
           it "should return recorded status" do
-            @response.status.should == "202"
+            @response.status.should be == "202"
           end
 
           it "should return recorded status message" do
-            @response.message.should == "OK"
+            @response.message.should be == "OK"
           end
         end
 
@@ -720,12 +722,12 @@ shared_examples_for "WebMock" do
 
           it "should return response from evaluated file" do
             stub_http_request(:get, "www.example.com").to_return(lambda {|request| @files[request.uri.host.to_s] })
-            http_request(:get, "http://www.example.com/").body.size.should == 419
+            http_request(:get, "http://www.example.com/").body.size.should be == 419
           end
 
           it "should return response from evaluated string" do
             stub_http_request(:get, "www.example.com").to_return(lambda {|request| @files[request.uri.host.to_s].read })
-            http_request(:get, "http://www.example.com/").body.size.should == 419
+            http_request(:get, "http://www.example.com/").body.size.should be == 419
           end
 
         end
@@ -734,23 +736,23 @@ shared_examples_for "WebMock" do
 
           it "should return responses one by one if declared in array" do
             stub_http_request(:get, "www.example.com").to_return([ {:body => "1"}, {:body => "2"}, {:body => "3"} ])
-            http_request(:get, "http://www.example.com/").body.should == "1"
-            http_request(:get, "http://www.example.com/").body.should == "2"
-            http_request(:get, "http://www.example.com/").body.should == "3"
+            http_request(:get, "http://www.example.com/").body.should be == "1"
+            http_request(:get, "http://www.example.com/").body.should be == "2"
+            http_request(:get, "http://www.example.com/").body.should be == "3"
           end
 
           it "should repeat returning last declared response from a sequence after all responses were returned" do
             stub_http_request(:get, "www.example.com").to_return([ {:body => "1"}, {:body => "2"} ])
-            http_request(:get, "http://www.example.com/").body.should == "1"
-            http_request(:get, "http://www.example.com/").body.should == "2"
-            http_request(:get, "http://www.example.com/").body.should == "2"
+            http_request(:get, "http://www.example.com/").body.should be == "1"
+            http_request(:get, "http://www.example.com/").body.should be == "2"
+            http_request(:get, "http://www.example.com/").body.should be == "2"
           end
 
           it "should return responses one by one if declared as comma separated params" do
             stub_http_request(:get, "www.example.com").to_return({:body => "1"}, {:body => "2"}, {:body => "3"})
-            http_request(:get, "http://www.example.com/").body.should == "1"
-            http_request(:get, "http://www.example.com/").body.should == "2"
-            http_request(:get, "http://www.example.com/").body.should == "3"
+            http_request(:get, "http://www.example.com/").body.should be == "1"
+            http_request(:get, "http://www.example.com/").body.should be == "2"
+            http_request(:get, "http://www.example.com/").body.should be == "3"
           end
 
           it "should return responses one by one if declared with several to_return invokations" do
@@ -758,17 +760,17 @@ shared_examples_for "WebMock" do
               to_return({:body => "1"}).
               to_return({:body => "2"}).
               to_return({:body => "3"})
-            http_request(:get, "http://www.example.com/").body.should == "1"
-            http_request(:get, "http://www.example.com/").body.should == "2"
-            http_request(:get, "http://www.example.com/").body.should == "3"
+            http_request(:get, "http://www.example.com/").body.should be == "1"
+            http_request(:get, "http://www.example.com/").body.should be == "2"
+            http_request(:get, "http://www.example.com/").body.should be == "3"
           end
 
           it "should return responses one by one if declared with to_return invocations separated with then syntactic sugar" do
             stub_http_request(:get, "www.example.com").to_return({:body => "1"}).then.
                 to_return({:body => "2"}).then.to_return({:body => "3"})
-                http_request(:get, "http://www.example.com/").body.should == "1"
-                http_request(:get, "http://www.example.com/").body.should == "2"
-                http_request(:get, "http://www.example.com/").body.should == "3"
+                http_request(:get, "http://www.example.com/").body.should be == "1"
+                http_request(:get, "http://www.example.com/").body.should be == "2"
+                http_request(:get, "http://www.example.com/").body.should be == "3"
           end
 
         end
@@ -779,9 +781,9 @@ shared_examples_for "WebMock" do
             stub_http_request(:get, "www.example.com").
               to_return({:body => "1"}).times(2).
               to_return({:body => "2"})
-              http_request(:get, "http://www.example.com/").body.should == "1"
-              http_request(:get, "http://www.example.com/").body.should == "1"
-              http_request(:get, "http://www.example.com/").body.should == "2"
+              http_request(:get, "http://www.example.com/").body.should be == "1"
+              http_request(:get, "http://www.example.com/").body.should be == "1"
+              http_request(:get, "http://www.example.com/").body.should be == "2"
           end
 
 
@@ -789,20 +791,20 @@ shared_examples_for "WebMock" do
              stub_http_request(:get, "www.example.com").
                 to_return({:body => "1"}, {:body => "2"}).times(2).
                 to_return({:body => "3"})
-                http_request(:get, "http://www.example.com/").body.should == "1"
-                http_request(:get, "http://www.example.com/").body.should == "2"
-                http_request(:get, "http://www.example.com/").body.should == "1"
-                http_request(:get, "http://www.example.com/").body.should == "2"
-                http_request(:get, "http://www.example.com/").body.should == "3"
+                http_request(:get, "http://www.example.com/").body.should be == "1"
+                http_request(:get, "http://www.example.com/").body.should be == "2"
+                http_request(:get, "http://www.example.com/").body.should be == "1"
+                http_request(:get, "http://www.example.com/").body.should be == "2"
+                http_request(:get, "http://www.example.com/").body.should be == "3"
           end
 
 
           it "should repeat infinitely last response even if number of declared times is lower" do
             stub_http_request(:get, "www.example.com").
               to_return({:body => "1"}).times(2)
-              http_request(:get, "http://www.example.com/").body.should == "1"
-              http_request(:get, "http://www.example.com/").body.should == "1"
-              http_request(:get, "http://www.example.com/").body.should == "1"
+              http_request(:get, "http://www.example.com/").body.should be == "1"
+              http_request(:get, "http://www.example.com/").body.should be == "1"
+              http_request(:get, "http://www.example.com/").body.should be == "1"
           end
 
           it "should give error if times is declared without specifying response" do
@@ -825,7 +827,7 @@ shared_examples_for "WebMock" do
               lambda {
                 http_request(:get, "http://www.example.com/")
               }.should raise_error(MyException, "Exception from WebMock")
-              http_request(:get, "http://www.example.com/").body.should == "2"
+              http_request(:get, "http://www.example.com/").body.should be == "2"
           end
 
            it "should repeat raising sequence of exceptions declared number of times" do
@@ -844,7 +846,7 @@ shared_examples_for "WebMock" do
               lambda {
                 http_request(:get, "http://www.example.com/")
               }.should raise_error(ArgumentError)
-              http_request(:get, "http://www.example.com/").body.should == "2"
+              http_request(:get, "http://www.example.com/").body.should be == "2"
           end
         end
       end
@@ -854,13 +856,13 @@ shared_examples_for "WebMock" do
             it "should use the last declared matching request stub" do
               stub_http_request(:get, "www.example.com").to_return(:body => "abc")
               stub_http_request(:get, "www.example.com").to_return(:body => "def")
-              http_request(:get, "http://www.example.com/").body.should == "def"
+              http_request(:get, "http://www.example.com/").body.should be == "def"
             end
 
             it "should not be affected by the type of uri or request method" do
               stub_http_request(:get, "www.example.com").to_return(:body => "abc")
               stub_http_request(:any, /.*example.*/).to_return(:body => "def")
-              http_request(:get, "http://www.example.com/").body.should == "def"
+              http_request(:get, "http://www.example.com/").body.should be == "def"
             end
 
           end
@@ -1440,34 +1442,38 @@ shared_examples_for "WebMock" do
       end
 
       it "should not invoke callback unless request is made" do
+        @called = nil
         WebMock.after_request {
           @called = true
         }
-        @called.should == nil
+        @called.should be == nil
       end
 
       it "should invoke a callback after request is made" do
+        @called = nil
         WebMock.after_request {
           @called = true
         }
         http_request(:get, "http://www.example.com/")
-        @called.should == true
+        @called.should be == true
       end
 
       it "should not invoke a callback if specific http library should be ignored" do
+        @called = nil
         WebMock.after_request(:except => [http_library()]) {
           @called = true
         }
         http_request(:get, "http://www.example.com/")
-        @called.should == nil
+        @called.should be == nil
       end
 
       it "should invoke a callback even if other http libraries should be ignored" do
+        @called = nil
         WebMock.after_request(:except => [:other_lib]) {
           @called = true
         }
         http_request(:get, "http://www.example.com/")
-        @called.should == true
+        @called.should be == true
       end
 
       it "should pass request signature to the callback" do
@@ -1475,7 +1481,7 @@ shared_examples_for "WebMock" do
           @request_signature = request_signature
         end
         http_request(:get, "http://www.example.com/")
-        @request_signature.uri.to_s.should == "http://www.example.com:80/"
+        @request_signature.uri.to_s.should be == "http://www.example.com:80/"
       end
 
       describe "passing response to callback" do
@@ -1495,18 +1501,18 @@ shared_examples_for "WebMock" do
           end
 
           it "should pass response with status and message" do
-            @response.status.should == ["200", "hello"]
+            @response.status.should be == ["200", "hello"]
           end
 
           it "should pass response with headers" do
-            @response.headers.should == {
+            @response.headers.should be == {
               'Content-Length' => '666',
               'Hello' => 'World'
             }
           end
 
           it "should pass response with body" do
-            @response.body.should == "foo bar"
+            @response.body.should be == "foo bar"
           end
 
         end
@@ -1522,16 +1528,16 @@ shared_examples_for "WebMock" do
           end
 
           it "should pass response with status and message" do
-            @response.status[0].should == 302
-            @response.status[1].should == "Found"
+            @response.status[0].should be == 302
+            @response.status[1].should be == "Found"
           end
 
           it "should pass response with headers" do
-            @response.headers["Content-Length"].should == "#{WWW_EXAMPLE_COM_CONTENT_LENGTH}"
+            @response.headers["Content-Length"].should be == "#{WWW_EXAMPLE_COM_CONTENT_LENGTH}"
           end
 
           it "should pass response with body" do
-            @response.body.size.should == WWW_EXAMPLE_COM_CONTENT_LENGTH
+            @response.body.size.should be == WWW_EXAMPLE_COM_CONTENT_LENGTH
           end
 
         end
@@ -1539,27 +1545,30 @@ shared_examples_for "WebMock" do
       end
 
       it "should invoke multiple callbacks in order of their declarations" do
+        @called = nil
         WebMock.after_request { @called = 1 }
         WebMock.after_request { @called += 1 }
         http_request(:get, "http://www.example.com/")
-        @called.should == 2
+        @called.should be == 2
       end
 
       it "should invoke callbacks only for real requests if requested", :net_connect => true do
+        @called = nil
         WebMock.after_request(:real_requests_only => true) { @called = true }
         http_request(:get, "http://www.example.com/")
-        @called.should == nil
+        @called.should be == nil
         WebMock.allow_net_connect!
         http_request(:get, "http://www.example.net/")
-        @called.should == true
+        @called.should be == true
       end
 
       it "should clear all declared callbacks on reset callbacks" do
+        @called = nil
         WebMock.after_request { @called = 1 }
         WebMock.reset_callbacks
         stub_request(:get, "http://www.example.com")
         http_request(:get, "http://www.example.com/")
-        @called.should == nil
+        @called.should be == nil
       end
 
     end

--- a/test/test_webmock.rb
+++ b/test/test_webmock.rb
@@ -16,8 +16,8 @@ class TestWebMock < Test::Unit::TestCase
     req.basic_auth uri.user, uri.password if uri.user
     http = ::Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true if uri.scheme == "https"
-    response = http.start {|http|
-      http.request(req, options[:body])
+    response = http.start {|h|
+      h.request(req, options[:body])
     }
     OpenStruct.new({
       :body => response.body,


### PR DESCRIPTION
With this commit, WebMock's code and specs do not generate any warnings when running the specs in verbose mode. Warnings are still generated, but these are all from WebMock's dependencies.

Before:

```
$ RUBYOPT=-w rake 2>&1 | wc -l
19063
```

After:

```
$ RUBYOPT=-w rake 2>&1 | wc -l
1364
```
