### PR TITLE
Fix em_http_request adapter for correct timeout+request handling

### DIFF
--- a/lib/webmock/http_lib_adapters/em_http_request/em_http_request_1_x.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request/em_http_request_1_x.rb
@@ -70,6 +70,10 @@ if defined?(EventMachine::HttpClient)
           raise WebMock::NetConnectNotAllowedError.new(request_signature)
         end
       end
+
+      def drop_client
+        @clients.shift
+      end
     end
 
     class WebMockHttpClient < EventMachine::HttpClient
@@ -83,6 +87,7 @@ if defined?(EventMachine::HttpClient)
         @last_effective_url = @uri = uri
         if error
           on_error(error)
+          @conn.drop_client
           fail(self)
         else
           @conn.receive_data(response)


### PR DESCRIPTION
em-http-request allows you to send multiple requests on the same
EM::HTTPConnection object, which is mostly useful for pipelining.  If the
underlying TCP connection drops, it will be re-established if another
request is made on the same connection object.

In testing that a user of em-http-request correctly dealt with timeouts (by
retrying the request on the same connection object), it was discovered that
webmock does not correctly emulate the real-world behaviour of
em-http-request, and the parsed response data was being sent to the wrong
`EM::HTTPClient` instance.  This commit provides a failing test case (along
with a test case that succeeded already, to ensure the basic behaviour
continues to work in the future), along with a small change to the adapter
code to correctly handle the change in clients after a timeout.