### PR TITLE
Match EM::HttpRequest Hash bodies

### DIFF
--- a/lib/webmock/http_lib_adapters/em_http_request/em_http_request_0_x.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request/em_http_request_0_x.rb
@@ -112,10 +112,13 @@ if defined?(EventMachine::HttpRequest)
 
         uri.query = encode_query(@req.uri, options[:query]).slice(/\?(.*)/, 1)
 
+        body = options[:body] || options['body']
+        body = form_encode_body(body) if body.is_a?(Hash)
+
         WebMock::RequestSignature.new(
           method.downcase.to_sym,
           uri.to_s,
-          :body => (options[:body] || options['body']),
+          :body => body,
           :headers => (options[:head] || options['head'])
         )
       end

--- a/lib/webmock/http_lib_adapters/em_http_request/em_http_request_1_x.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request/em_http_request_1_x.rb
@@ -163,6 +163,8 @@ if defined?(EventMachine::HttpClient)
 
         uri.query = encode_query(@req.uri, query).slice(/\?(.*)/, 1)
 
+        body = form_encode_body(body) if body.is_a?(Hash)
+
         WebMock::RequestSignature.new(
           method.downcase.to_sym,
           uri.to_s,

--- a/spec/em_http_request_spec.rb
+++ b/spec/em_http_request_spec.rb
@@ -126,6 +126,11 @@ unless RUBY_PLATFORM =~ /java/
       http_request(:get, "http://www.example.com/?x=3", :query => "a[]=b&a[]=c").body.should == "abc"
     end
 
+    it "should work when the body is passed as a Hash" do
+      stub_http_request(:post, "www.example.com").with(:body => {:a => "1", :b => "2"}).to_return(:body => "ok")
+      http_request(:post, "http://www.example.com", :body => {:a => "1", :b => "2"}).body.should == "ok"
+    end
+
     describe "mocking EM::HttpClient API" do
       before do
         stub_http_request(:get, "www.example.com/")


### PR DESCRIPTION
Here's the fix that simply changes the generated request signatures rather than altering the request pattern matcher.

I tested it against em-http-request 0.3.0 and 1.0.0.beta.4, which was green except for the em-synchrony tests, but it looks like a bug in that library (em-synchrony seems to assume em-http-request < 1.0.0).

Thanks.

Dave
