### PR TITLE
net_http.rb: StubSocket needs read_timeout for aws-sdk

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -184,6 +184,8 @@ end
 
 class StubSocket #:nodoc:
 
+  attr_accessor :read_timeout
+
   def initialize(*args)
   end
 


### PR DESCRIPTION
Sorry that I failed to find out how to reproduce this in a simple
way without using aws-sdk, ending up with Net::WebMockNetBufferedIO
instead of StubSocket. aws-sdk is maintaining a connection pool which
is too complicated and I am tired of digging into it. Time to sleep...

Thanks!
