### PR TITLE
Unintialized constant Pathname fix

### DIFF
--- a/lib/webmock/response.rb
+++ b/lib/webmock/response.rb
@@ -1,4 +1,5 @@
 #compatibility with Ruby 1.9.2 preview1 to allow reading raw responses
+require 'pathname'
 class StringIO
   alias_method :read_nonblock, :sysread
 end


### PR DESCRIPTION
Opened lib/webmock/response.rb file and added
require 'pathname'
