### PR TITLE
Turn off sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ matrix:
     - rvm: jruby-18mode
     - rvm: jruby-head
     - rvm: ruby-head
+sudo: false


### PR DESCRIPTION
Travis's new container-based infrastructure requires you to explicitly turn off `sudo`. No commands in this build use it, so compliance is as simple as specifying `sudo: false` in .travis.yml