### PR TITLE
convert status to int and back (HTTP gem)

### DIFF
--- a/lib/webmock/http_lib_adapters/http_gem/response.rb
+++ b/lib/webmock/http_lib_adapters/http_gem/response.rb
@@ -3,7 +3,7 @@ module HTTP
     def to_webmock
       webmock_response = ::WebMock::Response.new
 
-      webmock_response.status  = [status, reason]
+      webmock_response.status  = [status.to_i, reason]
       webmock_response.body    = body.to_s
       webmock_response.headers = headers.to_h
 
@@ -11,7 +11,7 @@ module HTTP
     end
 
     def self.from_webmock(webmock_response, request_signature = nil)
-      status  = webmock_response.status.first
+      status  = Status.new(webmock_response.status.first)
       headers = webmock_response.headers || {}
       body    = Body.new Streamer.new webmock_response.body
       uri     = URI request_signature.uri.to_s if request_signature


### PR DESCRIPTION
Compatibility with https://github.com/tarcieri/http/commit/136e2ad37e857b260345f6c7e14a3f79e59dc901, which introduced a status object.

Do I need to add specs/bump dependencies to complete this?

/cc @ixti