### PR TITLE
Allow EM::HttpRequest bodies that are hashes to match hash patterns

### DIFF
--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -149,7 +149,8 @@ module WebMock
         when :xml then
           matching_hashes?(Crack::XML.parse(body), @pattern)
         else
-          matching_hashes?(Addressable::URI.parse('?' + body).query_values, @pattern)
+          body_hash = body.is_a?(Hash) ? normalize_hash(body) : Addressable::URI.parse('?' + body).query_values
+          matching_hashes?(body_hash, @pattern)
         end
       else
         empty_string?(@pattern) && empty_string?(body) ||

--- a/spec/em_http_request_spec.rb
+++ b/spec/em_http_request_spec.rb
@@ -126,6 +126,15 @@ unless RUBY_PLATFORM =~ /java/
       http_request(:get, "http://www.example.com/?x=3", :query => "a[]=b&a[]=c").body.should == "abc"
     end
 
+    it "should work with POST body params declared as a Hash" do
+      stub_http_request(:post, "www.example.com").with(:body => {:a => "1", :b => "2"}).to_return(:body => "ok")
+      http_request(:post, "http://www.example.com", :body => {:a => "1", :b => "2"}).body.should == "ok"
+
+      expect {
+        http_request(:post, "http://www.example.com", :body => {:a => "1", :b => "2", :c => "3"})
+      }.to raise_error(WebMock::NetConnectNotAllowedError)
+    end
+
     describe "mocking EM::HttpClient API" do
       before do
         stub_http_request(:get, "www.example.com/")

--- a/spec/request_pattern_spec.rb
+++ b/spec/request_pattern_spec.rb
@@ -235,6 +235,18 @@ describe WebMock::RequestPattern do
           end
         end
 
+        describe "for request with body as a hash (a la EM::HttpRequest)" do
+          it "should match when hash matches body" do
+            WebMock::RequestPattern.new(:post, 'www.example.com', :body => body_hash).
+              should match(WebMock::RequestSignature.new(:post, "www.example.com", :body => body_hash))
+          end
+
+          it "should not match when hash does not match body" do
+            WebMock::RequestPattern.new(:post, 'www.example.com', :body => body_hash).
+              should_not match(WebMock::RequestSignature.new(:post, "www.example.com", :body => body_hash.merge(:x => "y")))
+          end
+        end
+
         describe "for request with json body and content type is set to json" do
           it "should match when hash matches body" do
            WebMock::RequestPattern.new(:post, 'www.example.com', :body => body_hash).


### PR DESCRIPTION
And I just realized that the other option would be to force EM::HttpRequest's request signature to convert the body to a URI-encoded string. But in any case, here's one solution.
