### PR TITLE
Allow xfer of parms from httpclient request header to response header

### DIFF
--- a/lib/webmock/http_lib_adapters/httpclient_adapter.rb
+++ b/lib/webmock/http_lib_adapters/httpclient_adapter.rb
@@ -46,7 +46,7 @@ if defined?(::HTTPClient)
 
       if webmock_responses[request_signature]
         webmock_response = webmock_responses.delete(request_signature)
-        response = build_httpclient_response(webmock_response, stream, &block)
+        response = build_httpclient_response(webmock_response, stream, req.header, &block)
         @request_filter.each do |filter|
           filter.filter_response(req, response)
         end
@@ -89,9 +89,9 @@ if defined?(::HTTPClient)
       end
     end
 
-    def build_httpclient_response(webmock_response, stream = false, &block)
+    def build_httpclient_response(webmock_response, stream = false, req_header = nil, &block)
       body = stream ? StringIO.new(webmock_response.body) : webmock_response.body
-      response = HTTP::Message.new_response(body)
+      response = HTTP::Message.new_response(body, req_header)
       response.header.init_response(webmock_response.status[0])
       response.reason=webmock_response.status[1]
       webmock_response.headers.to_a.each { |name, value| response.header.set(name, value) }

--- a/spec/acceptance/httpclient/httpclient_spec.rb
+++ b/spec/acceptance/httpclient/httpclient_spec.rb
@@ -152,4 +152,11 @@ describe "HTTPClient" do
 
   end
 
+  context 'httpclient response header' do
+    it 'receives request_method, request_uri, and request_query from the request header' do
+      stub_request :get, 'www.example.com'
+      message = HTTPClient.new.get 'www.example.com'
+      message.header.request_uri.to_s.should == 'www.example.com'
+    end
+  end
 end


### PR DESCRIPTION
As of [HTTPClient ed9c65c](https://github.com/nahi/httpclient/commit/ed9c65c440c7c03905e9df117d642c536ca92de9#diff-b39809a3be5ff11e15c4c772d6c6b2a8), HTTP::Message::Headers::init_response makes provision to transfer request_method, request_uri, and request_query from a request header to the response header, but the adapter isn't passing the request during build_httpclient_response; and so (e.g.) response.header.request_uri is always nil.
