### PR TITLE
Add some missing Curl::Easy aliases

### DIFF
--- a/lib/webmock/http_lib_adapters/curb_adapter.rb
+++ b/lib/webmock/http_lib_adapters/curb_adapter.rb
@@ -200,12 +200,14 @@ if defined?(Curl)
         @put_data = data if data
         super
       end
+      alias put http_put
 
       def http_post *data
         @webmock_method = :post
         @post_body = data.join('&') if data && !data.empty?
         super
       end
+      alias post http_post
 
       def perform
         @webmock_method ||= :get
@@ -236,6 +238,7 @@ if defined?(Curl)
       def body_str
         @body_str || super
       end
+      alias body body_str
 
       def response_code
         @response_code || super
@@ -244,6 +247,7 @@ if defined?(Curl)
       def header_str
         @header_str || super
       end
+      alias head header_str
 
       def last_effective_url
         @last_effective_url || super

--- a/spec/acceptance/curb/curb_spec.rb
+++ b/spec/acceptance/curb/curb_spec.rb
@@ -331,6 +331,15 @@ unless RUBY_PLATFORM =~ /java/
         c.http(:GET)
         c.body_str.should == "abc"
       end
+
+      it "should alias body to body_str" do
+        stub_request(:get, "www.example.com").to_return(:body => "abc")
+
+        c = Curl::Easy.new
+        c.url = "http://www.example.com"
+        c.http(:GET)
+        c.body.should == "abc"
+      end
     end
 
     describe "using #http_* methods for requests" do


### PR DESCRIPTION
I had some code where I was using `#body` instead of `#body_str` and it was silently failing because the aliases weren't being redirected to the new methods.
