### PR TITLE
Remove unnecessary @query_params.nil? check

### DIFF
--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -137,7 +137,7 @@ module WebMock
       else
         # WebMock checks the query, Addressable checks everything else
         WebMock::Util::URI.variations_of_uri_as_strings(uri.omit(:query)).any? { |u| @pattern.match(u) } &&
-        (@query_params.nil? || @query_params == WebMock::Util::QueryMapper.query_to_values(uri.query))
+          @query_params == WebMock::Util::QueryMapper.query_to_values(uri.query)
       end
     end
 


### PR DESCRIPTION
In this branch, we already know that @query_params is not nil. Looks like this was the result of a copy-pasta. :P