### PR TITLE
Ignore ArgumentError during sort of non-comparable values

### DIFF
--- a/lib/webmock/util/query_mapper.rb
+++ b/lib/webmock/util/query_mapper.rb
@@ -196,7 +196,11 @@ module WebMock::Util
           end
           # Useful default for OAuth and caching.
           # Only to be used for non-Array inputs. Arrays should preserve order.
-          new_query_values.sort!
+          begin
+            new_query_values.sort! # may raise for non-comparable values
+          rescue ArgumentError => e
+            # ignore
+          end
         end
 
         buffer = ''

--- a/spec/unit/util/query_mapper_spec.rb
+++ b/spec/unit/util/query_mapper_spec.rb
@@ -89,15 +89,22 @@ describe WebMock::Util::QueryMapper do
   end
 
   it 'converts array values, vice versa' do
-    query = "one%5B%5D=1&one%5B%5D=2"
+    query = "one%5B%5D=1&one%5B%5D=2" # one[]=1&one[]=2
     values = {"one" => ["1","2"]}
     expect(subject.values_to_query values).to eq query
     expect(subject.query_to_values query).to eq values
   end
 
   it 'converts hash values, vice versa' do
-    query = "one%5Ba%5D=1&one%5Bb%5D=2"
+    query = "one%5Ba%5D=1&one%5Bb%5D=2" # one[a]=1&one[b]=2
     values = {"one" => {"a" => "1", "b" => "2"}}
+    expect(subject.values_to_query values).to eq query
+    expect(subject.query_to_values query).to eq values
+  end
+
+  it 'converts complex nested values, vice versa' do
+    query = "one%5B%5D[foo]=bar&one%5B%5D[zoo]=car" # one[][foo]=bar&one[][zoo]=car
+    values = {"one" => [{"foo" => "bar"}, {"zoo" => "car"}]}
     expect(subject.values_to_query values).to eq query
     expect(subject.query_to_values query).to eq values
   end


### PR DESCRIPTION
Since the sort is optional anyways, it’s better to just continue.