### PR TITLE
HashCounter put/get methods should be synchronized

### DIFF
--- a/lib/webmock/util/hash_counter.rb
+++ b/lib/webmock/util/hash_counter.rb
@@ -6,13 +6,18 @@ module WebMock
         self.hash = {}
         @order = {}
         @max = 0
+        @lock = Mutex.new
       end
       def put key, num=1
-        hash[key] = (hash[key] || 0) + num
-        @order[key] = @max = @max + 1
+        @lock.synchronize do
+          hash[key] = (hash[key] || 0) + num
+          @order[key] = @max = @max + 1
+        end
       end
       def get key
-        hash[key] || 0
+        @lock.synchronize do
+          hash[key] || 0
+        end
       end
 
       def each(&block)


### PR DESCRIPTION
We ran into an issue using webmock in a JRuby multi-thread environment. We ended up having two threads hanging when trying to "put" to the HashCounter. Since this is used on the RequestRegistry class, which is a singleton you can have multiple threads trying to add to the same HashCounter.
