### PR TITLE
Handles the case where a post request contains an array, and the array contains a regex.

### DIFF
--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -236,6 +236,10 @@ module WebMock
 
         if actual.is_a?(Hash) && expected.is_a?(Hash)
           return false unless matching_hashes?(actual, expected)
+        elsif actual.is_a?(Array) && expected.is_a?(Array)
+          actual_as_hash = Hash[actual.each_with_index.map { |x,i| [i+1, x] }]
+          expected_as_hash = Hash[expected.each_with_index.map { |x,i| [i+1, x] }]
+          return false unless matching_hashes?(actual_as_hash, expected_as_hash)
         else
           return false unless expected === actual
         end


### PR DESCRIPTION
The matching_hashes? method falls over if the post request contains an array, and the
array contains a Regex, since ['a'] != [/*./]. Here I convert the Array into a Hash, and we carry on the recursion.
