### PR TITLE
Fix TeamCity incompatibility

### DIFF
--- a/lib/webmock/rspec.rb
+++ b/lib/webmock/rspec.rb
@@ -3,7 +3,7 @@ require 'webmock'
 # RSpec 1.x and 2.x compatibility
 if defined?(RSpec) && defined?(RSpec::Expectations)
   RSPEC_NAMESPACE = RSPEC_CONFIGURER = RSpec
-elsif defined?(Spec)
+elsif defined?(Spec) && defined?(Spec.configure)
   RSPEC_NAMESPACE = Spec
   RSPEC_CONFIGURER = Spec::Runner
 else


### PR DESCRIPTION
Rspecs using webmock fail when run on TeamCity servers. This should probably be fixed on the TeamCity side, but this patch seems reasonable and works. See http://www.coding4streetcred.com/blog/post/Issue-RubyMine-31-Webmock-162-and-“Specconfigure”-curse.aspx for a more detailed explanation of what's going on.
