### PR TITLE
Can't write to a Logger in a signal handler

### DIFF
--- a/spec/support/webmock_server.rb
+++ b/spec/support/webmock_server.rb
@@ -29,7 +29,11 @@ class WebMockServer
 
     concurrent do
       ['TERM', 'INT'].each do |signal|
-        trap(signal){ server.shutdown }
+        trap(signal) do
+          Thread.new do
+            server.shutdown
+          end
+        end
       end
       server.start do |socket|
         socket.puts <<-EOT.gsub(/^\s+\|/, '')


### PR DESCRIPTION
Remove warning with ruby 2.0.
Warning shows below:
"log writing failed. can't be called from trap context"

Related:
Can't write to a Logger in a signal handler
https://bugs.ruby-lang.org/issues/7917
