### PR TITLE
Clone the URI before mutating it.

### DIFF
--- a/lib/webmock/http_lib_adapters/em_http_request/em_http_request_1_x.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request/em_http_request_1_x.rb
@@ -153,7 +153,7 @@ if defined?(EventMachine::HttpClient)
         end
 
         method = @req.method
-        uri = @req.uri
+        uri = @req.uri.clone
         auth = @req.proxy[:authorization] if @req.proxy
         query = @req.query
 


### PR DESCRIPTION
The #build_request_signature method was mutating the URI if there were
any @req.query options. This means that if the request does actually get
sent, em-http-request appends the query to the URI a second time, and
the parameters are repeated.

For example:

EventMachine::HttpRequest.new('http://example.com/').get(:query => { :a => '1' })

would result in the follow URI being used for a live request:

http://example.com/?a=1&a=1
