### PR TITLE
Clear cached webmock response in HTTPClient instance.

### DIFF
--- a/lib/webmock/http_lib_adapters/httpclient_adapter.rb
+++ b/lib/webmock/http_lib_adapters/httpclient_adapter.rb
@@ -53,6 +53,9 @@ if defined?(::HTTPClient)
           {:lib => :httpclient}, request_signature, webmock_response)
         res
       elsif WebMock.net_connect_allowed?(request_signature.uri)
+        # in case there is a nil entry in the hash...
+        webmock_responses.delete(request_signature)
+
         res = if stream
           do_get_stream_without_webmock(req, proxy, conn, &block)
         else

--- a/spec/acceptance/httpclient/httpclient_spec_helper.rb
+++ b/spec/acceptance/httpclient/httpclient_spec_helper.rb
@@ -5,7 +5,7 @@ module HTTPClientSpecHelper
 
   def http_request(method, uri, options = {}, &block)
     uri = Addressable::URI.heuristic_parse(uri)
-    c = HTTPClient.new
+    c = options.fetch(:client) { HTTPClient.new }
     c.ssl_config.verify_mode = OpenSSL::SSL::VERIFY_NONE
     c.set_basic_auth(nil, uri.user, uri.password) if uri.user
     params = [method, "#{uri.omit(:userinfo, :query).normalize.to_s}",


### PR DESCRIPTION
When the a request was not stubbed, the `nil` value of the webmock response was
being cached in the `webmock_responses` hash. Then, when a second request was 
made with the same HTTPClient instance and an identical signature, it was not 
checking for a stub again, even though there may have been one for the second request (e.g. when using a global stub hook or if another stub is registered between the 1st and 2nd requests).

Fixes myronmarston/vcr#190.
