### PR TITLE
Log WebMock::NetConnectNotAllowedError in Rails

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -111,7 +111,9 @@ module WebMock
               }
             end
           else
-            raise WebMock::NetConnectNotAllowedError.new(request_signature)
+            error = WebMock::NetConnectNotAllowedError.new(request_signature)
+            Rails.logger.error(error.to_s) if defined?(Rails) && Rails.logger
+            raise error
           end
         end
 


### PR DESCRIPTION
For Rails projects, log in Rails.logger.error the WebMock::NetConnectNotAllowedError exception in order to have a trace when using AJAX call in Rails 4 (due to the mutli-thread issue with Ajax)
