### PR TITLE
Fix 'rack.errors' not being set for Rack apps

### DIFF
--- a/lib/webmock/rack_response.rb
+++ b/lib/webmock/rack_response.rb
@@ -44,6 +44,7 @@ module WebMock
 
       # Rack-specific variables
       env['rack.input']      = StringIO.new(body)
+      env['rack.errors']     = $stderr
       env['rack.version']    = Rack::VERSION
       env['rack.url_scheme'] = uri.scheme
       env['rack.run_once']   = true

--- a/spec/support/my_rack_app.rb
+++ b/spec/support/my_rack_app.rb
@@ -2,7 +2,7 @@ require 'rack'
 
 class MyRackApp
   class NonArrayResponse
-    # The rack response body need not implement #join, 
+    # The rack response body need not implement #join,
     # but it must implement #each.  It need not be an Array.
     # ActionDispatch::Response, for example, exercises that fact.
     # See: http://rack.rubyforge.org/doc/SPEC.html
@@ -32,6 +32,9 @@ class MyRackApp
         else
           [401, {}, [""]]
         end
+      when ['GET', '/error']
+        env['rack.errors'].puts('Error!')
+        [500, {}, ['']]
       else
         [404, {}, ['']]
     end

--- a/spec/unit/rack_response_spec.rb
+++ b/spec/unit/rack_response_spec.rb
@@ -49,6 +49,24 @@ describe WebMock::RackResponse do
     response.body.should include('Good to meet you, Jimmy!')
   end
 
+  describe 'rack error output' do
+    before :each do
+      @original_stderr = $stderr
+      $stderr = StringIO.new
+    end
+
+    after :each do
+      $stderr = @original_stderr
+    end
+
+    it 'should behave correctly when an app uses rack.errors' do
+      request = WebMock::RequestSignature.new(:get, 'www.example.com/error')
+
+      expect { @rack_response.evaluate(request) }.to_not raise_error
+      expect($stderr.length).to_not eq 0
+    end
+  end
+
   describe 'basic auth request' do
     before :each do
       @rack_response_with_basic_auth = WebMock::RackResponse.new(


### PR DESCRIPTION
I ran into an issue recently where Sinatra's error handler expects `env['rack.errors']` to contain something that responds to `puts`, but when running under WebMock, it doesn't. This causes the error handler itself to throw an error, making debugging rather difficult.

The attached code fixes this issue and includes a test case for it.
