### PR TITLE
Add license in .gemspec

### DIFF
--- a/webmock.gemspec
+++ b/webmock.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
   s.name        = 'webmock'
   s.version     = WebMock::VERSION
   s.platform    = Gem::Platform::RUBY
+  s.license     = 'MIT'
   s.authors     = ['Bartosz Blimke']
   s.email       = ['bartosz.blimke@gmail.com']
   s.homepage    = 'http://github.com/bblimke/webmock'


### PR DESCRIPTION
Rubygems warns empty license

```
spec/quality_spec.rb
```

WARNING:  licenses is empty

Warn is licenses is empty. Fixes #202 · ed1098d · rubygems/rubygems
https://github.com/rubygems/rubygems/commit/ed1098d5f14f2d2e97b2ac85d839915bf4c88161
