### PR TITLE
Make repeated keys in queries act like array queries all the time

### DIFF
--- a/lib/webmock/util/query_mapper.rb
+++ b/lib/webmock/util/query_mapper.rb
@@ -162,7 +162,15 @@ module WebMock::Util
             current_node[last_key] = [] unless current_node[last_key]
             current_node[last_key] << value
           else
-            current_node[last_key] = value
+            if current_node.has_key?(last_key)
+              unless current_node[last_key].is_a?(Array)
+                current_node[last_key] = [current_node[last_key]]
+              end
+
+              current_node[last_key] << value
+            else
+              current_node[last_key] = value
+            end
           end
         end
       end

--- a/spec/unit/util/query_mapper_spec.rb
+++ b/spec/unit/util/query_mapper_spec.rb
@@ -34,6 +34,13 @@ describe WebMock::Util::QueryMapper do
       expect(hsh['one']).to eq(%w(foo bar))
     end
 
+    it 'should parse queries with repeated keys like array queries' do
+      # {"one" => ["foo", "bar"]}
+      query = 'one=foo&one=bar'
+      hsh = subject.query_to_values(query)
+      expect(hsh['one']).to eq(%w(foo bar))
+    end
+
     it 'should parse string queries' do
       # {"one" => "two", "three" => "four"}
       query = 'one=two&three=four'


### PR DESCRIPTION
Right now QueryMapper will normalize a query like:

`"abc=123&abc=456"` to `"abc=456"`

This means that if I interface with an API that expects
parameters passed that way, and I want to assert a_request to
have_been_made, I can't. The assertion will expect the form
`"abc=123&abc=456"`, but the captured request will be normalized to
`"abc=456"`.

This change simply makes the repetition of a key in the query turn that
particular parameter into an array, rather than writing over the
previous value.
