### PR TITLE
Raise WriteError if returning -1 from on_body callback, just like real Curl

### DIFF
--- a/lib/webmock/http_lib_adapters/curb_adapter.rb
+++ b/lib/webmock/http_lib_adapters/curb_adapter.rb
@@ -144,8 +144,13 @@ if defined?(Curl)
       def invoke_curb_callbacks
         @on_progress.call(0.0,1.0,0.0,1.0) if @on_progress
         @on_header.call(self.header_str) if @on_header
-        @on_body.call(self.body_str) if @on_body
+        on_body_return = @on_body.call(self.body_str) if @on_body
         @on_complete.call(self) if @on_complete
+
+        # Raise WriteError just like real curl
+        if on_body_return == -1
+          raise Curl::Easy.error(23).first
+        end
 
         case response_code
         when 200..299

--- a/spec/acceptance/curb/curb_spec.rb
+++ b/spec/acceptance/curb/curb_spec.rb
@@ -81,6 +81,19 @@ unless RUBY_PLATFORM =~ /java/
         test.should == body
       end
 
+      it "should raise WriteError when -1 is returned from on_body" do
+        body = "on_body fired"
+        stub_request(:any, "example.com").
+          to_return(:body => body)
+
+        @curl.on_body do |data|
+          -1
+        end
+        expect {
+          @curl.http_get
+        }.to raise_error Curl::Err::WriteError
+      end
+
       it "should call on_header when response headers are read" do
         stub_request(:any, "example.com").
           to_return(:headers => {:one => 1})


### PR DESCRIPTION
So we have code that goes something like this:

```
curl.on_body do |data|
  total_size += data.size
  if disallowed_content_type
    # Do this here instead of on-header to allow for redirects
    -1
  elsif total_size > 30_000_000
    -1
  else
    file << data
    data.size
  end
end
```

And in production (or outside of tests), this raises a Curl::Err::WriteError

```
req = Curl::Easy.new('http://www.microsoft.com')
=> #<Curl::Easy http://www.microsoft.com>
req.on_body do |data|
-1
end
=> nil
req.perform
Curl::Err::WriteError: Curl::Err::WriteError
  from /Users/jure/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/curb-0.8.3/lib/curl/easy.rb:60:in `perform'
  from (irb):6
  from /Users/jure/.rbenv/versions/2.0.0-p0/bin/irb:12:in `<main>'
req.last_result
=> 23
```

But when using WebMock, there is no WriteError, which makes it impossible to test for those situations. 

Curl raises this error from here: 
https://github.com/taf2/curb/blob/master/lib/curl/easy.rb#L58-L60

I have no idea how to get a realistic last_result in WebMock (right now it seems to vary wildly, probably because it's not really defined?), but the attached code worked well for my case and is what we're using right now.

I'm happy to debate this further and improve it.
