### PR TITLE
Allow WebMock.disable_net_connect! to accept a RegExp as :allow Parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ You can also use WebMock outside a test framework:
 
     Net::HTTP.get('localhost:9887', '/')      # ===> Allowed. Perhaps to Selenium?
 
-### External requests can be disabled while allowing any hostname or port
+### External requests can be disabled while allowing any hostname or port or parts thereof
 
     WebMock.disable_net_connect!(:allow => "www.example.org:8080")
 
@@ -328,6 +328,10 @@ You can also use WebMock outside a test framework:
     RestClient.get('www.example.org', '/')     # ===> Failure.
 
     RestClient.get('www.example.org:8080', '/')     # ===> Allowed
+
+    WebMock.disable_net_connect!(:allow => /ample.org/)
+
+    RestClient.get('www.example.org', '/')   # ===> Allowed
 
 ## Connecting on Net::HTTP.start
 

--- a/lib/webmock/webmock.rb
+++ b/lib/webmock/webmock.rb
@@ -59,7 +59,10 @@ module WebMock
     end
     Config.instance.allow_net_connect ||
       (Config.instance.allow_localhost && WebMock::Util::URI.is_uri_localhost?(uri)) ||
-      Config.instance.allow && (Config.instance.allow.include?(uri.host) || Config.instance.allow.include?("#{uri.host}:#{uri.port}"))
+      Config.instance.allow && (
+        (Config.instance.allow.kind_of?(Regexp) && uri.to_s =~ Config.instance.allow) ||
+        (Config.instance.allow.respond_to?(:include?) &&
+         Config.instance.allow.include?(uri.host) || Config.instance.allow.include?("#{uri.host}:#{uri.port}")))
   end
 
   def self.reset!

--- a/spec/acceptance/net_http/net_http_spec.rb
+++ b/spec/acceptance/net_http/net_http_spec.rb
@@ -184,7 +184,14 @@ describe "Net:HTTP" do
           cert.should be_a(OpenSSL::X509::Certificate)
         }
       end
+
+      it "should connect to the server if the URI matches an regex", :net_connect => true do
+        WebMock.disable_net_connect!(:allow => /google.com/)
+        response = Net::HTTP.get('www.google.com','/')
+      end
+
     end
+
   end
 
   describe "when net_http_connect_on_start is true" do


### PR DESCRIPTION
Hi,

this implements the handling of a Regex as `:allow` option 
for `WebMock.disable_net_connect!`
## Background

When running tests on our CI system we connect to multiple changing hostnames like `n1.host.somedomain.com` and `n2.host.somedomain.com`.

Specifiying all hosts would be too much and result in update dependencies when we add more hostnames.

This allows for a blacklisting approach without much update work.

Greetings,
thenoseman
