### PR TITLE
 WebMock::Util::JSON.parse fails for binary strings.

### DIFF
--- a/spec/unit/util/json_spec.rb
+++ b/spec/unit/util/json_spec.rb
@@ -4,4 +4,8 @@ describe WebMock::Util::JSON do
   it "should parse json without parsing dates" do
     WebMock::Util::JSON.parse("\"a\":\"2011-01-01\"").should == {"a" => "2011-01-01"}
   end
+
+  it "should parse json that includes binary strings" do
+    WebMock::Util::JSON.parse("{\"a\":\"\\u0000\\u0001\\u0002\"}").should == {"a" => "\x00\x01\x02"}
+  end
 end


### PR DESCRIPTION
Webmock includes its own JSON parser. Turns out it doesn't parse some valid JSON strings.

What's a good way to proceed here? Should I try to fix the JSON parser or would it be better to include a JSON dependency?
