### PR TITLE
Fix query mapper

### DIFF
--- a/lib/webmock/util/query_mapper.rb
+++ b/lib/webmock/util/query_mapper.rb
@@ -133,8 +133,10 @@ module WebMock::Util
         new_query_values = new_query_values.inject([]) do |object, (key, value)|
           key = key.to_s if key.kind_of?(Symbol) || key.nil?
 
-          if value.respond_to?(:each)
+          if value.is_a?(Array)
             value.each { |v| object << [key.to_s + '[]', v] }
+          elsif value.is_a?(Hash)
+            value.each { |k, v| object << ["#{key.to_s}[#{k}]", v]}
           else
             object << [key.to_s, value]
           end

--- a/spec/unit/util/query_mapper_spec.rb
+++ b/spec/unit/util/query_mapper_spec.rb
@@ -33,4 +33,11 @@ describe WebMock::Util::QueryMapper do
     expect(query_mapper.values_to_query values).to eq query
     expect(query_mapper.query_to_values query).to eq values
   end
+
+  it 'converts hash values, vice versa' do
+    query = "one%5Ba%5D=1&one%5Bb%5D=2"
+    values = {"one" => {"a" => "1", "b" => "2"}}
+    expect(query_mapper.values_to_query values).to eq query
+    expect(query_mapper.query_to_values query).to eq values
+  end
 end


### PR DESCRIPTION
`WebMock::Util::QueryMapper` and `Rack::Utils` are different with nested parameters

``` ruby
WebMock::Util::QueryMapper.values_to_query('one' => ['1','2'])
#=> "one[0]=1&one[1]=2"
WebMock::Util::QueryMapper.query_to_values('one[0]=1&one[1]=2')
#=> {"one"=>["1", "2"]}
WebMock::Util::QueryMapper.query_to_values('one[]=1&one[]=2')
#=> {"one"=>["1", "2"]} # same with 'one[0]=1&one[1]=2'
```

``` ruby
Rack::Utils.build_nested_query('one' => ['1','2'])
#=> "one[]=1&one[]=2"
Rack::Utils.parse_nested_query('one[]=1&one[]=2')
#=> {"one"=>["1", "2"]}
Rack::Utils.parse_nested_query('one[0]=1&one[1]=2')
#=> {"one"=>{"0"=>"1", "1"=>"2"}}
```

I wonder what is correct mapping.

Anyway, when calling  `Curl.get('http://example.com/test?one[]=1&one[]=2')`, WebMock shows tip.

```
You can stub this request with the following snippet:

stub_request(:get, "http://example.com/test?one%5B0%5D=1&one%5B1%5D=2").
  to_return(:status => 200, :body => "", :headers => {})
```

After decoding url of tip above, query is converted to `one[0]=1&one[1]=2`
This is confusing. So I fixed only this case.

``` ruby
WebMock::Util::QueryMapper.values_to_query('one' => ['1','2'])
#=> "one%5B%5D=1&one%5B%5D=2"
```
