### PR TITLE
Bumping the crack version

### DIFF
--- a/webmock.gemspec
+++ b/webmock.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = 'webmock'
 
   s.add_dependency 'addressable', '>= 2.2.7'
-  s.add_dependency 'crack', '>=0.1.7'
+  s.add_dependency 'crack', '>=0.3.2'
 
   s.add_development_dependency 'rspec',           '~> 2.10'
   s.add_development_dependency 'httpclient',      '>= 2.2.4'


### PR DESCRIPTION
[Security vulnerabilities have been discovered](https://support.cloud.engineyard.com/entries/22915701-january-14-2013-security-vulnerabilities-httparty-extlib-crack-nori-update-these-gems-immediately) in all versions of crack <= 0.3.1. This change ensures that those versions aren't used.
