### PR TITLE
fix query parametter with can't dup Object

### DIFF
--- a/lib/webmock/util/query_mapper.rb
+++ b/lib/webmock/util/query_mapper.rb
@@ -169,7 +169,7 @@ module WebMock::Util
           return parent
         else
           encoded_value = Addressable::URI.encode_component(
-            value.dup, Addressable::URI::CharacterClasses::UNRESERVED
+            value.to_s.dup, Addressable::URI::CharacterClasses::UNRESERVED
           )
           return "#{parent}=#{encoded_value}"
         end

--- a/spec/acceptance/shared/stubbing_requests.rb
+++ b/spec/acceptance/shared/stubbing_requests.rb
@@ -6,6 +6,11 @@ shared_examples_for "stubbing requests" do |*adapter_info|
         http_request(:get, "http://www.example.com/hello%2B/?#{ESCAPED_PARAMS}").body.should == "abc"
       end
 
+      it "should return stubbed response if query params as a hash with can't dup object" do
+        stub_request(:get, "www.example.com").with(:query => {"a" => 1}).to_return(:body => "abc")
+        http_request(:get, "http://www.example.com/?a=1").body.should == "abc"
+      end
+
       it "should return stubbed response even if request has non escaped params" do
         stub_request(:get, "www.example.com/hello%2B/?#{ESCAPED_PARAMS}").to_return(:body => "abc")
         http_request(:get, "http://www.example.com/hello+/?#{NOT_ESCAPED_PARAMS}").body.should == "abc"


### PR DESCRIPTION
Raise TypeError when query value is can't dup Object(etc Symbol, Fixnum).

```
 1) Webmock with Curb using #http for requests it should behave like Curb with WebMock when requests are stubbed based on query params should return stubbed response when stub declares query params as a hash with can't dup object
     Failure/Error: stub_request(:get, "www.example.com").with(:query => {"a" => 1}).to_return(:body => "abc")
     TypeError:
       can't dup Fixnum
     Shared Example Group: "Curb" called from ./spec/acceptance/curb/curb_spec.rb:274
     # ./lib/webmock/util/query_mapper.rb:172:in `dup'

```
