### PR TITLE
show a hash diff for requests that have stubs with body set;

### DIFF
--- a/lib/webmock.rb
+++ b/lib/webmock.rb
@@ -28,6 +28,8 @@ require 'webmock/response'
 require 'webmock/rack_response'
 
 require 'webmock/stub_request_snippet'
+require 'webmock/request_signature_snippet'
+require 'webmock/request_body_diff'
 
 require 'webmock/assertion_failure'
 require 'webmock/request_execution_verifier'

--- a/lib/webmock/config.rb
+++ b/lib/webmock/config.rb
@@ -4,6 +4,7 @@ module WebMock
 
     def initialize
       @show_stubbing_instructions = true
+      @show_body_diff = true
     end
 
     attr_accessor :allow_net_connect
@@ -12,5 +13,6 @@ module WebMock
     attr_accessor :net_http_connect_on_start
     attr_accessor :show_stubbing_instructions
     attr_accessor :query_values_notation
+    attr_accessor :show_body_diff
   end
 end

--- a/lib/webmock/errors.rb
+++ b/lib/webmock/errors.rb
@@ -2,34 +2,16 @@ module WebMock
 
   class NetConnectNotAllowedError < Exception
     def initialize(request_signature)
+      request_signature_snippet = RequestSignatureSnippet.new(request_signature)
       text = [
         "Real HTTP connections are disabled. Unregistered request: #{request_signature}",
-        stubbing_instructions(request_signature),
-        request_stubs,
+        request_signature_snippet.stubbing_instructions,
+        request_signature_snippet.request_stubs,
         "="*60
       ].compact.join("\n\n")
       super(text)
     end
 
-    private
-
-    def request_stubs
-      return if WebMock::StubRegistry.instance.request_stubs.empty?
-      text = "registered request stubs:\n"
-      WebMock::StubRegistry.instance.request_stubs.each do |stub|
-        text << "\n#{WebMock::StubRequestSnippet.new(stub).to_s(false)}"
-      end
-      text
-    end
-
-    def stubbing_instructions(request_signature)
-      return unless WebMock.show_stubbing_instructions?
-      text = ""
-      request_stub = RequestStub.from_request_signature(request_signature)
-      text << "You can stub this request with the following snippet:\n\n"
-      text << WebMock::StubRequestSnippet.new(request_stub).to_s
-      text
-    end
   end
 
 end

--- a/lib/webmock/request_body_diff.rb
+++ b/lib/webmock/request_body_diff.rb
@@ -1,0 +1,60 @@
+require "hashdiff"
+require "JSON"
+
+module WebMock
+ class RequestBodyDiff
+
+  def initialize(request_signature, request_stub)
+    @request_signature = request_signature
+    @request_stub = request_stub
+    @body_pattern = nil
+    @body_pattern_hash = nil
+  end
+
+  def body_diff
+    request_pattern = @request_stub.request_pattern
+    return {} unless request_pattern
+    @body_pattern = request_pattern.body_pattern
+    return {} unless @body_pattern
+    return {} unless body_pattern_diffable?
+    @body_pattern_hash = @body_pattern.pattern
+    HashDiff.diff(request_signature_body_hash, stub_body_hash)
+  end
+
+  private
+
+  def body_pattern_diffable?
+    @body_pattern.pattern.is_a?(Hash) || body_pattern_parseable_as_json?
+  end
+
+  def body_pattern_parseable_as_json?
+    return false unless @body_pattern.pattern.is_a?(String)
+    begin
+      JSON.parse(@body_pattern.pattern)
+      true
+    rescue JSON::ParserError
+      false
+    end
+  end
+
+  def stub_body_hash
+    case @body_pattern_hash
+      when Hash
+        @body_pattern_hash
+      when String
+        JSON.parse(@body_pattern_hash)
+      else
+        raise "Don't know how to handle body pattern #{@body_pattern_hash.inspect}"
+    end
+  end
+
+  def request_signature_body_hash
+    case @request_signature.headers["Content-Type"]
+      when "application/json"
+        JSON.parse(@request_signature.body)
+      else
+        {}
+    end
+  end
+ end
+end

--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -200,6 +200,8 @@ module WebMock
       'text/plain'             => :plain
     }
 
+    attr_reader :pattern
+
     def initialize(pattern)
       @pattern = if pattern.is_a?(Hash)
         normalize_hash(pattern)

