### PR TITLE
Fix assigned but unused variable warning

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -97,7 +97,7 @@ module WebMock
               response = super(request, nil, &nil)
               after_request.call(response)
             }
-            response = if started?
+            if started?
               if WebMock::Config.instance.net_http_connect_on_start
                 super_with_after_request.call
               else


### PR DESCRIPTION
Loading webmock with a verbose warning level e.g. `ruby -W2 -r webmock -e ''` prints out "warning: assigned but unused variable - response". Patch removes the unused variable in question.
