### PR TITLE
stub request snippet shows the body as a hash when its a url encoded form

### DIFF
--- a/lib/webmock/stub_request_snippet.rb
+++ b/lib/webmock/stub_request_snippet.rb
@@ -11,11 +11,12 @@ module WebMock
       with = ""
 
       if (@request_signature.body.to_s != '')
-        with << ":body => #{@request_signature.body.inspect}"
+        body = use_body_hash? ? body_hash : @request_signature.body
+        with << ":body => #{body.inspect}"
       end
 
       if (@request_signature.headers && !@request_signature.headers.empty?)
-        with << ", \n       " unless with.empty?
+        with << ",\n       " unless with.empty?
 
         with << ":headers => #{WebMock::Util::Headers.sorted_headers_string(@request_signature.headers)}"
       end
@@ -23,5 +24,14 @@ module WebMock
       string << ".\n  to_return(:status => 200, :body => \"\", :headers => {})"
       string
     end
+
+    def body_hash
+      Addressable::URI.parse('?' + @request_signature.body).query_values
+    end
+
+    def use_body_hash?
+      @request_signature.headers['Content-Type'] == 'application/x-www-form-urlencoded'
+    end
+
   end
 end

--- a/spec/stub_request_snippet_spec.rb
+++ b/spec/stub_request_snippet_spec.rb
@@ -2,46 +2,82 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe WebMock::StubRequestSnippet do
   describe "to_s" do
-    before(:each) do
-      @request_signature = WebMock::RequestSignature.new(:get, "www.example.com/?a=b&c=d")
+    describe "GET" do
+      before(:each) do
+        @request_signature = WebMock::RequestSignature.new(:get, "www.example.com/?a=b&c=d", :headers => {})
+      end
+
+      it "should print stub request snippet with url with params and method and empty successful response" do
+        expected = %Q(stub_request(:get, "http://www.example.com/?a=b&c=d").\n  to_return(:status => 200, :body => "", :headers => {}))
+        WebMock::StubRequestSnippet.new(@request_signature).to_s.should == expected
+      end
+
+      it "should print stub request snippet with body if available" do
+        @request_signature.body = "abcdef"
+        expected = %Q(stub_request(:get, "http://www.example.com/?a=b&c=d").)+
+        "\n  with(:body => \"abcdef\")." +
+        "\n  to_return(:status => 200, :body => \"\", :headers => {})"
+        WebMock::StubRequestSnippet.new(@request_signature).to_s.should == expected
+      end
+
+      it "should print stub request snippet with multiline body" do
+        @request_signature.body = "abc\ndef"
+        expected = %Q(stub_request(:get, "http://www.example.com/?a=b&c=d").)+
+        "\n  with(:body => \"abc\\ndef\")." +
+        "\n  to_return(:status => 200, :body => \"\", :headers => {})"
+        WebMock::StubRequestSnippet.new(@request_signature).to_s.should == expected
+      end
+
+      it "should print stub request snippet with headers if any" do
+        @request_signature.headers = {'B' => 'b', 'A' => 'a'}
+        expected = 'stub_request(:get, "http://www.example.com/?a=b&c=d").'+
+        "\n  with(:headers => {\'A\'=>\'a\', \'B\'=>\'b\'})." +
+        "\n  to_return(:status => 200, :body => \"\", :headers => {})"
+        WebMock::StubRequestSnippet.new(@request_signature).to_s.should == expected
+      end
+
+      it "should print stub request snippet with body and headers" do
+        @request_signature.body = "abcdef"
+        @request_signature.headers = {'B' => 'b', 'A' => 'a'}
+        expected = 'stub_request(:get, "http://www.example.com/?a=b&c=d").'+
+        "\n  with(:body => \"abcdef\",\n       :headers => {\'A\'=>\'a\', \'B\'=>\'b\'})." +
+        "\n  to_return(:status => 200, :body => \"\", :headers => {})"
+        WebMock::StubRequestSnippet.new(@request_signature).to_s.should == expected
+      end
     end
 
