### PR TITLE
Fix Json parse problem with multibyte characters

### DIFF
--- a/lib/webmock/util/json.rb
+++ b/lib/webmock/util/json.rb
@@ -42,10 +42,16 @@ module WebMock
           json.gsub(/\\\//, '/')
         else
           left_pos  = [-1].push(*marks)
-          right_pos = marks << json.length
+          right_pos = marks << json.bytesize
           output    = []
           left_pos.each_with_index do |left, i|
-            output << json[left.succ..right_pos[i]]
+            if json.respond_to?(:byteslice)
+              output << json.byteslice(left.succ..right_pos[i])
+            elsif (RUBY_VERSION >= "1.9" && RUBY_VERSION <= '1.9.2')
+              output << json.dup.force_encoding("binary").slice(left.succ..right_pos[i]).force_encoding(json.encoding)
+            else
+              output << json[left.succ..right_pos[i]]
+            end
           end
           output = output * " "
 

--- a/spec/unit/util/json_spec.rb
+++ b/spec/unit/util/json_spec.rb
@@ -1,7 +1,12 @@
+# encoding: utf-8
 require 'spec_helper'
 
 describe WebMock::Util::JSON do
   it "should parse json without parsing dates" do
     expect(WebMock::Util::JSON.parse("\"a\":\"2011-01-01\"")).to eq({"a" => "2011-01-01"})
+  end
+
+  it "can parse json with multibyte characters" do
+    expect(WebMock::Util::JSON.parse("{\"name\":\"山田太郎\"\,\"job\":\"会社員\"}")).to eq({"name" => "山田太郎", "job" => "会社員"})
   end
 end


### PR DESCRIPTION
When dealing with multibyte characters, sometimes inappropriate white spaces are inserted.
This PR fixes this.