### PR TITLE
The curb adapter doesn't call on_failure on 4xx response codes

### DIFF
--- a/lib/webmock/http_lib_adapters/curb_adapter.rb
+++ b/lib/webmock/http_lib_adapters/curb_adapter.rb
@@ -148,7 +148,7 @@ if defined?(Curl)
         case response_code
         when 200..299
           @on_success.call(self) if @on_success
-        when 500..599
+        when 400..599
           @on_failure.call(self, self.response_code) if @on_failure
         end
       end

--- a/spec/acceptance/curb/curb_spec.rb
+++ b/spec/acceptance/curb/curb_spec.rb
@@ -42,6 +42,19 @@ unless RUBY_PLATFORM =~ /java/
         test.should == body
       end
 
+      it "should call on_failure with 4xx response" do
+        response_code = 403
+        stub_request(:any, "example.com").
+          to_return(:status => [response_code, "None shall pass"])
+
+        test = nil
+        @curl.on_failure do |c, code|
+          test = code
+        end
+        @curl.http_get
+        test.should == response_code
+      end
+
       it "should call on_failure with 5xx response" do
         response_code = 599
         stub_request(:any, "example.com").


### PR DESCRIPTION
The real curb calls on_failure when response code is 4xx, so this commit
 matches the behavior in the webmock.
