### PR TITLE
Pass through SERVER_PORT when stubbing to rack

### DIFF
--- a/lib/webmock/rack_response.rb
+++ b/lib/webmock/rack_response.rb
@@ -35,7 +35,8 @@ module WebMock
         'CONTENT_LENGTH' => body.size,
         'PATH_INFO'      => uri.path,
         'QUERY_STRING'   => uri.query || '',
-        'SERVER_NAME'    => uri.host
+        'SERVER_NAME'    => uri.host,
+        'SERVER_PORT'    => uri.port
       }
 
       env['HTTP_AUTHORIZATION'] = 'Basic ' + [uri.userinfo].pack('m').delete("\r\n") if uri.userinfo

--- a/spec/acceptance/shared/returning_declared_responses.rb
+++ b/spec/acceptance/shared/returning_declared_responses.rb
@@ -238,12 +238,14 @@ shared_context "declared responses" do |*adapter_info|
     end
 
     describe "when response is declared as an Rack app" do
-      before(:each) do
+      it "should return response returned by the rack app" do
         stub_request(:any, "http://www.example.com/greet").to_rack(MyRackApp)
+        http_request(:post, 'http://www.example.com/greet', :body => 'name=Jimmy').body.should == 'Good to meet you, Jimmy!'
       end
 
-      it "should return response returned by the rack app" do
-        http_request(:post, 'http://www.example.com/greet', :body => 'name=Jimmy').body.should == 'Good to meet you, Jimmy!'
+      it "should pass along the port number to the rack app" do
+        stub_request(:get, "http://www.example.com/compute").to_rack(MyRackApp)
+        http_request(:get, "http://www.example.com/compute").status.should == "200"
       end
     end
 

--- a/spec/support/my_rack_app.rb
+++ b/spec/support/my_rack_app.rb
@@ -26,6 +26,12 @@ class MyRackApp
       when ['POST', '/greet']
         name = env["rack.input"].read[/name=([^&]*)/, 1] || "World"
         [200, {}, ["Good to meet you, #{name}!"]]
+      when ['GET', '/compute']
+        if env['SERVER_PORT'] == 80
+          [200, {}, [""]]
+        else
+          [401, {}, [""]]
+        end
       else
         [404, {}, ['']]
     end


### PR DESCRIPTION
If the server verifies a signature that includes 
the port, the webmock stub would otherwise make 
the request invalid.

For example, OAuth 2 computes a signature that includes the server port.
