### PR TITLE
Use ancestors' `hash_including` if available.

### DIFF
--- a/lib/webmock/api.rb
+++ b/lib/webmock/api.rb
@@ -15,16 +15,6 @@ module WebMock
 
     class << self
       alias :request :a_request
-
-      def included(mod)
-        unless mod.respond_to?(:hash_including)
-          mod.class_eval do
-            def hash_including(expected)
-              WebMock::Matchers::HashIncludingMatcher.new(expected)
-            end
-          end
-        end
-      end
     end
 
     def assert_requested(*args, &block)
@@ -43,6 +33,14 @@ module WebMock
         raise ArgumentError, "assert_not_requested with a stub object, doesn't accept blocks"
       end
       assert_request_not_requested(*args)
+    end
+
+    def hash_including(*expected)
+      if defined?(super)
+        super
+      else
+        WebMock::Matchers::HashIncludingMatcher.new(expected)
+      end
     end
 
     def remove_request_stub(stub)

--- a/spec/unit/include_spec.rb
+++ b/spec/unit/include_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe WebMock::API do
+  describe '#hash_including' do
+    context 'when mixed into a class that does not define `hash_including`' do
+      subject do
+        Class.new do
+          include WebMock::API
+        end.new
+      end
+
+      it 'uses WebMock::Matchers::HashIncludingMatcher' do
+        expect(subject.hash_including(:foo, :bar)).to be_a(WebMock::Matchers::HashIncludingMatcher)
+      end
+    end
+
+    context 'when mixed into a class that defines `hash_including`' do
+      subject do
+        Class.new do
+          def hash_including(*args)
+            args
+          end
+
+          include WebMock::API
+        end.new
+      end
+
+      it 'uses super and passes the args untampered' do
+        expect(subject.hash_including(:foo, :bar)).to be_a(Array)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The previous solution didn't work because rspec does a complicated dance
with module inclusion and inheritence, so we must check this condition
at call-time, rather than include-time.

@bblimke sorry about this, we had not tested this thoroughly enough the first time. Hopefully nobody has been bitten yet. cc @strongriley
