### PR TITLE
Prevent Webmock hash_including from overriding RSpec version 1 hash_including method.

### DIFF
--- a/lib/webmock/api.rb
+++ b/lib/webmock/api.rb
@@ -35,6 +35,8 @@ module WebMock
     def hash_including(expected)
       if defined?(::RSpec::Mocks::ArgumentMatchers::HashIncludingMatcher)
         RSpec::Mocks::ArgumentMatchers::HashIncludingMatcher.new(expected)
+      elsif defined?(::Spec::Mocks::ArgumentMatchers::HashIncludingMatcher)
+        Spec::Mocks::ArgumentMatchers::HashIncludingMatcher.new(expected)
       else
         WebMock::Matchers::HashIncludingMatcher.new(expected)
       end


### PR DESCRIPTION
After setting up webmock on a project using rspec version one, every test in the suite using hash_including began to fail. The fix was pretty simple. If it looks okay, I'll add some tests and we can get this merged in.
