### PR TITLE
assert_requested & assert_not_requested at_least_times & at_most_times matchers

### DIFF
--- a/lib/webmock/api.rb
+++ b/lib/webmock/api.rb
@@ -65,12 +65,19 @@ module WebMock
     end
 
     def assert_request_requested(request, options = {})
-      verifier = WebMock::RequestExecutionVerifier.new(request, options.delete(:times) || 1)
+      times = options.delete(:times)
+      at_least_times = options.delete(:at_least_times)
+      at_most_times  = options.delete(:at_most_times)
+      times = 1 if times.nil? && at_least_times.nil? && at_most_times.nil?
+      verifier = WebMock::RequestExecutionVerifier.new(request, times, at_least_times, at_most_times)
       WebMock::AssertionFailure.failure(verifier.failure_message) unless verifier.matches?
     end
 
     def assert_request_not_requested(request, options = {})
-      verifier = WebMock::RequestExecutionVerifier.new(request, options.delete(:times))
+      times = options.delete(:times)
+      at_least_times = options.delete(:at_least_times)
+      at_most_times  = options.delete(:at_most_times)
+      verifier = WebMock::RequestExecutionVerifier.new(request, times, at_least_times, at_most_times)
       WebMock::AssertionFailure.failure(verifier.failure_message_when_negated) unless verifier.does_not_match?
     end
 


### PR DESCRIPTION
READY

I overlooked this bit in my pull request the other day. This allows for example:

```
  assert_requested :post, "http://localhost:1234/thumbnails", at_least_times: 25
```

which on a heavily javascript-driven page in an acceptance (Cucumber) test, I'm finding I need.
