### PR TITLE
Fix HTTP Gem replayed Response object's init

### DIFF
--- a/lib/webmock/http_lib_adapters/http_gem/response.rb
+++ b/lib/webmock/http_lib_adapters/http_gem/response.rb
@@ -10,12 +10,13 @@ module HTTP
       webmock_response
     end
 
-    def self.from_webmock(webmock_response)
+    def self.from_webmock(webmock_response, request_signature = nil)
       status  = webmock_response.status.first
       headers = webmock_response.headers || {}
       body    = Body.new Streamer.new webmock_response.body
+      uri     = URI request_signature.uri.to_s if request_signature
 
-      new(status, "1.1", headers, body)
+      new(status, "1.1", headers, body, uri)
     end
   end
 end

--- a/lib/webmock/http_lib_adapters/http_gem/webmock.rb
+++ b/lib/webmock/http_lib_adapters/http_gem/webmock.rb
@@ -37,7 +37,7 @@ module HTTP
       webmock_response.raise_error_if_any
 
       invoke_callbacks(webmock_response, :real_request => false)
-      ::HTTP::Response.from_webmock webmock_response
+      ::HTTP::Response.from_webmock webmock_response, request_signature
     end
 
     def perform

--- a/spec/acceptance/http_gem/http_gem_spec.rb
+++ b/spec/acceptance/http_gem/http_gem_spec.rb
@@ -47,4 +47,13 @@ describe "HTTP Gem" do
       expect(headers).to include "Host" => "www.example.com"
     end
   end
+
+  it "restores request uri on replayed response object" do
+    uri = URI "http://example.com/foo"
+
+    stub_request :get, "example.com/foo"
+    response = HTTP.get uri
+
+    expect(response.uri).to eq uri
+  end
 end


### PR DESCRIPTION
0.6.x version introduced optional last argument of Response object:
request's uri. That allows for example to figure out a real URI after
following redirects. This patch brinsg this ability to HTTP Gem adapter.
