### PR TITLE
Change NetConnectNotAllowedError to inherit from Exception

### DIFF
--- a/lib/webmock/errors.rb
+++ b/lib/webmock/errors.rb
@@ -1,6 +1,6 @@
 module WebMock
 
-  class NetConnectNotAllowedError < StandardError
+  class NetConnectNotAllowedError < Exception
     def initialize(request_signature)
       text = "Real HTTP connections are disabled. Unregistered request: #{request_signature}"
       text << "\n\n"

--- a/spec/unit/errors_spec.rb
+++ b/spec/unit/errors_spec.rb
@@ -27,6 +27,24 @@ describe "errors" do
                "bbb\n\nregistered request stubs:\n\nbbb\n\n============================================================"
         WebMock::NetConnectNotAllowedError.new(request_signature).message.should == expected
       end
+
+      it "should not be caught by a rescue block without arguments" do
+        request_signature = mock(:to_s => "aaa")
+        request_stub = mock
+        WebMock::RequestStub.stub!(:from_request_signature).and_return(request_stub)
+        WebMock::StubRequestSnippet.stub!(:new).
+          with(request_stub).and_return(mock(:to_s => "bbb"))
+
+        exception = WebMock::NetConnectNotAllowedError.new(request_signature)
+
+        expect do
+          begin
+            raise exception
+          rescue
+            raise "exception should not be caught"
+          end
+        end.to raise_exception exception
+      end
     end
   end
 end


### PR DESCRIPTION
Because a default ruby rescue block:

```
begin
rescue
end
```

will catch StandardErrors, all NetConnectNotAllowedErrors will be swallowed by the block above. So they wont raise in your test suite. We now changed the parent from StandardError to Exception to allow it to bubble up into our test suite. 

We also renamed the class to NetConnectNotAllowedException to reflect this change.
