### PR TITLE
Stubs for Typhoeus::Request#on_body

### DIFF
--- a/lib/webmock/http_lib_adapters/typhoeus_hydra_adapter.rb
+++ b/lib/webmock/http_lib_adapters/typhoeus_hydra_adapter.rb
@@ -143,6 +143,9 @@ if defined?(Typhoeus)
             if webmock_response = ::WebMock::StubRegistry.instance.response_for_request(request_signature)
               # ::WebMock::HttpLibAdapters::TyphoeusAdapter.stub_typhoeus(request_signature, webmock_response, self)
               response = ::WebMock::HttpLibAdapters::TyphoeusAdapter.generate_typhoeus_response(request_signature, webmock_response)
+              if request.respond_to?(:on_headers)
+                request.execute_headers_callbacks(response)
+              end
               if request.respond_to?(:streaming?) && request.streaming?
                 response.options[:response_body] = ""
                 request.on_body.each { |callback| callback.call(webmock_response.body, response) }

--- a/spec/acceptance/typhoeus/typhoeus_hydra_spec.rb
+++ b/spec/acceptance/typhoeus/typhoeus_hydra_spec.rb
@@ -97,6 +97,20 @@ unless RUBY_PLATFORM =~ /java/
           test_body.should == body
           test_complete.should == ""
         end
+
+        it "should call on_headers with 2xx response" do
+          body = "on_headers fired"
+          stub_request(:any, "example.com").to_return(:body => body, :headers => {'X-Test' => '1'})
+
+          test_headers = nil
+          pending("This test requires a newer version of Typhoeus") unless @request.respond_to?(:on_headers)
+          @request.on_headers do |response|
+            test_headers = response.headers
+          end
+          hydra.queue @request
+          hydra.run
+          test_headers.should include('X-Test' => '1')
+        end
       end
     end
   end


### PR DESCRIPTION
Typhoeus 0.6.7 includes support for streaming. This branch adds support for mocking streamed typhoeus requests. For example, it makes it possible to use wemock to do the stubbing for this code:

``` ruby
request = Typhoeus::Request.new('https://github.com')
request.on_body { |chunk| p chunk }
request.run
```

cc typhoeus/typhoeus#339
