### PR TITLE
Fix failure with HTTPClient.get_content

### DIFF
--- a/lib/webmock/http_lib_adapters/httpclient_adapter.rb
+++ b/lib/webmock/http_lib_adapters/httpclient_adapter.rb
@@ -103,7 +103,7 @@ if defined?(::HTTPClient)
       raise HTTPClient::TimeoutError if webmock_response.should_timeout
       webmock_response.raise_error_if_any
 
-      block.call(nil, body) if block
+      block.call(response, body) if block
 
       response
     end

--- a/spec/acceptance/httpclient/httpclient_spec.rb
+++ b/spec/acceptance/httpclient/httpclient_spec.rb
@@ -37,6 +37,15 @@ describe "HTTPClient" do
     include_examples "with WebMock"
   end
 
+  it "should work with get_content" do
+    stub_request(:get, 'www.example.com').to_return(:status => 200, :body => 'test', :headers => {})
+    str = ''
+    HTTPClient.get_content('www.example.com') do |content|
+      str << content
+    end
+    str.should == 'test'
+  end
+
   context "Filters" do
     class Filter
       def filter_request(request)


### PR DESCRIPTION
HTTPClient calls r.status in the block in #follow_redirect but WebMock was passing in nil instead of the actual response leading to failure. Passing in response causes the failing test I added to pass and (actually, really this time) works in my app.
