### PR TITLE
Net:HTTP adapter tries to close connection two times and throws error

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -87,10 +87,9 @@ module WebMock
             end
             response = if (started? && !WebMock::Config.instance.net_http_connect_on_start) || !started?
               @started = false #otherwise start_with_connect wouldn't execute and connect
-              start_with_connect {
-                response = request_without_webmock(request, nil)
-                after_request.call(response)
-              }
+              start_with_connect
+              response = request_without_webmock(request, nil)
+              after_request.call(response)
             else
               response = request_without_webmock(request, nil)
               after_request.call(response)


### PR DESCRIPTION
If the Net:HTTP adapter sends a request (opening and closing a HTTP session) and the server's response includes a "Connection: close" header then Net:HTTP will try to close the connection again, resulting in a "Net::HTTP::Persistent::Error: too many connection resets (due to HTTP session not yet started)".
