### PR TITLE
Fixed a Rack::Lock bug around failing to close the response body

### DIFF
--- a/lib/webmock/rack_response.rb
+++ b/lib/webmock/rack_response.rb
@@ -19,6 +19,7 @@ module WebMock
     def body_from_rack_response(response)
       body = ""
       response.each { |line| body << line }
+      response.close if response.respond_to?(:close)
       return body
     end
 

--- a/spec/support/my_rack_app.rb
+++ b/spec/support/my_rack_app.rb
@@ -21,11 +21,22 @@ class MyRackApp
         [200, {}, ["Hello, #{name}"]]
       when ['GET', '/non_array_response']
         [200, {}, NonArrayResponse.new]
+      when ['GET', '/locked']
+        [200, {}, ["Single threaded response."]]
       when ['POST', '/greet']
         name = env["rack.input"].read[/name=([^&]*)/, 1] || "World"
         [200, {}, ["Good to meet you, #{name}!"]]
       else
         [404, {}, ['']]
     end
+  end
+end
+
+class MyLockedRackApp
+  MUTEX = Mutex.new
+
+  def self.call(env)
+    lock = Rack::Lock.new(MyRackApp, MUTEX)
+    lock.call(env)
   end
 end

--- a/spec/unit/rack_response_spec.rb
+++ b/spec/unit/rack_response_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe WebMock::RackResponse do
   before :each do
     @rack_response = WebMock::RackResponse.new(MyRackApp)
+    @locked_rack_response = WebMock::RackResponse.new(MyLockedRackApp)
   end
 
   it "should hook up to a rack appliance" do
@@ -19,6 +20,15 @@ describe WebMock::RackResponse do
 
     response.status.first.should == 200
     response.body.should include('This is not in an array!')
+  end
+
+  it "should shouldn't blow up when hitting a locked resource twice" do
+    request   = WebMock::RequestSignature.new(:get, 'www.example.com/locked')
+    response  = @locked_rack_response.evaluate(request)
+    response2 = @locked_rack_response.evaluate(request)
+
+    response2.body.should include('Single threaded response.')
+    response2.status.first.should == 200
   end
 
   it "should send along params" do


### PR DESCRIPTION
Looks like my last patch (https://github.com/bblimke/webmock/pull/150) introduced a bug where the Rack::Lock mutex wasn't being released.  We believe this is fixed in Rack 1.4.1, but as Rails 3.1 is still on Rack 1.3.x, we figured we should handle it here as well.
