### PR TITLE
Send header one line at a time from curb adapter

### DIFF
--- a/lib/webmock/http_lib_adapters/curb_adapter.rb
+++ b/lib/webmock/http_lib_adapters/curb_adapter.rb
@@ -143,7 +143,7 @@ if defined?(Curl)
 
       def invoke_curb_callbacks
         @on_progress.call(0.0,1.0,0.0,1.0) if @on_progress
-        @on_header.call(self.header_str) if @on_header
+        self.header_str.lines.each { |header_line| @on_header.call header_line } if @on_header
         @on_body.call(self.body_str) if @on_body
         @on_complete.call(self) if @on_complete
 

--- a/spec/acceptance/curb/curb_spec.rb
+++ b/spec/acceptance/curb/curb_spec.rb
@@ -85,12 +85,15 @@ unless RUBY_PLATFORM =~ /java/
         stub_request(:any, "example.com").
           to_return(:headers => {:one => 1})
 
-        test = nil
+        test = []
         @curl.on_header do |data|
-          test = data
+          test << data
         end
         @curl.http_get
-        test.should match(/One: 1/)
+        test.should == [
+          "HTTP/1.1 200 \r\n",
+          'One: 1'
+        ]
       end
 
       it "should call on_complete when request is complete" do


### PR DESCRIPTION
When calling the on_header callback because this is how curb behaves.