-    it "should print stub request snippet with url with params and method and empty successful response" do
-      expected = %Q(stub_request(:get, "http://www.example.com/?a=b&c=d").\n  to_return(:status => 200, :body => "", :headers => {}))
-      WebMock::StubRequestSnippet.new(@request_signature).to_s.should == expected
+    describe "POST" do
+      let(:form_body) { 'user%5bfirst_name%5d=Bartosz&user%5blast_name%5d=Blimke' }
+      let(:multipart_form_body) { 'complicated stuff--ABC123--goes here' }
+      it "should print stub request snippet with body as a hash using rails conventions on form posts" do
+        @request_signature = WebMock::RequestSignature.new(:post, "www.example.com",
+                   :headers => {'Content-Type' => 'application/x-www-form-urlencoded'},
+                   :body => form_body)
+
+        expected = <<-STUB
+stub_request(:post, "http://www.example.com/").
+  with(:body => {"user"=>{"last_name"=>"Blimke", "first_name"=>"Bartosz"}},
+       :headers => {'Content-Type'=>'application/x-www-form-urlencoded'}).
+  to_return(:status => 200, :body => \"\", :headers => {})
+        STUB
+        WebMock::StubRequestSnippet.new(@request_signature).to_s.should == expected.strip
+      end
+
+      it "should print stub request snippet leaving body as string when not a urlencoded form" do
+        @request_signature = WebMock::RequestSignature.new(:post, "www.example.com",
+                   :headers => {'Content-Type' => 'multipart/form-data; boundary=ABC123'},
+                   :body => multipart_form_body)
+
+        expected = <<-STUB
+stub_request(:post, "http://www.example.com/").
+  with(:body => "#{multipart_form_body}",
+       :headers => {'Content-Type'=>'multipart/form-data; boundary=ABC123'}).
+  to_return(:status => 200, :body => \"\", :headers => {})
+        STUB
+        WebMock::StubRequestSnippet.new(@request_signature).to_s.should == expected.strip
+      end
     end
 
-    it "should print stub request snippet with body if available" do
-      @request_signature.body = "abcdef"
-      expected = %Q(stub_request(:get, "http://www.example.com/?a=b&c=d").)+
-      "\n  with(:body => \"abcdef\")." +
-      "\n  to_return(:status => 200, :body => \"\", :headers => {})"
-      WebMock::StubRequestSnippet.new(@request_signature).to_s.should == expected
-    end
 
-    it "should print stub request snippet with multiline body" do
-      @request_signature.body = "abc\ndef"
-      expected = %Q(stub_request(:get, "http://www.example.com/?a=b&c=d").)+
-      "\n  with(:body => \"abc\\ndef\")." +
-      "\n  to_return(:status => 200, :body => \"\", :headers => {})"
-      WebMock::StubRequestSnippet.new(@request_signature).to_s.should == expected
-    end
-
-    it "should print stub request snippet with headers if any" do
-      @request_signature.headers = {'B' => 'b', 'A' => 'a'}
-      expected = 'stub_request(:get, "http://www.example.com/?a=b&c=d").'+
-      "\n  with(:headers => {\'A\'=>\'a\', \'B\'=>\'b\'})." +
-      "\n  to_return(:status => 200, :body => \"\", :headers => {})"
-      WebMock::StubRequestSnippet.new(@request_signature).to_s.should == expected
-    end
-
-    it "should print stub request snippet with body and headers" do
-      @request_signature.body = "abcdef"
-      @request_signature.headers = {'B' => 'b', 'A' => 'a'}
-      expected = 'stub_request(:get, "http://www.example.com/?a=b&c=d").'+
-      "\n  with(:body => \"abcdef\", \n       :headers => {\'A\'=>\'a\', \'B\'=>\'b\'})." +
-      "\n  to_return(:status => 200, :body => \"\", :headers => {})"
-      WebMock::StubRequestSnippet.new(@request_signature).to_s.should == expected
-    end
   end
 end


### PR DESCRIPTION
stub request snippet shows the body as a hash when its a url encoded form.  This is more like what you would want to copy and paste into your spec as a stub_request
