### PR TITLE
Add a failing spec demonstrating a bug in the em-http-request adapter.

### DIFF
--- a/lib/webmock/http_lib_adapters/em_http_request/em_http_request_1_x.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request/em_http_request_1_x.rb
@@ -108,14 +108,16 @@ if defined?(EventMachine::HttpClient)
         end
       end
 
-      def set_deferred_status(status, *args)
-        if status == :succeeded && !stubbed_webmock_response && WebMock::CallbackRegistry.any_callbacks?
+      def unbind(reason = nil)
+        if !stubbed_webmock_response && WebMock::CallbackRegistry.any_callbacks?
           webmock_response = build_webmock_response
           WebMock::CallbackRegistry.invoke_callbacks(
             {:lib => :em_http_request, :real_request => true},
             request_signature,
             webmock_response)
         end
+        @request_signature = nil
+        remove_instance_variable(:@stubbed_webmock_response)
 
         super
       end

--- a/spec/acceptance/em_http_request/em_http_request_spec.rb
+++ b/spec/acceptance/em_http_request/em_http_request_spec.rb
@@ -36,7 +36,7 @@ unless RUBY_PLATFORM =~ /java/
 
       it 'invokes the after_request hook with both requests' do
         urls = []
-        WebMock.after_request { |r| urls << r.uri.to_s }
+        WebMock.after_request { |req, res| urls << req.uri.to_s }
 
         make_request
 


### PR DESCRIPTION
When a request is made to a URL that returns a 3xx response and the
:redirects option is set, the globally_stub_request/after_request
hooks are not paired properly.  Both hooks should receive the original
request and the redirect-following request.

This spec should probably be re-written to use the local webmock
server, but I couldn't figure out how to get it to conditionally
send a redirect response since it writes directly to the socket
and doesn't (as far as I can tell) have the request info available
in that scope...so there's not easy way to have it send a different
response for different requests :(.

See myronmarston/vcr#171 for the original VCR issue that caused
me to investigate this bug.

@bblimke -- let me know if I can help with this in anyway.  I'm pretty useless when it comes to em-http issues since I've never used it but I'll see what I can do.  Also, there's some other weirdness here...the spec for the `after_request` hook fails in different ways, different times it is run...sometimes the `after_request` hook is invoked twice and sometimes it's invoked only once.  Either way, it never gets invoked with the https redirect URL.
