### PR TITLE
Fix Rack response mutating request headers

### DIFF
--- a/lib/webmock/rack_response.rb
+++ b/lib/webmock/rack_response.rb
@@ -25,7 +25,7 @@ module WebMock
 
     def build_rack_env(request)
       uri = request.uri
-      headers = request.headers || {}
+      headers = (request.headers || {}).dup
       body = request.body || ''
 
       env = {

--- a/spec/acceptance/webmock_shared.rb
+++ b/spec/acceptance/webmock_shared.rb
@@ -22,6 +22,19 @@ shared_examples "with WebMock" do |*adapter_info|
       WebMock.reset!
     end
 
+    it "preserves content-type header when proxying to a rack app" do
+      stub_request(:any, //).to_rack(lambda {|req| [200, {}, ["OK"]] })
+
+      url = "https://google.com/hi/there"
+      headers = {
+        "Accept"       => "application/json",
+        "Content-Type" => "application/json"
+      }
+
+      http_request(:get, url, :headers => headers)
+      WebMock.should have_requested(:get, url).with(:headers => headers)
+    end
+
     include_context "allowing and disabling net connect", *adapter_info
 
     include_context "stubbing requests", *adapter_info


### PR DESCRIPTION
This came up when a `before(:each) {}` RSpec block set up a general Rack-backed stub for all requests to a domain and an individual spec placed a further expectation on the request for the `Content-Type` header. To our surprise, the `Content-Type` header was mysteriously vanishing.

@mattonrails and I traced it to WebMock and were able to write a failing test and fix the issue with no other failing specs. The spec we wrote is probably not in an ideal location so I'm happy to move it around with your feedback.

If you uncomment our diff in `lib/webmock/rack_response.rb`, you'll see the spec fail with the `Accept` header still present, but the `Content-Type` header missing and unable to be matched against.
