### PR TITLE
Curb http post put w multi args

### DIFF
--- a/lib/webmock/http_lib_adapters/curb.rb
+++ b/lib/webmock/http_lib_adapters/curb.rb
@@ -138,11 +138,11 @@ if defined?(Curl)
         alias_method "http_#{verb}", "http_#{verb}_with_webmock"
       end
 
-      def http_put_with_webmock *data
+      def http_put_with_webmock data = nil
         @webmock_method = :put
-        @put_data = data.join('&') if data && !data.empty?
+        @put_data = data if data
         curb_or_webmock do
-          http_put_without_webmock(*data)
+          http_put_without_webmock(data)
         end
       end
       alias_method :http_put_without_webmock, :http_put
@@ -250,17 +250,23 @@ if defined?(Curl)
         METHOD
       end
 
-      %w[ put post ].each do |verb|
-        class_eval <<-METHOD, __FILE__, __LINE__
-          def self.http_#{verb}(url, data, &block)
-            c = new
-            c.url = url
-            block.call(c) if block
-            c.send("http_#{verb}", data)
-            c
-          end
-        METHOD
-      end
+      class_eval <<-METHOD, __FILE__, __LINE__
+        def self.http_put(url, data, &block)
+          c = new
+          c.url = url
+          block.call(c) if block
+          c.send(:http_put, data)
+          c
+        end
+
+        def self.http_post(url, *data, &block)
+          c = new
+          c.url = url
+          block.call(c) if block
+          c.send(:http_post, *data)
+          c
+        end
+      METHOD
 
       module WebmockHelper
         # Borrowed from Patron:

--- a/spec/curb_spec.rb
+++ b/spec/curb_spec.rb
@@ -1,6 +1,5 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 require 'webmock_shared'
-require 'uri'
 
 unless RUBY_PLATFORM =~ /java/
   require 'curb_spec_helper'
@@ -282,6 +281,12 @@ unless RUBY_PLATFORM =~ /java/
         c.response_code.should == 200
       end
 
+      it "should work with several body arguments for post using the class method" do
+        stub_http_request(:post, "www.example.com").with(:user => {:first_name=>'Bartosz', :last_name=>'Blimke'})
+        c = Curl::Easy.http_post "http://www.example.com", 'user[first_name]=Bartosz', 'user[last_name]=Blimke'
+        c.response_code.should == 200
+      end
+
       it "should work with blank arguments for put" do
         stub_http_request(:put, "www.example.com").with(:body => "01234")
         c = Curl::Easy.new
@@ -293,24 +298,11 @@ unless RUBY_PLATFORM =~ /java/
 
       it "should work with multiple arguments for post" do
         data = { :name => "john", :address => "111 example ave" }
-        body = data.map{ |k,v| "#{k}=#{URI.encode(v)}"}.join('&')
 
-        stub_http_request(:post, "www.example.com").with(:body => body)
+        stub_http_request(:post, "www.example.com").with(:body => data)
         c = Curl::Easy.new
         c.url = "http://www.example.com"
         c.http_post Curl::PostField.content('name', data[:name]),  Curl::PostField.content('address', data[:address])
-
-        c.response_code.should == 200
-      end
-
-      it "should work with multiple arguments for put" do
-        data = { :name => "john", :address => "111 example ave" }
-        body = data.map{ |k,v| "#{k}=#{URI.encode(v)}"}.join('&')
-
-        stub_http_request(:put, "www.example.com").with(:body => body)
-        c = Curl::Easy.new
-        c.url = "http://www.example.com"
-        c.http_put Curl::PostField.content('name', data[:name]),  Curl::PostField.content('address', data[:address])
 
         c.response_code.should == 200
       end


### PR DESCRIPTION
Follow on to #96.

Curb http_post can take arbitrary number of parameters in class & instance methods.  However http_put only takes one parameter.
