### PR TITLE
Fix for httpclient 2.5.3+

### DIFF
--- a/lib/webmock/http_lib_adapters/httpclient_adapter.rb
+++ b/lib/webmock/http_lib_adapters/httpclient_adapter.rb
@@ -148,7 +148,12 @@ if defined?(::HTTPClient)
       hdrs[header[0]] << header[1]
       hdrs
     end
-    headers = headers_from_session(uri).merge(headers)
+    arg = if respond_to?(:default_header)
+            req # httpclient >=2.5.3
+          else
+            uri # httpclient <=2.5.2
+          end
+    headers = headers_from_session(arg).merge(headers)
 
     if (auth_cred = auth.get(req)) && auth.scheme == 'Basic'
       userinfo = WebMock::Util::Headers.decode_userinfo_from_header(auth_cred)


### PR DESCRIPTION
Checkout:
https://github.com/nahi/httpclient/compare/v2.5.2...v2.5.3#diff-9c128a1e92647c91c6efad47c0709bf7L198

In 2.5.2, it's taking the `uri`, but in 2.5.3, it's taking the `req`.
We could also detect by versions, but I chose to detect by if
`default_header` is defined here:
https://github.com/nahi/httpclient/compare/v2.5.2...v2.5.3#diff-2b61e1f08102d46865dd580cfa9bc88aR329

Either way should be fine, no strong opinions here.
(Detecting by method signature would be the best, but the arity
 is the same, and I am not sure how else we could detect)
