### PR TITLE
Update matchers for RSpec 3's matcher protocol

### DIFF
--- a/lib/webmock/api.rb
+++ b/lib/webmock/api.rb
@@ -71,7 +71,7 @@ module WebMock
 
     def assert_request_not_requested(request, options = {})
       verifier = WebMock::RequestExecutionVerifier.new(request, options.delete(:times))
-      WebMock::AssertionFailure.failure(verifier.negative_failure_message) unless verifier.does_not_match?
+      WebMock::AssertionFailure.failure(verifier.failure_message_when_negated) unless verifier.does_not_match?
     end
 
     #this is a based on RSpec::Mocks::ArgumentMatchers#anythingize_lonely_keys

--- a/lib/webmock/request_execution_verifier.rb
+++ b/lib/webmock/request_execution_verifier.rb
@@ -32,7 +32,7 @@ module WebMock
       text
     end
 
-    def negative_failure_message
+    def failure_message_when_negated
       text = if @expected_times_executed
         %Q(The request #{request_pattern.to_s} was not expected to execute #{times(expected_times_executed)} but it executed #{times(times_executed)})
       else

--- a/lib/webmock/rspec/matchers/request_pattern_matcher.rb
+++ b/lib/webmock/rspec/matchers/request_pattern_matcher.rb
@@ -34,9 +34,11 @@ module WebMock
       @request_execution_verifier.failure_message
     end
 
-
-    def negative_failure_message
-      @request_execution_verifier.negative_failure_message
+    def failure_message_when_negated
+      @request_execution_verifier.failure_message_when_negated
     end
+
+    # RSpec 2 compatibility:
+    alias_method :negative_failure_message, :failure_message_when_negated
   end
 end

--- a/lib/webmock/rspec/matchers/webmock_matcher.rb
+++ b/lib/webmock/rspec/matchers/webmock_matcher.rb
@@ -38,9 +38,11 @@ module WebMock
       @request_execution_verifier.failure_message
     end
 
-
-    def negative_failure_message
-      @request_execution_verifier.negative_failure_message
+    def failure_message_when_negated
+      @request_execution_verifier.failure_message_when_negated
     end
+
+    # RSpec 2 compatibility:
+    alias_method :negative_failure_message, :failure_message_when_negated
   end
 end

--- a/spec/unit/request_execution_verifier_spec.rb
+++ b/spec/unit/request_execution_verifier_spec.rb
@@ -37,14 +37,14 @@ describe WebMock::RequestExecutionVerifier do
       @verifier.expected_times_executed = 2
       expected_text = "The request www.example.com was not expected to execute 2 times but it executed 2 times"
       expected_text << @executed_requests_info
-      @verifier.negative_failure_message.should == expected_text
+      @verifier.failure_message_when_negated.should == expected_text
     end
 
     it "should report failure message when not expected request but it executed" do
       @verifier.times_executed = 1
       expected_text = "The request www.example.com was expected to execute 0 times but it executed 1 time"
       expected_text << @executed_requests_info
-      @verifier.negative_failure_message.should == expected_text
+      @verifier.failure_message_when_negated.should == expected_text
     end
 
   end


### PR DESCRIPTION
Resolves this deprecation message when using webmock's matchers on a project with RSpec 3:

> WebMock::WebMockMatcher implements a legacy RSpec matcher
> protocol. For the current protocol you should expose the failure messages
> via the `failure_message` and `failure_message_when_negated` methods.

Since `negative_failure_message` is being added back in with alias_method this will continue to work for users of RSpec 2 (e.g. webmock's own test suite).

What I did loosely matches [the fix that was applied to capybara](https://github.com/jnicklas/capybara/commit/2121ff12fb58ed2f8e4fff095a7ac9555da02f9e).
