### PR TITLE
Fix excon adapter to handle :body => some_file_object.

### DIFF
--- a/lib/webmock/http_lib_adapters/excon_adapter.rb
+++ b/lib/webmock/http_lib_adapters/excon_adapter.rb
@@ -43,7 +43,16 @@ if defined?(Excon)
           method  = (params.delete(:method) || :get).to_s.downcase.to_sym
           params[:query] = to_query(params[:query]) if params[:query].is_a?(Hash)
           uri = Addressable::URI.new(params).to_s
-          WebMock::RequestSignature.new method, uri, :body => params[:body], :headers => params[:headers]
+          WebMock::RequestSignature.new method, uri, :body => body_from(params), :headers => params[:headers]
+        end
+
+        def self.body_from(params)
+          body = params[:body]
+          return body unless body.respond_to?(:read)
+
+          contents = body.read
+          body.rewind if body.respond_to?(:rewind)
+          contents
         end
 
         def self.real_response(mock)

--- a/spec/acceptance/excon/excon_spec.rb
+++ b/spec/acceptance/excon/excon_spec.rb
@@ -11,5 +11,20 @@ describe "Excon" do
     Excon.get('http://example.com', :path => "resource/", :query => {:a => 1, :b => 2}).body.should == "abc"
   end
 
+  let(:file) { File.new(__FILE__) }
+  let(:file_contents) { File.new(__FILE__).read }
+
+  it 'handles file uploads correctly' do
+    stub_request(:put, "http://example.com/upload").with(:body => file_contents)
+
+    yielded_request_body = nil
+    WebMock.after_request do |req, res|
+      yielded_request_body = req.body
+    end
+
+    Excon.put("http://example.com", :path => "upload", :body => file)
+
+    yielded_request_body.should eq(file_contents)
+  end
 end
 


### PR DESCRIPTION
I investigated an issue a VCR user was having:

myronmarston/vcr#198

Turns out Excon supports `:body => File.new("path/to/some_file")` but WebMock wasn't handling this properly.  This PR fixes the issue.
