### PR TITLE
em_http_request_1_x: use bytesize of message instead of its length for content-length header

### DIFF
--- a/lib/webmock/http_lib_adapters/em_http_request/em_http_request_1_x.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request/em_http_request_1_x.rb
@@ -189,7 +189,7 @@ if defined?(EventMachine::HttpClient)
         response_string = []
         response_string << "HTTP/1.1 #{status[0]} #{status[1]}"
 
-        headers["Content-Length"] = body.length unless headers["Content-Length"]
+        headers["Content-Length"] = body.bytesize unless headers["Content-Length"]
         headers.each do |header, value|
           value = value.join(", ") if value.is_a?(Array)
 

--- a/spec/acceptance/em_http_request/em_http_request_spec.rb
+++ b/spec/acceptance/em_http_request/em_http_request_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 require 'acceptance/webmock_shared'
 require 'ostruct'
@@ -131,6 +132,12 @@ unless RUBY_PLATFORM =~ /java/
     it "should work when the body is passed as a Hash" do
       stub_request(:post, "www.example.com").with(:body => {:a => "1", :b => "2"}).to_return(:body => "ok")
       http_request(:post, "http://www.example.com", :body => {:a => "1", :b => "2"}).body.should == "ok"
+    end
+
+    it "should work with UTF-8 strings" do
+      body = "Привет, Мир!"
+      stub_request(:post, "www.example.com").to_return(:body => body)
+      http_request(:post, "http://www.example.com").body.bytesize.should == body.bytesize
     end
 
     describe "mocking EM::HttpClient API" do


### PR DESCRIPTION
Patch is sort of trivial.

In rubies 1.8.x this will have no effect whatsoever
In rubies 1.9.x this fixes problem of receiver's message getting truncated
   (since some utf-8 characters are more than 1 byte long)

Spec attached. 

NB: I haven't checked 0_x em adapter or any other adapters, but it's possible that this problem exists somewhere else too.
