### PR TITLE
Give RestClient examples

### DIFF
--- a/lib/webmock/stub_request_snippet.rb
+++ b/lib/webmock/stub_request_snippet.rb
@@ -5,6 +5,8 @@ module WebMock
     end
 
     def to_s(with_response = true)
+      restclient_example = ENV['RESTCLIENT_EXAMPLE']
+
       request_pattern = @request_stub.request_pattern
       string = "stub_request(:#{request_pattern.method_pattern.to_s},"
       string << " \"#{request_pattern.uri_pattern.to_s}\")"
@@ -24,6 +26,14 @@ module WebMock
       if with_response
         string << ".\n  to_return(:status => 200, :body => \"\", :headers => {})"
       end
+
+      if restclient_example
+        string << "\n You can run this manually and get the response with rest-client like so:"
+        string << "\n RestClient.#{request_pattern.method_pattern} '#{request_pattern.uri_pattern.to_s}'"
+        string << ", #{request_pattern.body_pattern.to_s}" unless request_pattern.body_pattern.nil?
+        string << ", #{request_pattern.headers_pattern.to_s}" unless request_pattern.headers_pattern.nil?
+      end
+
       string
     end
   end

--- a/spec/unit/stub_request_snippet_spec.rb
+++ b/spec/unit/stub_request_snippet_spec.rb
@@ -56,6 +56,16 @@ describe WebMock::StubRequestSnippet do
         stub = WebMock::RequestStub.new(:get, "www.example.com").with(:body => "abcdef").to_return(:body => "hello")
         WebMock::StubRequestSnippet.new(stub).to_s(false).should == expected
       end
+
+      it "should print rest-client example if environment variable declared" do
+        ENV.stub(:[]).with('RESTCLIENT_EXAMPLE').and_return('true')
+        expected = 'stub_request(:get, "http://www.example.com/").'+
+        "\n  with(:body => \"abcdef\")"+
+        "\n You can run this manually and get the response with rest-client like so:"+
+        "\n RestClient.get 'http://www.example.com/', \"abcdef\""
+        stub = WebMock::RequestStub.new(:get, "www.example.com").with(:body => "abcdef").to_return(:body => "hello")
+        WebMock::StubRequestSnippet.new(stub).to_s(false).should == expected
+      end
     end
 
     describe "POST" do


### PR DESCRIPTION
Hi @bblimke!

I've been working on some API wrapper stuff with webmock recently, and wanting to keep things TDD, write the specs before I actually know what responses are going to fully look like.

So I usually end up taking the stub requests from the webmock output and curling them to see what things actually look like, either with curl or Ruby scripts.

So, I thought of having an option to have a copy+pastable script to test out things immediately!

I've made a basic prototype here, I was wondering if you'd be interested in something like this in the project? If so, I'll tidy this up a bit and add some more specs. If not, I'll see if I can extend it into my own gem and keep it separate :smile: 

Thanks!
