### PR TITLE
Compatibility fix for to_rack mocking + Rails 4

### DIFF
--- a/lib/webmock/rack_response.rb
+++ b/lib/webmock/rack_response.rb
@@ -49,6 +49,7 @@ module WebMock
       env['rack.url_scheme'] = uri.scheme
       env['rack.run_once']   = true
       env['rack.session']    = session
+      env['rack.session.options'] = session_options
 
       headers.each do |k, v|
         env["HTTP_#{k.tr('-','_').upcase}"] = v
@@ -59,6 +60,10 @@ module WebMock
 
     def session
       @session ||= {}
+    end
+
+    def session_options
+      @session_options ||= {}
     end
   end
 end


### PR DESCRIPTION
I wish I understood this problem better, but using WebMock's `to_rack` method when testing Rails 4 apps raises exceptions on any method that touches the session. Digging in to the Session class in ActionPack (https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/request/session.rb) is become clear that they expect a rack environment variable called 'rack.session.options' to be passed in in order for Session#load! to not explode on line 169 when setting a key in a nil  hash.

The attached change is a 'works-for-me' patch I made after spending hours trying to fix this issue. YMMV.
