### PR TITLE
Adds support for invoking the `on_error` handler.

### DIFF
--- a/lib/webmock/http_lib_adapters/em_http_request/em_http_request_0_x.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request/em_http_request_0_x.rb
@@ -58,6 +58,7 @@ if defined?(EventMachine::HttpRequest)
           {:lib => :em_http_request}, request_signature, webmock_response)
           client = WebMockHttpClient.new(nil)
           client.options = @req.options
+          client.on_error("WebMock errback", true) if webmock_response.should_errback
           client.on_error("WebMock timeout error") if webmock_response.should_timeout
           client.setup(make_raw_response(webmock_response), @uri,
             webmock_response.should_timeout ? "WebMock timeout error" : nil)

--- a/lib/webmock/request_stub.rb
+++ b/lib/webmock/request_stub.rb
@@ -39,6 +39,11 @@ module WebMock
       self
     end
 
+    def to_errback
+      @responses_sequences << ResponsesSequence.new([ResponseFactory.response_for(:should_errback => true)])
+      self
+    end
+
     def response
       if @responses_sequences.empty?
         WebMock::Response.new

--- a/lib/webmock/response.rb
+++ b/lib/webmock/response.rb
@@ -72,12 +72,17 @@ module WebMock
       @should_timeout == true
     end
 
+    def should_errback
+      @should_errback == true
+    end
+
     def options=(options)
       self.headers = options[:headers]
       self.status = options[:status]
       self.body = options[:body]
       self.exception = options[:exception]
       @should_timeout = options[:should_timeout]
+      @should_errback = options[:should_errback]
     end
 
     def evaluate(request_signature)

--- a/spec/acceptance/em_http_request/em_http_request_spec.rb
+++ b/spec/acceptance/em_http_request/em_http_request_spec.rb
@@ -210,6 +210,23 @@ unless RUBY_PLATFORM =~ /java/
       expect { |b| http_request(:get, "http://www.example.com/", &b) }.to yield_control
     end
 
+    describe "when request stub declares that request should errback" do
+      it "should errback" do
+        stub_request(:get, "www.example.com").to_errback
+        lambda {
+          http_request(:get, "http://www.example.com/")
+        }.should raise_error("WebMock errback")
+      end
+
+      it "should errback after returning declared successful response first" do
+        stub_request(:get, "www.example.com").to_return(:body => "abc").then.to_errback
+        http_request(:get, "http://www.example.com/").body.should == "abc"
+        lambda {
+          http_request(:get, "http://www.example.com/")
+        }.should raise_error("WebMock errback")
+      end
+    end
+
     describe "mocking EM::HttpClient API" do
       let(:uri) { "http://www.example.com/" }
 


### PR DESCRIPTION
Hi,

When writing tests for an EventMachine client, I wanted to ensure that `on_error` handlers were properly triggered.

This PR adds support for `to_errback`:

``` ruby
stub_request(:get, "www.example.com").to_errback
```

Which will then invoke the `on_error` handler.
