### PR TITLE
Add support for matching JSON with an Array as the containing element.

### DIFF
--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -180,6 +180,9 @@ module WebMock
       if (@pattern).is_a?(Hash)
         return true if @pattern.empty?
         matching_hashes?(body_as_hash(body, content_type), @pattern)
+      elsif (@pattern).is_a?(Array)
+        return true if @pattern.empty?
+        matching_arrays?(body_as_hash(body, content_type), @pattern)
       elsif (@pattern).is_a?(WebMock::Matchers::HashIncludingMatcher)
         @pattern == body_as_hash(body, content_type)
       else
@@ -238,6 +241,21 @@ module WebMock
           return false unless matching_hashes?(actual, expected)
         else
           return false unless expected === actual
+        end
+      end
+      true
+    end
+
+    def matching_arrays?(query_parameters, pattern)
+      return false unless query_parameters.is_a?(Array)
+      return false unless query_parameters.length == pattern.length
+      query_parameters.each_with_index do |actual, index|
+        expected = pattern[index]
+
+        if actual.is_a?(Hash)
+          return false unless matching_hashes?(actual, expected)
+        else
+          return false unless actual === expected
         end
       end
       true


### PR DESCRIPTION
JSON evaluation (Content-Type == "application/json") currently fails if the outer element of the data is an array. This change adds support for this type of array evaluation.
