### PR TITLE
Fix #to_rack to handle non-array response bodies.

### DIFF
--- a/lib/webmock/rack_response.rb
+++ b/lib/webmock/rack_response.rb
@@ -10,10 +10,16 @@ module WebMock
       status, headers, response = @app.call(env)
 
       Response.new(
-        :body => response.join,
+        :body => body_from_rack_response(response),
         :headers => headers,
         :status => status
       )
+    end
+
+    def body_from_rack_response(response)
+      body = ""
+      response.each { |line| body << line }
+      return body
     end
 
     def build_rack_env(request)

--- a/spec/support/my_rack_app.rb
+++ b/spec/support/my_rack_app.rb
@@ -1,6 +1,17 @@
 require 'rack'
 
 class MyRackApp
+  class NonArrayResponse
+    # The rack response body need not implement #join, 
+    # but it must implement #each.  It need not be an Array.
+    # ActionDispatch::Response, for example, exercises that fact.
+    # See: http://rack.rubyforge.org/doc/SPEC.html
+
+    def each(*args, &blk)
+      ["This is not in an array!"].each(*args, &blk)
+    end
+  end
+
   def self.call(env)
     case env.values_at('REQUEST_METHOD', 'PATH_INFO')
       when ['GET', '/']
@@ -8,6 +19,8 @@ class MyRackApp
       when ['GET', '/greet']
         name = env['QUERY_STRING'][/name=([^&]*)/, 1] || "World"
         [200, {}, ["Hello, #{name}"]]
+      when ['GET', '/non_array_response']
+        [200, {}, NonArrayResponse.new]
       when ['POST', '/greet']
         name = env["rack.input"].read[/name=([^&]*)/, 1] || "World"
         [200, {}, ["Good to meet you, #{name}!"]]

--- a/spec/unit/rack_response_spec.rb
+++ b/spec/unit/rack_response_spec.rb
@@ -13,6 +13,14 @@ describe WebMock::RackResponse do
     response.body.should include('This is my root!')
   end
 
+  it "should behave correctly when the rack response is not a simple array of strings" do
+    request = WebMock::RequestSignature.new(:get, 'www.example.com/non_array_response')
+    response = @rack_response.evaluate(request)
+
+    response.status.first.should == 200
+    response.body.should include('This is not in an array!')
+  end
+
   it "should send along params" do
     request = WebMock::RequestSignature.new(:get, 'www.example.com/greet?name=Johnny')
 


### PR DESCRIPTION
When using `#to_rack` with a Rails endpoint, such as:

``` ruby
stub_request(:any, %r{api.example.com/.*}).to_rack(Rails.application)
```

...you receive the following error:

```
NoMethodError: undefined method `join' for #<ActionDispatch::Response:0x007ffd06e6f540>
```

Turns out `ActionDispatch::Response` is in the right. A Rack response body
is only required to implement `#each`, not `#join`.

This patch fixes `#to_rack` to build the body using the `#each` method.
