### PR TITLE
Detect presence of HTTP gem a little more cleanly.

### DIFF
--- a/lib/webmock/http_lib_adapters/http_gem_adapter.rb
+++ b/lib/webmock/http_lib_adapters/http_gem_adapter.rb
@@ -1,11 +1,10 @@
 begin
   require "http"
-  __http_gem_found__ = true
 rescue LoadError
-  __http_gem_found__ = false
+  # HTTP gem not found
 end
 
-if __http_gem_found__
+if defined?(HTTP) && defined?(HTTP::VERSION)
   WebMock::VersionChecker.new("HTTP Gem", HTTP::VERSION, "0.6.0").check_version!
 
   module WebMock


### PR DESCRIPTION
Currently the loaders assume that the http gem is there as long as "require 'http'" doesn't fail -- which doesn't work well for codebases with a file called "http".

This pull request resolves that by making the HTTP gem detection work more like how all the other detectors work.