### PR TITLE
em-http-request problems with queries

### DIFF
--- a/lib/webmock/http_lib_adapters/em_http_request/em_http_request_0_x.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request/em_http_request_0_x.rb
@@ -90,11 +90,11 @@ if defined?(EventMachine::HttpRequest)
         if @req
           options = @req.options
           method = @req.method
-          uri = @req.uri
+          uri = @req.uri.dup
         else
           options = @options
           method = @method
-          uri = @uri
+          uri = @uri.dup
         end
 
         if options[:authorization] || options['authorization']


### PR DESCRIPTION
Hi,
I'm using webmock to test integration with pusher (vcr, webmock, pusher, pusher-client and em-http-request) and I have noticed that webmock was breaking the em-http-requests to pusher servers.

It modified the internal request/uri from em-http request. I fixed that by duplicating the uri for purpose of creating WebMock::RequestSignature.

Sorry for specles request, but I have no time for digging more in WebMock, believe me, it is covered in my project's test suite. ;) 
