### PR TITLE
Trigger error callbacks asynchronously

### DIFF
--- a/lib/webmock/http_lib_adapters/em_http_request/em_http_request_1_x.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request/em_http_request_1_x.rb
@@ -94,7 +94,6 @@ if defined?(EventMachine::HttpClient)
         WebMock::RequestRegistry.instance.requested_signatures.put(request_signature)
 
         if stubbed_webmock_response
-          on_error("WebMock timeout error") if stubbed_webmock_response.should_timeout
           WebMock::CallbackRegistry.invoke_callbacks({:lib => :em_http_request}, request_signature, stubbed_webmock_response)
           EM.next_tick {
             setup(make_raw_response(stubbed_webmock_response), @uri,

--- a/spec/acceptance/em_http_request/em_http_request_spec.rb
+++ b/spec/acceptance/em_http_request/em_http_request_spec.rb
@@ -127,6 +127,23 @@ unless RUBY_PLATFORM =~ /java/
         end
       end
 
+      it 'should trigger error callbacks asynchronously' do
+        stub_request(:get, 'www.example.com').to_timeout
+        called = false
+
+        EM.run do
+          conn = EventMachine::HttpRequest.new('http://www.example.com/')
+          http = conn.get
+          http.errback do
+            called = true
+            EM.stop
+          end
+          called.should == false
+        end
+
+        called.should == true
+      end
+
       # not pretty, but it works
       if defined?(EventMachine::Synchrony)
         describe "with synchrony" do


### PR DESCRIPTION
This allows one to, e.g., yield the current fiber after making the request and resume it in a callback.
