### PR TITLE
Prefer super to alias method chain.

### DIFF
--- a/lib/webmock/http_lib_adapters/curb_adapter.rb
+++ b/lib/webmock/http_lib_adapters/curb_adapter.rb
@@ -170,117 +170,83 @@ if defined?(Curl)
       ### Mocks of Curl::Easy methods below here.
       ###
 
-      def http_with_webmock(method)
+      def http(method)
         @webmock_method = method
-          http_without_webmock(method)
+        super
       end
-      alias_method :http_without_webmock, :http
-      alias_method :http, :http_with_webmock
 
       %w[ get head delete ].each do |verb|
-        define_method "http_#{verb}_with_webmock" do
+        define_method "http_#{verb}" do
           @webmock_method = verb
-          send( "http_#{verb}_without_webmock" )
+          super()
         end
-
-        alias_method "http_#{verb}_without_webmock", "http_#{verb}"
-        alias_method "http_#{verb}", "http_#{verb}_with_webmock"
       end
 
-      def http_put_with_webmock data = nil
+      def http_put data = nil
         @webmock_method = :put
         @put_data = data if data
-        http_put_without_webmock(data)
+        super
       end
-      alias_method :http_put_without_webmock, :http_put
-      alias_method :http_put, :http_put_with_webmock
 
-      def http_post_with_webmock *data
+      def http_post *data
         @webmock_method = :post
         @post_body = data.join('&') if data && !data.empty?
-        http_post_without_webmock(*data)
+        super
       end
-      alias_method :http_post_without_webmock, :http_post
-      alias_method :http_post, :http_post_with_webmock
 
-
-      def perform_with_webmock
+      def perform
         @webmock_method ||= :get
-        curb_or_webmock do
-          perform_without_webmock
-        end
+        curb_or_webmock { super }
       end
-      alias :perform_without_webmock :perform
-      alias :perform :perform_with_webmock
 
-      def put_data_with_webmock= data
+      def put_data= data
         @webmock_method = :put
         @put_data = data
-        self.put_data_without_webmock = data
+        super
       end
-      alias_method :put_data_without_webmock=, :put_data=
-      alias_method :put_data=, :put_data_with_webmock=
 
-      def post_body_with_webmock= data
+      def post_body= data
         @webmock_method = :post
-        self.post_body_without_webmock = data
+        super
       end
-      alias_method :post_body_without_webmock=, :post_body=
-      alias_method :post_body=, :post_body_with_webmock=
 
-      def delete_with_webmock= value
+      def delete= value
         @webmock_method = :delete if value
-        self.delete_without_webmock = value
+        super
       end
-      alias_method :delete_without_webmock=, :delete=
-      alias_method :delete=, :delete_with_webmock=
 
-      def head_with_webmock= value
+      def head= value
         @webmock_method = :head if value
-        self.head_without_webmock = value
+        super
       end
-      alias_method :head_without_webmock=, :head=
-      alias_method :head=, :head_with_webmock=
 
-      def body_str_with_webmock
-        @body_str || body_str_without_webmock
+      def body_str
+        @body_str || super
       end
-      alias :body_str_without_webmock :body_str
-      alias :body_str :body_str_with_webmock
 
-      def response_code_with_webmock
-        @response_code || response_code_without_webmock
+      def response_code
+        @response_code || super
       end
-      alias :response_code_without_webmock :response_code
-      alias :response_code :response_code_with_webmock
 
-      def header_str_with_webmock
-        @header_str || header_str_without_webmock
+      def header_str
+        @header_str || super
       end
-      alias :header_str_without_webmock :header_str
-      alias :header_str :header_str_with_webmock
 
-      def last_effective_url_with_webmock
-        @last_effective_url || last_effective_url_without_webmock
+      def last_effective_url
+        @last_effective_url || super
       end
-      alias :last_effective_url_without_webmock :last_effective_url
-      alias :last_effective_url :last_effective_url_with_webmock
 
