### PR TITLE
This needs tests but can I get your opinion? Optionally autolaunch a visual diff tool for comparing registered stubs

### DIFF
--- a/lib/webmock/errors.rb
+++ b/lib/webmock/errors.rb
@@ -1,7 +1,8 @@
 module WebMock
-
   class NetConnectNotAllowedError < StandardError
     def initialize(request_signature)
+      RegisteredStubDiffer.new(request_signature.body) if ENV['show_visual_diffs_for_webmock']
+
       text = "Real HTTP connections are disabled. Unregistered request: #{request_signature}"
       text << "\n\n"
       text << stubbing_instructions(request_signature)
@@ -29,5 +30,4 @@ module WebMock
       text
     end
   end
-
 end

--- a/lib/webmock/register_stub_differ.rb
+++ b/lib/webmock/register_stub_differ.rb
@@ -1,0 +1,55 @@
+module WebMock
+  class RegisteredStubDiffer
+    def initialize body
+      if body
+        Dir.mkdir_p stub_directory
+
+        save_attempted_file body
+
+        registered = save_registered_stubs
+        registered.each { |r| diff r }
+
+        cleanup registered
+      end
+    end
+
+    private
+
+    def diff registered
+      `#{diff_tool} #{registered} #{attempted_file}`
+    end
+
+    def attempted_file
+      attempted = File.join stub_directory, "attempted_stub.txt"
+    end
+
+    def stub_directory
+      File.join %w(tmp webmock)
+    end
+
+    def cleanup files
+      File.delete attempted, *files
+    end
+
+    def save_attempted_file body
+      File.open(attempted, "w") { |f| f << body }
+    end
+
+    def save_registered_stubs
+      WebMock::StubRegistry.instance.request_stubs.map.
+        each_with_index do |stub, index|
+        file = "tmp/webmock/registered_stub_#{index}"
+
+        File.open file, "w" do |f|
+          f << stub.request_pattern.body_pattern
+        end
+
+        file
+        end
+    end
+
+    def diff_tool
+      ENV['diff_tool'] || "opendiff"
+    end
+  end
+end

--- a/spec/unit/registered_stub_differ_spec.rb
+++ b/spec/unit/registered_stub_differ_spec.rb
@@ -1,0 +1,4 @@
+require File.expand_path('spec/spec_helper')
+
+describe WebMock::RegisteredStubDiffer do
+end


### PR DESCRIPTION
I found myself debugging some XML for an external service and found it very difficult doing a spot-the-difference on a huge wall of text.

This will popup opendiff against all the registered stubs and the attempted request.
Tried out and working on my mac.
Apart from tests would you recommend anything else?
Perhaps a better way to configure the diff tool, and make it switchable?
Any other points?
