### PR TITLE
fix excon adapter version

### DIFF
--- a/lib/webmock/http_lib_adapters/excon_adapter.rb
+++ b/lib/webmock/http_lib_adapters/excon_adapter.rb
@@ -5,7 +5,7 @@ rescue LoadError
 end
 
 if defined?(Excon)
-  WebMock::VersionChecker.new('Excon', Excon::VERSION, '0.9.6').check_version!
+  WebMock::VersionChecker.new('Excon', Gem.loaded_specs["excon"].version.to_s, '0.9.6').check_version!
 
   module WebMock
     module HttpLibAdapters


### PR DESCRIPTION
When tried to run the tests using excon adapter, I got this error

```
uninitialized constant Excon::VERSION
```

The issue was that excon doesn't define this varible `Excon::VERSION`
