### PR TITLE
Faye + WebMock

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -216,7 +216,7 @@ module Net  #:nodoc: all
       @debug_output = debug_output
 
       @io = case io
-      when Socket, OpenSSL::SSL::SSLSocket, IO
+      when Socket, OpenSSL::SSL::SSLSocket, IO, StringIO
         io
       when String
         StringIO.new(io)


### PR DESCRIPTION
When using [faye](https://github.com/faye/faye) ruby client with webmock - when trying to subscribe to any channel - it fails with `RuntimeError: Unable to create local socket`. It turns out, that StringIO is being passed into Net::BufferedIO class and WebMockNetBufferedIO does not deal with StringIO properly. This commit fixes it.