--- a/lib/webmock/request_signature_snippet.rb
+++ b/lib/webmock/request_signature_snippet.rb
@@ -1,0 +1,64 @@
+require "pp"
+module WebMock
+  class RequestSignatureSnippet
+
+    attr_reader :request_signature, :request_stub
+
+    def initialize(request_signature)
+      @request_signature = request_signature
+      @request_stub = create_request_stub
+    end
+
+    def stubbing_instructions
+      return unless WebMock.show_stubbing_instructions?
+      text = ""
+      text << "You can stub this request with the following snippet:\n\n"
+      text << WebMock::StubRequestSnippet.new(request_stub).to_s
+      text
+    end
+
+
+    def signature_stub_body_diff(stub)
+      diff = RequestBodyDiff.new(request_signature, stub).body_diff
+      diff.empty? ? "" : "Body diff:\n #{pretty_print_to_string(diff)}"
+    end
+
+    def request_params
+      @request_params ||= case request_signature.headers["Content-Type"]
+        when "application/json"
+          JSON.parse(request_signature.body)
+        else
+          ""
+      end
+    end
+
+    def request_stubs
+      return if WebMock::StubRegistry.instance.request_stubs.empty?
+      text = "registered request stubs:\n"
+      WebMock::StubRegistry.instance.request_stubs.each do |stub|
+        text << "\n#{WebMock::StubRequestSnippet.new(stub).to_s(false)}"
+        if WebMock.show_body_diff?
+          body_diff_str = signature_stub_body_diff(stub)
+          text << "\n\n#{body_diff_str}" if !body_diff_str.empty?
+        end
+      end
+      text
+    end
+
+
+    private
+
+    def create_request_stub
+      RequestStub.from_request_signature(request_signature)
+    end
+
+    def pretty_print_to_string(string_to_print)
+      StringIO.open("") do |stream|
+        PP.pp(string_to_print, stream)
+        stream.rewind
+        stream.read
+      end
+    end
+
+  end
+end

--- a/lib/webmock/stub_request_snippet.rb
+++ b/lib/webmock/stub_request_snippet.rb
@@ -4,6 +4,10 @@ module WebMock
       @request_stub = request_stub
     end
 
+    def body_pattern
+      request_pattern.body_pattern
+    end
+
     def to_s(with_response = true)
       request_pattern = @request_stub.request_pattern
       string = "stub_request(:#{request_pattern.method_pattern.to_s},"

--- a/lib/webmock/webmock.rb
+++ b/lib/webmock/webmock.rb
@@ -75,6 +75,18 @@ module WebMock
     end
   end
 
+  def self.show_body_diff!
+    Config.instance.show_body_diff = true
+  end
+
+  def self.hide_body_diff!
+    Config.instance.show_body_diff = false
+  end
+
+  def self.show_body_diff?
+    Config.instance.show_body_diff
+  end
+
   def self.hide_stubbing_instructions!
     Config.instance.show_stubbing_instructions = false
   end

--- a/spec/unit/errors_spec.rb
+++ b/spec/unit/errors_spec.rb
@@ -21,6 +21,7 @@ describe "errors" do
         allow(WebMock::RequestStub).to receive(:from_request_signature).and_return(request_stub)
         allow(WebMock::StubRequestSnippet).to receive(:new).
            with(request_stub).and_return(stub_result)
+        allow_any_instance_of(WebMock::RequestBodyDiff).to receive(:body_diff).and_return({})
 
         expected =  \
           "Real HTTP connections are disabled. Unregistered request: #{request_signature}" \
@@ -48,6 +49,44 @@ describe "errors" do
         end.to raise_exception exception
       end
 