-      def content_type_with_webmock
-        @content_type || content_type_without_webmock
+      def content_type
+        @content_type || super
       end
-      alias :content_type_without_webmock :content_type
-      alias :content_type :content_type_with_webmock
 
       %w[ success failure header body complete progress ].each do |callback|
         class_eval <<-METHOD, __FILE__, __LINE__
-          def on_#{callback}_with_webmock &block
+          def on_#{callback} &block
             @on_#{callback} = block
-            on_#{callback}_without_webmock &block
+            super
           end
         METHOD
-        alias_method "on_#{callback}_without_webmock", "on_#{callback}"
-        alias_method "on_#{callback}", "on_#{callback}_with_webmock"
       end
     end
   end

--- a/lib/webmock/http_lib_adapters/em_http_request/em_http_request_0_x.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request/em_http_request_0_x.rb
@@ -47,7 +47,7 @@ if defined?(EventMachine::HttpRequest)
         end
       end
 
-      def send_request_with_webmock(&block)
+      def send_request(&block)
         request_signature = build_request_signature
 
         WebMock::RequestRegistry.instance.requested_signatures.put(request_signature)
@@ -61,7 +61,7 @@ if defined?(EventMachine::HttpRequest)
             webmock_response.should_timeout ? "WebMock timeout error" : nil)
           client
         elsif WebMock.net_connect_allowed?(request_signature.uri)
-          http = send_request_without_webmock(&block)
+          http = super
           http.callback {
             if WebMock::CallbackRegistry.any_callbacks?
               webmock_response = build_webmock_response(http)
@@ -75,10 +75,6 @@ if defined?(EventMachine::HttpRequest)
           raise WebMock::NetConnectNotAllowedError.new(request_signature)
         end
       end
-
-      alias_method :send_request_without_webmock, :send_request
-      alias_method :send_request, :send_request_with_webmock
-
 
       private
 

--- a/lib/webmock/http_lib_adapters/em_http_request/em_http_request_1_x.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request/em_http_request_1_x.rb
@@ -48,7 +48,7 @@ if defined?(EventMachine::HttpClient)
     end
 
     class WebMockHttpConnection < HttpConnection
-      def webmock_activate_connection(client)
+      def activate_connection(client)
         request_signature = client.request_signature
 
         if client.stubbed_webmock_response
@@ -65,13 +65,11 @@ if defined?(EventMachine::HttpClient)
           finalize_request(client)
           @conn.set_deferred_status :succeeded
         elsif WebMock.net_connect_allowed?(request_signature.uri)
-          real_activate_connection(client)
+          super
         else
           raise WebMock::NetConnectNotAllowedError.new(request_signature)
         end
       end
-      alias_method :real_activate_connection, :activate_connection
-      alias_method :activate_connection, :webmock_activate_connection
     end
 
     class WebMockHttpClient < EventMachine::HttpClient
@@ -92,7 +90,7 @@ if defined?(EventMachine::HttpClient)
         end
       end
 
-      def send_request_with_webmock(head, body)
+      def send_request(head, body)
         WebMock::RequestRegistry.instance.requested_signatures.put(request_signature)
 
         if stubbed_webmock_response
@@ -104,14 +102,11 @@ if defined?(EventMachine::HttpClient)
           }
           self
         elsif WebMock.net_connect_allowed?(request_signature.uri)
-          send_request_without_webmock(head, body)
+          super
         else
           raise WebMock::NetConnectNotAllowedError.new(request_signature)
         end
       end
-
-      alias_method :send_request_without_webmock, :send_request
-      alias_method :send_request, :send_request_with_webmock
 
       def set_deferred_status(status, *args)
         if status == :succeeded && !stubbed_webmock_response && WebMock::CallbackRegistry.any_callbacks?

--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -32,11 +32,9 @@ module WebMock
 
       @webMockNetHTTP = Class.new(Net::HTTP) do
         class << self
-          def socket_type_with_webmock
+          def socket_type
             StubSocket
           end
