### PR TITLE
Ensure em-synchrony HTTPMethods inclusion.

### DIFF
--- a/lib/webmock/http_lib_adapters/em_http_request/em_http_request_1_x.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request/em_http_request_1_x.rb
@@ -27,7 +27,7 @@ if defined?(EventMachine::HttpClient)
 
   module EventMachine
 
-    if defined?(Synchrony)
+    if defined?(Synchrony) && HTTPMethods.instance_methods.include?(:aget)
       # have to make the callbacks fire on the next tick in order
       # to avoid the dreaded "double resume" exception
       module HTTPMethods


### PR DESCRIPTION
In a project I use em-synchrony without em-synchrony/em-http inclusion. Since Webmock considers  EM::Synchrony's HTTPMethods included as soon as EM::Synchrony constant is present, but no methods really overridden that leads to a `can't yield from root fiber` exception.

Overriding EM::HTTPMethods by Webmock is not really needed when they were not overridden by em-synchrony/em-http. The only way to figure it out I can imagine is to inspect existing HTTPMethods for inclusion of methods defined by em-synchrony/em-http.

I'm really sorry for the lack of test, but I don't see a way to make properly.
