### PR TITLE
net_http.rb: StubSocket needs continue_timeout for aws-sdk

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -193,7 +193,7 @@ end
 
 class StubSocket #:nodoc:
 
-  attr_accessor :read_timeout
+  attr_accessor :read_timeout, :continue_timeout
 
   def initialize(*args)
   end


### PR DESCRIPTION
For Ruby 2.0
See:
https://github.com/aws/aws-sdk-ruby/blob/7c4ea3d6004068e4905994be91de459651a96116/lib/aws/core/http/connection_pool.rb#L127

and:
https://github.com/ruby/ruby/blob/v2_0_0_0/lib/net/http.rb#L725
