### PR TITLE
Fix exception raised when keys are symbols

### DIFF
--- a/lib/webmock/util/query_mapper.rb
+++ b/lib/webmock/util/query_mapper.rb
@@ -241,7 +241,7 @@ module WebMock::Util
         when ::Hash
           value = value.map do |key, val|
             [
-              ::Addressable::URI.encode_component(key.dup, ::Addressable::URI::CharacterClasses::UNRESERVED),
+              ::Addressable::URI.encode_component(key.to_s.dup, ::Addressable::URI::CharacterClasses::UNRESERVED),
               val
             ]
           end

--- a/spec/unit/util/query_mapper_spec.rb
+++ b/spec/unit/util/query_mapper_spec.rb
@@ -60,6 +60,9 @@ describe WebMock::Util::QueryMapper do
     it 'should transform hash value' do
       expect(subject.to_query('a', {'key' => 'value'})).to eq('a[key]=value')
     end
+    it 'should transform hash value with keys that are symbols' do
+      expect(subject.to_query('a', {:key => 'value'})).to eq('a[key]=value')
+    end
     it 'should transform array value' do
       expect(subject.to_query('a', ['b', 'c'])).to eq('a[0]=b&a[1]=c')
     end


### PR DESCRIPTION
When symbols are keys, `QueryMapper#to_query` blows up with `TypeError: can't dup Symbol`.