### PR TITLE
Add support for :expects option in Excon adapter

### DIFF
--- a/lib/webmock/http_lib_adapters/excon_adapter.rb
+++ b/lib/webmock/http_lib_adapters/excon_adapter.rb
@@ -87,7 +87,14 @@ if defined?(Excon)
 
           if mock_response = WebMock::StubRegistry.instance.response_for_request(mock_request)
             ExconAdapter.perform_callbacks(mock_request, mock_response, :real_request => false)
-            ExconAdapter.real_response(mock_response)
+            response = ExconAdapter.real_response(mock_response)
+
+            if params.has_key?(:expects) && ![*params[:expects]].include?(response.status)
+              raise(Excon::Errors.status_error(params, response))
+            else
+              response
+            end
+
           elsif WebMock.net_connect_allowed?(mock_request.uri)
             real_response = super
             ExconAdapter.perform_callbacks(mock_request, ExconAdapter.mock_response(real_response), :real_request => true)

--- a/spec/acceptance/excon/excon_spec.rb
+++ b/spec/acceptance/excon/excon_spec.rb
@@ -11,6 +11,11 @@ describe "Excon" do
     Excon.get('http://example.com', :path => "resource/", :query => {:a => 1, :b => 2}).body.should == "abc"
   end
 
+  it 'should support Excon :expects options' do
+    stub_request(:get, "http://example.com/").to_return(:body => 'a')
+    lambda { Excon.get('http://example.com', :expects => 204) }.should raise_error(Excon::Errors::OK)
+  end
+
   let(:file) { File.new(__FILE__) }
   let(:file_contents) { File.new(__FILE__).read }
 
@@ -27,4 +32,3 @@ describe "Excon" do
     yielded_request_body.should eq(file_contents)
   end
 end
-


### PR DESCRIPTION
Excon provides `:expects` option allowing to set expected HTTP status on response, if the expectation is not met - exception is raised. Since excon adapter redefines `request_kernel` this functionality is lost https://github.com/geemus/excon/blob/master/lib/excon/connection.rb#L307
