### PR TITLE
Ensure uppercase request method for Curb

### DIFF
--- a/spec/acceptance/curb/curb_spec_helper.rb
+++ b/spec/acceptance/curb/curb_spec_helper.rb
@@ -66,7 +66,7 @@ module CurbSpecHelper
         curl.put_data = body
       end
 
-      curl.http(method)
+      curl.http(method.to_s.upcase)
       curl
     end
   end


### PR DESCRIPTION
Curb's `http` method takes its argument and sets it as the value for libcurl's `CURLOPT_CUSTOMREQUEST`. Apparently this _needs_ to be uppercase, though we're not sure why it's failing now (or how it _ever_ worked, really). This fixes [the failing tests](https://travis-ci.org/bblimke/webmock/jobs/10469034) on our local machine.
