### PR TITLE
Support for native typhoeus timeouts

### DIFF
--- a/lib/webmock/http_lib_adapters/typhoeus_hydra_adapter.rb
+++ b/lib/webmock/http_lib_adapters/typhoeus_hydra_adapter.rb
@@ -85,7 +85,8 @@ if defined?(Typhoeus)
               :code         => 0,
               :status_message => "",
               :body         => "",
-              :headers_hash => {}
+              :headers_hash => {},
+              :curl_return_code => 28
             )
           else
             ::Typhoeus::Response.new(

--- a/spec/acceptance/typhoeus/typhoeus_hydra_spec.rb
+++ b/spec/acceptance/typhoeus/typhoeus_hydra_spec.rb
@@ -27,6 +27,16 @@ unless RUBY_PLATFORM =~ /java/
         end
       end
 
+      describe "timeouts" do
+        it "should support native typhoeus timeouts" do
+          stub_request(:any, "example.com").to_timeout
+
+          response = Typhoeus::Request.get("http://example.com")
+
+          response.should be_timed_out
+        end
+      end
+
       describe "callbacks" do
         before(:each) do
           @hydra = Typhoeus::Hydra.new


### PR DESCRIPTION
With this patch the typhoeus way of checking timeouts works. The way they check timeouts is with the curl_return_code

https://github.com/dbalatero/typhoeus/blob/master/lib/typhoeus/response.rb#L100
