### PR TITLE
Fix Net::HTTP adapter so that it returns `nil` for an empty body response.

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -128,7 +128,10 @@ module WebMock
 
         def build_net_http_response(webmock_response, &block)
           response = Net::HTTPResponse.send(:response_class, webmock_response.status[0].to_s).new("1.0", webmock_response.status[0].to_s, webmock_response.status[1])
-          response.instance_variable_set(:@body, webmock_response.body)
+          body = webmock_response.body
+          body = nil if body.to_s == ''
+
+          response.instance_variable_set(:@body, body)
           webmock_response.headers.to_a.each do |name, values|
             values = [values] unless values.is_a?(Array)
             values.each do |value|

--- a/spec/acceptance/shared/complex_cross_concern_behaviors.rb
+++ b/spec/acceptance/shared/complex_cross_concern_behaviors.rb
@@ -17,5 +17,18 @@ shared_context "complex cross-concern behaviors" do |*adapter_info|
     played_back_response.headers.keys.should include('Set-Cookie')
     played_back_response.should == real_response
   end
+
+  let(:no_content_url) { 'http://httpstat.us/204' }
+  [nil, ''].each do |stub_val|
+    it "returns the same value (nil or "") for a request stubbed as #{stub_val.inspect} that a real empty response has" do
+      WebMock.allow_net_connect!
+
+      real_response = http_request(:get, no_content_url)
+      stub_request(:get, no_content_url).to_return(:status => 204, :body => stub_val)
+      stubbed_response = http_request(:get, no_content_url)
+
+      stubbed_response.body.should eq(real_response.body)
+    end
+  end
 end
 


### PR DESCRIPTION
This mirrors the real behavior of Net::HTTP and is the source of myronmarston/vcr#173.

A couple things to note:
- Rather than hitting an external URL (httpstat.us/204), this should probably
  hit the local webmock server; however, I can't figure out how to make the
  webmock server return a different response for different requests since it's
  writing directly to the socket w/o any request context available. Maybe it
  should be refactored to use rack or sinatra?
- I have no idea why, but Curb is returning a 400 Bad Request response for
  the request. Weird. Not sure why or how to fix it.
