### PR TITLE
Failing unit test demonstrating WebMock ignoring params

### DIFF
--- a/spec/unit/request_pattern_spec.rb
+++ b/spec/unit/request_pattern_spec.rb
@@ -192,6 +192,11 @@ describe WebMock::RequestPattern do
             should match(WebMock::RequestSignature.new(:get, "www.example.com?a[]=b&a[]=c"))
         end
 
+        it "should not match when repeated query params are not the same as declared as string" do
+          WebMock::RequestPattern.new(:get, "www.example.com", :query => "a=b&a=c").
+            should_not match(WebMock::RequestSignature.new(:get, "www.example.com?a=z&a=c"))
+        end
+
         it "should match when query params are the same as declared both in query option or url" do
           WebMock::RequestPattern.new(:get, "www.example.com/?x=3", :query => "a[]=b&a[]=c").
             should match(WebMock::RequestSignature.new(:get, "www.example.com/?x=3&a[]=b&a[]=c"))


### PR DESCRIPTION
For params specified multiple times all but the last value is ignored.

Issue #227
