### PR TITLE
Add rspec matcher descriptions

### DIFF
--- a/lib/webmock/request_execution_verifier.rb
+++ b/lib/webmock/request_execution_verifier.rb
@@ -33,6 +33,9 @@ module WebMock
       end
     end
 
+    def description
+      "request #{request_pattern.to_s} #{quantity_phrase.strip}"
+    end
 
     def failure_message
       failure_message_phrase(is_negated=false)

--- a/lib/webmock/request_execution_verifier.rb
+++ b/lib/webmock/request_execution_verifier.rb
@@ -35,30 +35,11 @@ module WebMock
 
 
     def failure_message
-      expected_times_executed = @expected_times_executed || 1
-      text = if @at_least_times_executed
-        %Q(The request #{request_pattern.to_s} was expected to execute at least #{times(@at_least_times_executed)} but it executed #{times(times_executed)})
-      elsif @at_most_times_executed
-        %Q(The request #{request_pattern.to_s} was expected to execute at most #{times(@at_most_times_executed)} but it executed #{times(times_executed)})
-      else
-        %Q(The request #{request_pattern.to_s} was expected to execute #{times(expected_times_executed)} but it executed #{times(times_executed)})
-      end
-      text << self.class.executed_requests_message
-      text
+      failure_message_phrase(is_negated=false)
     end
 
     def failure_message_when_negated
-      text = if @at_least_times_executed
-        %Q(The request #{request_pattern.to_s} was not expected to execute at least #{times(@at_least_times_executed)} but it executed #{times(times_executed)})
-      elsif @at_most_times_executed
-        %Q(The request #{request_pattern.to_s} was not expected to execute at most #{times(@at_most_times_executed)} but it executed #{times(times_executed)})
-      elsif @expected_times_executed
-        %Q(The request #{request_pattern.to_s} was not expected to execute #{times(expected_times_executed)} but it executed #{times(times_executed)})
-      else
-        %Q(The request #{request_pattern.to_s} was expected to execute 0 times but it executed #{times(times_executed)})
-      end
-      text << self.class.executed_requests_message
-      text
+      failure_message_phrase(is_negated=true)
     end
 
     def self.executed_requests_message
@@ -66,6 +47,25 @@ module WebMock
     end
 
     private
+
+    def failure_message_phrase(is_negated=false)
+      negation = is_negated ? "was not" : "was"
+      text = "The request #{request_pattern.to_s} #{negation} expected to execute #{quantity_phrase(is_negated)}but it executed #{times(times_executed)}"
+      text << self.class.executed_requests_message
+      text
+    end
+
+    def quantity_phrase(is_negated=false)
+      if @at_least_times_executed
+        "at least #{times(@at_least_times_executed)} "
+      elsif @at_most_times_executed
+        "at most #{times(@at_most_times_executed)} "
+      elsif @expected_times_executed
+        "#{times(@expected_times_executed)} "
+      else
+        is_negated ? "" : "#{times(1)} "
+      end
+    end
 
     def times(times)
       "#{times} time#{ (times == 1) ? '' : 's'}"

--- a/lib/webmock/rspec/matchers/request_pattern_matcher.rb
+++ b/lib/webmock/rspec/matchers/request_pattern_matcher.rb
@@ -68,6 +68,10 @@ module WebMock
       @request_execution_verifier.failure_message_when_negated
     end
 
+    def description
+      @request_execution_verifier.description
+    end
+
     # RSpec 2 compatibility:
     alias_method :negative_failure_message, :failure_message_when_negated
   end

--- a/lib/webmock/rspec/matchers/webmock_matcher.rb
+++ b/lib/webmock/rspec/matchers/webmock_matcher.rb
@@ -42,6 +42,10 @@ module WebMock
       @request_execution_verifier.failure_message_when_negated
     end
 
+    def description
+      @request_execution_verifier.description
+    end
+
     # RSpec 2 compatibility:
     alias_method :negative_failure_message, :failure_message_when_negated
   end

--- a/spec/acceptance/shared/request_expectations.rb
+++ b/spec/acceptance/shared/request_expectations.rb
@@ -31,7 +31,7 @@ shared_context "request expectations" do |*adapter_info|
         expect {
           http_request(:get, "http://www.example.com/")
           expect(a_request(:get, "http://www.example.com")).not_to have_been_made
-        }.to fail_with(%r(The request GET http://www.example.com/ was expected to execute 0 times but it executed 1 time))
+        }.to fail_with(%r(The request GET http://www.example.com/ was not expected to execute but it executed 1 time))
       end
 
       it "should fail resulting with failure with a message and executed requests listed" do
@@ -626,7 +626,7 @@ shared_context "request expectations" do |*adapter_info|
           expect {
             http_request(:post, "http://www.example.com/", :body => "wadus")
             expect(a_request(:post, "www.example.com").with { |req| req.body == "wadus" }).not_to have_been_made
-          }.to fail_with(%r(The request POST http://www.example.com/ with given block was expected to execute 0 times but it executed 1 time))
+          }.to fail_with(%r(The request POST http://www.example.com/ with given block was not expected to execute but it executed 1 time))
         end
       end
 
@@ -692,7 +692,7 @@ shared_context "request expectations" do |*adapter_info|
           expect {
             http_request(:get, "http://www.example.com/")
             expect(WebMock).not_to have_requested(:get, "http://www.example.com")
-          }.to fail_with(%r(The request GET http://www.example.com/ was expected to execute 0 times but it executed 1 time))
+          }.to fail_with(%r(The request GET http://www.example.com/ was not expected to execute but it executed 1 time))
         end
 
         it "should satisfy expectation if request was executed and expectation had block which evaluated to true" do
@@ -713,7 +713,7 @@ shared_context "request expectations" do |*adapter_info|
           expect {
             http_request(:post, "http://www.example.com/", :body => "wadus")
             expect(WebMock).not_to have_requested(:post, "www.example.com").with { |req| req.body == "wadus" }
-          }.to fail_with(%r(The request POST http://www.example.com/ with given block was expected to execute 0 times but it executed 1 time))
+          }.to fail_with(%r(The request POST http://www.example.com/ with given block was not expected to execute but it executed 1 time))
         end
       end
 
@@ -737,14 +737,14 @@ shared_context "request expectations" do |*adapter_info|
           expect {
             http_request(:get, "http://www.example.com/")
             assert_not_requested(:get, "http://www.example.com")
-          }.to fail_with(%r(The request GET http://www.example.com/ was expected to execute 0 times but it executed 1 time))
+          }.to fail_with(%r(The request GET http://www.example.com/ was not expected to execute but it executed 1 time))
         end
 
         it "should fail if request expected not to be made was made and expectation block evaluated to true" do
           expect {
             http_request(:post, "http://www.example.com/", :body => "wadus")
             assert_not_requested(:post, "www.example.com") { |req| req.body == "wadus" }
-          }.to fail_with(%r(The request POST http://www.example.com/ with given block was expected to execute 0 times but it executed 1 time))
+          }.to fail_with(%r(The request POST http://www.example.com/ with given block was not expected to execute but it executed 1 time))
         end
 
         it "should satisfy expectation if request was made and expectation block evaluated to true" do
@@ -777,7 +777,7 @@ shared_context "request expectations" do |*adapter_info|
           expect {
             http_request(:get, "http://www.example.com/")
             assert_not_requested(stub_http)
-          }.to fail_with(%r(The request GET http://www.example.com/ was expected to execute 0 times but it executed 1 time))
+          }.to fail_with(%r(The request GET http://www.example.com/ was not expected to execute but it executed 1 time))
         end
       end
     end
@@ -809,7 +809,7 @@ shared_context "request expectations" do |*adapter_info|
           stub = stub_request(:get, "http://www.example.com")
           http_request(:get, "http://www.example.com/")
           expect(stub).not_to have_been_requested
-        }.to fail_with(%r(The request GET http://www.example.com/ was expected to execute 0 times but it executed 1 time))
+        }.to fail_with(%r(The request GET http://www.example.com/ was not expected to execute but it executed 1 time))
       end
 
       it "should fail request not expected to be made was made and expectation block evaluated to true" do
@@ -817,7 +817,7 @@ shared_context "request expectations" do |*adapter_info|
           stub = stub_request(:post, "www.example.com").with { |req| req.body == "wadus" }
           http_request(:post, "http://www.example.com/", :body => "wadus")
           expect(stub).not_to have_been_requested
-        }.to fail_with(%r(The request POST http://www.example.com/ with given block was expected to execute 0 times but it executed 1 time))
+        }.to fail_with(%r(The request POST http://www.example.com/ with given block was not expected to execute but it executed 1 time))
       end
 
       it "should satisfy expectation if request was made and expectation block evaluated to true" do
@@ -852,7 +852,7 @@ shared_context "request expectations" do |*adapter_info|
         expect {
           http_request(:get, "http://www.example.com/")
           expect(a_request(:get, "http://www.example.com")).not_to have_been_made
-        }.to fail_with(%r(The request GET http://www.example.com/ was expected to execute 0 times but it executed 1 time))
+        }.to fail_with(%r(The request GET http://www.example.com/ was not expected to execute but it executed 1 time))
       end
     end
   end

--- a/spec/unit/request_execution_verifier_spec.rb
+++ b/spec/unit/request_execution_verifier_spec.rb
@@ -77,7 +77,7 @@ describe WebMock::RequestExecutionVerifier do
 
     it "should report failure message when not expected request but it executed" do
       @verifier.times_executed = 1
-      expected_text = "The request www.example.com was expected to execute 0 times but it executed 1 time"
+      expected_text = "The request www.example.com was not expected to execute but it executed 1 time"
       expected_text << @executed_requests_info
       expect(@verifier.failure_message_when_negated).to eq(expected_text)
     end

--- a/spec/unit/request_execution_verifier_spec.rb
+++ b/spec/unit/request_execution_verifier_spec.rb
@@ -9,6 +9,43 @@ describe WebMock::RequestExecutionVerifier do
     @executed_requests_info = "\n\nThe following requests were made:\n\nexecuted requests\n" + "="*60
   end
 
+  describe "description" do
+
+    it "should report description" do
+      @verifier.expected_times_executed = 2
+      expect(@verifier.description).to eq "request www.example.com 2 times"
+    end
+
+    it "should report description correctly when expectation is 1 time" do
+      @verifier.expected_times_executed = 1
+      expect(@verifier.description).to eq "request www.example.com 1 time"
+    end
+
+    context "at_least_times_executed is set" do
+      it "reports description correctly when expectation at least 2 times" do
+        @verifier.at_least_times_executed = 2
+        expect(@verifier.description).to eq "request www.example.com at least 2 times"
+      end
+
+      it "reports description correctly when expectation is at least 3 times" do
+        @verifier.at_least_times_executed = 3
+        expect(@verifier.description).to eq "request www.example.com at least 3 times"
+      end
+    end
+
+    context "at_most_times_executed is set" do
+      it "reports description correctly when expectation is at most 2 times" do
+        @verifier.at_most_times_executed = 2
+        expect(@verifier.description).to eq "request www.example.com at most 2 times"
+      end
+
+      it "reports description correctly when expectation is at most 1 time" do
+        @verifier.at_most_times_executed = 1
+        expect(@verifier.description).to eq "request www.example.com at most 1 time"
+      end
+    end
+
+  end
 
   describe "failure message" do
 

--- a/test/shared_test.rb
+++ b/test/shared_test.rb
@@ -71,7 +71,7 @@ module SharedTest
   end
 
   def test_verification_that_non_expected_request_didnt_occur
-    expected_message = %r(The request GET http://www.example.com/ was expected to execute 0 times but it executed 1 time\n\nThe following requests were made:\n\nGET http://www.example.com/ with headers .+ was made 1 time\n\n============================================================)
+    expected_message = %r(The request GET http://www.example.com/ was not expected to execute but it executed 1 time\n\nThe following requests were made:\n\nGET http://www.example.com/ with headers .+ was made 1 time\n\n============================================================)
     assert_fail(expected_message) do
       http_request(:get, "http://www.example.com/")
       assert_not_requested(:get, "http://www.example.com")
@@ -79,7 +79,7 @@ module SharedTest
   end
 
   def test_verification_that_non_expected_stub_didnt_occur
-    expected_message = %r(The request ANY http://www.example.com/ was expected to execute 0 times but it executed 1 time\n\nThe following requests were made:\n\nGET http://www.example.com/ with headers .+ was made 1 time\n\n============================================================)
+    expected_message = %r(The request ANY http://www.example.com/ was not expected to execute but it executed 1 time\n\nThe following requests were made:\n\nGET http://www.example.com/ with headers .+ was made 1 time\n\n============================================================)
     assert_fail(expected_message) do
       http_request(:get, "http://www.example.com/")
       assert_not_requested(@stub_http)


### PR DESCRIPTION
PR for Issue https://github.com/bblimke/webmock/issues/501

- refactor generation of `#failure_message` and `#failure_message_when_negated`
- add `#description` method for use in rspec matchers