### PR TITLE
Fixing travis-ci image to report master's status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-WebMock [![Build Status](https://secure.travis-ci.org/bblimke/webmock.png)](http://travis-ci.org/bblimke/webmock) [![Dependency Status](https://gemnasium.com/bblimke/webmock.png)](http://gemnasium.com/bblimke/webmock)
+WebMock [![Build Status](https://secure.travis-ci.org/bblimke/webmock.png?branch=master)](http://travis-ci.org/bblimke/webmock) [![Dependency Status](https://gemnasium.com/bblimke/webmock.png)](http://gemnasium.com/bblimke/webmock)
 =======
 
 Library for stubbing and setting expectations on HTTP requests in Ruby.


### PR DESCRIPTION
I was originally turned off of webmock when I saw that the build was failing on travis and the last commit was 2 months ago.  This pull request scopes the travis status image to the master branch.
