### PR TITLE
Add ability to allow net connect inside a block

### DIFF
--- a/lib/webmock/config.rb
+++ b/lib/webmock/config.rb
@@ -6,5 +6,15 @@ module WebMock
     attr_accessor :allow_localhost
     attr_accessor :allow
     attr_accessor :net_http_connect_on_start
+
+    def to_h
+      {
+        allow_net_connect: allow_net_connect,
+        allow_localhost: allow_localhost,
+        allow: allow,
+        net_http_connect_on_start: net_http_connect_on_start
+      }
+    end
+
   end
 end

--- a/lib/webmock/webmock.rb
+++ b/lib/webmock/webmock.rb
@@ -42,11 +42,12 @@ module WebMock
   end
 
   def self.allow_net_connect!(options = {})
+    state_snapshot = Config.instance.to_h
     Config.instance.allow_net_connect = true
     Config.instance.net_http_connect_on_start = options[:net_http_connect_on_start]
     if block_given?
       yield
-      disable_net_connect!
+      disable_net_connect! state_snapshot
     end
   end
 

--- a/spec/acceptance/shared/allowing_and_disabling_net_connect.rb
+++ b/spec/acceptance/shared/allowing_and_disabling_net_connect.rb
@@ -31,6 +31,17 @@ shared_context "allowing and disabling net connect" do |*adapter_info|
           http_request(:get, "http://www.example.com/")
         }.should raise_error(WebMock::NetConnectNotAllowedError, %r(Real HTTP connections are disabled. Unregistered request: GET http://www.example.com/))
       end
+
+      it "remembers previous disable_net_connect state after yielding to block" do
+        WebMock.disable_net_connect! :allow_localhost => true, :allow => 'http://test.com', :net_http_connect_on_start => true
+        WebMock.allow_net_connect! do
+          http_request(:get, webmock_server_url).status.should == "200"
+        end
+        WebMock::Config.instance.allow_net_connect.should == false
+        WebMock::Config.instance.allow_localhost.should == true
+        WebMock::Config.instance.allow.should == 'http://test.com'
+        WebMock::Config.instance.net_http_connect_on_start.should == true
+      end
     end
 
     describe "is not allowed" do


### PR DESCRIPTION
If a block is given to allow_net_connect!, allow net connection within
it and then disable_net_connect! automatically.

I think this syntax has better aesthetics than explicitly calling
disable_net_connect!, as it nicely groups allowed code within the
block.
