### PR TITLE
Fix CONTENT_LENGTH in RackResponse

### DIFF
--- a/lib/webmock/rack_response.rb
+++ b/lib/webmock/rack_response.rb
@@ -32,7 +32,7 @@ module WebMock
         # CGI variables specified by Rack
         'REQUEST_METHOD' => request.method.to_s.upcase,
         'CONTENT_TYPE'   => headers.delete('Content-Type'),
-        'CONTENT_LENGTH' => body.size,
+        'CONTENT_LENGTH' => body.bytesize,
         'PATH_INFO'      => uri.path,
         'QUERY_STRING'   => uri.query || '',
         'SERVER_NAME'    => uri.host,

--- a/spec/support/my_rack_app.rb
+++ b/spec/support/my_rack_app.rb
@@ -24,7 +24,7 @@ class MyRackApp
       when ['GET', '/locked']
         [200, {}, ["Single threaded response."]]
       when ['POST', '/greet']
-        name = env["rack.input"].read[/name=([^&]*)/, 1] || "World"
+        name = env["rack.input"].read(env["CONTENT_LENGTH"]).force_encoding("UTF-8")[/name=([^&]*)/, 1] || "World"
         [200, {}, ["Good to meet you, #{name}!"]]
       when ['GET', '/compute']
         if env['SERVER_PORT'] == 80 && env["SCRIPT_NAME"] == ""

--- a/spec/unit/rack_response_spec.rb
+++ b/spec/unit/rack_response_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 
 describe WebMock::RackResponse do
@@ -47,6 +48,15 @@ describe WebMock::RackResponse do
 
     response = @rack_response.evaluate(request)
     response.body.should include('Good to meet you, Jimmy!')
+  end
+
+  it "should send params with proper content length if params have non-ascii symbols" do
+    request = WebMock::RequestSignature.new(:post, 'www.example.com/greet',
+      :body => 'name=Олег'
+    )
+
+    response = @rack_response.evaluate(request)
+    response.body.should include('Good to meet you, Олег!')
   end
 
   describe 'rack error output' do


### PR DESCRIPTION
Hello!

I think RackResponse calculates CONTENT_LENGTH wrongly. It takes body.size. But if body has non-ASCII symbols, they will be stored in two bytes each but the length of each of them will be one.
I'm confident it is right to take body.bytesize instead.
