### PR TITLE
HTTP::Request#method is deprecated. Use #verb instead.

### DIFF
--- a/lib/webmock/http_lib_adapters/http_gem_adapter.rb
+++ b/lib/webmock/http_lib_adapters/http_gem_adapter.rb
@@ -31,7 +31,7 @@ if defined?(HTTP::Client)
     class Request
 
       def webmock_signature
-        ::WebMock::RequestSignature.new(method, uri.to_s, {
+        ::WebMock::RequestSignature.new(verb, uri.to_s, {
           :headers  => headers,
           :body     => body
         })


### PR DESCRIPTION
HTTP::Request#method was renamed to #verb to avoid clashing with Object#method in https://github.com/tarcieri/http/pull/49.

If you’d prefer, I can check the `http` gem version, so `webmock` can support both versions before and after 0.6.0. Let me know.
