### PR TITLE
Fix compatibility with edge em-http-request

### DIFF
--- a/lib/webmock/http_lib_adapters/em_http_request/em_http_request_1_x.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request/em_http_request_1_x.rb
@@ -154,7 +154,7 @@ if defined?(EventMachine::HttpClient)
 
         method = @req.method
         uri = @req.uri
-        auth = @req.proxy[:authorization]
+        auth = @req.proxy[:authorization] if @req.proxy
         query = @req.query
 
         if auth


### PR DESCRIPTION
As of igrigorik/em-http-request@add8ad4f6ee85fe55659272ade91a93ba805e2d9 we can no longer assume that @req.proxy is not nil.

To verify this, add `gem "em-http-request", :git => 'https://github.com/igrigorik/em-http-request.git'` to `Gemfile` and run the specs in `spec/acceptance/em_http_request/em_http_request_spec.rb`.