+      it "should print body diff if available" do
+        allow(WebMock::StubRegistry.instance).to receive(:request_stubs).and_return([request_stub])
+        allow(WebMock::RequestStub).to receive(:from_request_signature).and_return(request_stub)
+        allow(WebMock::StubRequestSnippet).to receive(:new).
+           with(request_stub).and_return(stub_result)
+        allow_any_instance_of(WebMock::RequestBodyDiff).to receive(:body_diff).and_return(body_diff)
+        expected =  \
+          "Real HTTP connections are disabled. Unregistered request: #{request_signature}" \
+          "\n\nYou can stub this request with the following snippet:" \
+          "\n\n#{stub_result}" \
+          "\n\nregistered request stubs:" \
+          "\n\n#{stub_result}" \
+          "\n\nBody diff:\n [[\"+\", \"test\", \"test2\"], [\"-\", \"test3\"], [\"~\", \"test5\", \"test6\"]]" \
+          "\n\n\n============================================================"
+        expect(WebMock::NetConnectNotAllowedError.new(request_signature).message).to eq(expected)
+      end
+
+      context "WebMock.show_body_diff? is false" do
+        before do
+          WebMock.hide_body_diff!
+        end
+        it "should not show body diff" do
+          allow(WebMock::StubRegistry.instance).to receive(:request_stubs).and_return([request_stub])
+          allow(WebMock::RequestStub).to receive(:from_request_signature).and_return(request_stub)
+          allow(WebMock::StubRequestSnippet).to receive(:new).
+             with(request_stub).and_return(stub_result)
+          expect_any_instance_of(WebMock::RequestBodyDiff).to_not receive(:body_diff)
+          expected =  \
+            "Real HTTP connections are disabled. Unregistered request: #{request_signature}" \
+            "\n\nYou can stub this request with the following snippet:" \
+            "\n\n#{stub_result}" \
+            "\n\nregistered request stubs:" \
+            "\n\n#{stub_result}" \
+            "\n\n============================================================"
+          expect(WebMock::NetConnectNotAllowedError.new(request_signature).message).to eq(expected)
+        end
+      end
+
       context "WebMock.show_stubbing_instructions? is false" do
         before do
           WebMock.hide_stubbing_instructions!
@@ -69,6 +108,7 @@ describe "errors" do
           allow(WebMock::RequestStub).to receive(:from_request_signature).and_return(request_stub)
           allow(WebMock::StubRequestSnippet).to receive(:new).
             with(request_stub).and_return(stub_result)
+          allow(request_stub).to receive(:request_pattern).and_return(body_pattern)
 
           expected =  \
             "Real HTTP connections are disabled. Unregistered request: #{request_signature}" \
@@ -80,9 +120,10 @@ describe "errors" do
       end
     end
 
-    let(:request_signature) { double(:to_s => rand(10**20).to_s) }
-    let(:stub_result)       { double(:to_s => rand(10**20).to_s) }
-    let(:request_stub)      { double }
-
+    let(:request_signature) { double(:request_signature, :to_s => rand(10**20).to_s) }
+    let(:stub_result)       { double(:stub_result, :to_s => rand(10**20).to_s) }
+    let(:request_stub)      { double(:request_stub) }
+    let(:body_pattern)      { double(:body_pattern, :body_pattern => nil)}
+    let(:body_diff)         { [["+", "test", "test2"], ["-", "test3"], ["~", "test5", "test6"]] }
   end
 end

--- a/webmock.gemspec
+++ b/webmock.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'addressable', '>= 2.3.6'
   s.add_dependency 'crack', '>=0.3.2'
+  s.add_dependency 'hashdiff'
 
   patron_version = (RUBY_VERSION <= '1.8.7') ? '0.4.18' : '>= 0.4.18'
 


### PR DESCRIPTION
I am an avid user of Webmock and I use it in specs to stub requests specifying body as a JSON string, like this:
```ruby
stub_request(:post, url).
         with(:body => '{"request":"something","reference":"REF123","store_data":"true","email":"testme@test.com","test":"test2","test3":"test4"}',
              :headers => headers)
```
If I don't get it right and send a request with a different body, Webmock produces an error messages along the lines of:

WebMock::NetConnectNotAllowedError:
Real HTTP connections are disabled. Unregistered request: POST http://example.com with body '{"request":"something","reference":"REF-123","store_data":"true","email":"testme@test.com","test2":"test","test4":"test5"}'
registered request stubs:

```ruby
stub_request(:post, url).
         with(:body => '{"request":"something","reference":"REF123","store_data":"true","email":"testme@test.com","test":"test2","test3":"test4", }',
````

And then I have to manually compare both strings to find out that I haven't provided the "test" key and used "test2" instead. 
In my case bodies are much longer and comparing them takes a while and is very error-prone.
With this PR, webmock will include the body diff obtained via [hashdiff](https://github.com/liufengyun/hashdiff)  for each registered stub like this:

Body diff:
        [["-", "test", "test2"], ["+", "test4", "test5"]] 

So you clearly see that your request didn't have the "test" key with "test2" value but did have "test4" with "test5" on top.
This makes it much simpler to find what's missing or wrong.