### PR TITLE
a_request usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,15 @@ This forces WebMock Net::HTTP adapter to always connect on `Net::HTTP.start`.
 
 ## Setting Expectations
 
+### Using Expectations
+  These expectations below are set After making request
+
+ 	# stub_request as usual
+
+    # make request
+
+ 	# expectation that matches the request made
+
 ### Setting expectations in Test::Unit
     require 'webmock/test_unit'
 
@@ -376,12 +385,6 @@ This forces WebMock Net::HTTP adapter to always connect on `Net::HTTP.start`.
     Net::HTTP.get('www.example.com', '/')    # ===> Success
 
     assert_requested :get, "http://www.example.com"    # ===> Success
-
-### Using Expectations
-  These expectations below are set After making request
- 	# stub_request as usual
-    # make request
- 	# expectation that matches the request made
 
 ### Setting expectations in RSpec on `WebMock` module
  This style is borrowed from [fakeweb-matcher](http://github.com/freelancing-god/fakeweb-matcher)


### PR DESCRIPTION
Hi there:

This explains in readme pattern to use the expectations in reference to after the actual request, still using stub before the actual request.

In RSpec, you could be having stuff .should_receive where you set expectations mostly before doing the real call(in this case request).

This is to help others not to be confused by the usage of these expectations.
I was a bit confused but the past tense used helped me to finally reach at the conclusion.

Thanks for the great gem,
Rohit Sachdeva..