-          alias_method :socket_type_without_webmock, :socket_type
-          alias_method :socket_type, :socket_type_with_webmock
 
           if Module.method(:const_defined?).arity == 1
             def const_defined?(name)
@@ -63,7 +61,7 @@ module WebMock
           end
         end
 
-        def request_with_webmock(request, body = nil, &block)
+        def request(request, body = nil, &block)
           request_signature = WebMock::NetHTTPUtility.request_signature_from_request(self, request, body)
 
           WebMock::RequestRegistry.instance.requested_signatures.put(request_signature)
@@ -88,19 +86,17 @@ module WebMock
             response = if (started? && !WebMock::Config.instance.net_http_connect_on_start) || !started?
               @started = false #otherwise start_with_connect wouldn't execute and connect
               start_with_connect {
-                response = request_without_webmock(request, nil)
+                response = super(request, nil, &nil)
                 after_request.call(response)
               }
             else
-              response = request_without_webmock(request, nil)
+              response = super(request, nil, &nil)
               after_request.call(response)
             end
           else
             raise WebMock::NetConnectNotAllowedError.new(request_signature)
           end
         end
-        alias_method :request_without_webmock, :request
-        alias_method :request, :request_with_webmock
 
         def start_without_connect
           raise IOError, 'HTTP session already opened' if @started
@@ -116,15 +112,15 @@ module WebMock
           self
         end
 
-        def start_with_conditional_connect(&block)
+        alias_method :start_with_connect, :start
+
+        def start(&block)
           if WebMock::Config.instance.net_http_connect_on_start
-            start_with_connect(&block)
+            super(&block)
           else
             start_without_connect(&block)
           end
         end
-        alias_method :start_with_connect, :start
-        alias_method :start, :start_with_conditional_connect
 
         def build_net_http_response(webmock_response, &block)
           response = Net::HTTPResponse.send(:response_class, webmock_response.status[0].to_s).new("1.0", webmock_response.status[0].to_s, webmock_response.status[1])
@@ -204,7 +200,7 @@ end
 module Net  #:nodoc: all
 
   class WebMockNetBufferedIO < BufferedIO
-    def initialize_with_webmock(io, debug_output = nil)
+    def initialize(io, debug_output = nil)
       @read_timeout = 60
       @rbuf = ''
       @debug_output = debug_output
@@ -217,8 +213,6 @@ module Net  #:nodoc: all
       end
       raise "Unable to create local socket" unless @io
     end
-    alias_method :initialize_without_webmock, :initialize
-    alias_method :initialize, :initialize_with_webmock
   end
 
 end

--- a/lib/webmock/http_lib_adapters/patron_adapter.rb
+++ b/lib/webmock/http_lib_adapters/patron_adapter.rb
@@ -13,7 +13,7 @@ if defined?(::Patron)
         OriginalPatronSession = ::Patron::Session unless const_defined?(:OriginalPatronSession)
 
         class WebMockPatronSession < ::Patron::Session
-          def handle_request_with_webmock(req)
+          def handle_request(req)
             request_signature =
               WebMock::HttpLibAdapters::PatronAdapter.build_request_signature(req)
 
@@ -28,7 +28,7 @@ if defined?(::Patron)
                 {:lib => :patron}, request_signature, webmock_response)
               res
             elsif WebMock.net_connect_allowed?(request_signature.uri)
-              res = handle_request_without_webmock(req)
+              res = super
               if WebMock::CallbackRegistry.any_callbacks?
                 webmock_response = WebMock::HttpLibAdapters::PatronAdapter.
                   build_webmock_response(res)
@@ -41,9 +41,6 @@ if defined?(::Patron)
               raise WebMock::NetConnectNotAllowedError.new(request_signature)
             end
           end
-
-          alias_method :handle_request_without_webmock, :handle_request
-          alias_method :handle_request, :handle_request_with_webmock
         end
 
         def self.enable!


### PR DESCRIPTION
WebMock was using alias method chain in lots of situations where it didn't need to, since most of the adapters subclass the HTTP client.
