### PR TITLE
Add manticore adapter

### DIFF
--- a/lib/webmock.rb
+++ b/lib/webmock.rb
@@ -47,6 +47,7 @@ require 'webmock/http_lib_adapters/curb_adapter'
 require 'webmock/http_lib_adapters/em_http_request_adapter'
 require 'webmock/http_lib_adapters/typhoeus_hydra_adapter'
 require 'webmock/http_lib_adapters/excon_adapter'
+require 'webmock/http_lib_adapters/manticore_adapter'
 
 require 'webmock/webmock'
 

--- a/lib/webmock/http_lib_adapters/manticore_adapter.rb
+++ b/lib/webmock/http_lib_adapters/manticore_adapter.rb
@@ -1,0 +1,104 @@
+begin
+  require 'manticore'
+rescue LoadError
+  # manticore not found
+end
+
+if defined?(Manticore)
+  module WebMock
+    module HttpLibAdapters
+      class ManticoreAdapter < HttpLibAdapter
+        adapter_for :manticore
+
+        OriginalManticoreClient = Manticore::Client
+
+        def self.enable!
+          Manticore.send(:remove_const, :Client)
+          Manticore.send(:const_set, :Client, WebMockManticoreClient)
+        end
+
+        def self.disable!
+          Manticore.send(:remove_const, :Client)
+          Manticore.send(:const_set, :Client, OriginalManticoreClient)
+        end
+
+        class WebMockManticoreClient < Manticore::Client
+          def http(method, uri, options = {})
+            @method = method
+            @uri = uri
+            @options = options
+            super(method, WebMock::Util::URI.normalize_uri(uri).to_s, format_options(options))
+          end
+
+          private
+
+          def format_options(options)
+            return options unless headers = options[:headers]
+
+            options.merge(:headers => join_array_values(headers))
+          end
+
+          def join_array_values(headers)
+            headers.reduce({}) do |h, (k,v)|
+              v = v.join(', ') if v.is_a?(Array)
+              h.merge(k => v)
+            end
+          end
+
+          def response_object_for(client, request, context, &block)
+            request_signature = generate_webmock_request_signature
+            WebMock::RequestRegistry.instance.requested_signatures.put(request_signature)
+
+            if webmock_response = registered_response_for(request_signature)
+              webmock_response.raise_error_if_any
+              manticore_response = generate_manticore_response(webmock_response).call
+              real_request = false
+
+            elsif real_request_allowed?(request_signature.uri)
+              manticore_response = Manticore::Response.new(client, request, context, &block).call
+              webmock_response = generate_webmock_response(manticore_response)
+              real_request = true
+
+            else
+              raise WebMock::NetConnectNotAllowedError.new(request_signature)
+            end
+
+            WebMock::CallbackRegistry.invoke_callbacks({:lib => :manticore, :real_request => real_request}, request_signature, webmock_response)
+            manticore_response
+          end
+
+          def registered_response_for(request_signature)
+            WebMock::StubRegistry.instance.response_for_request(request_signature)
+          end
+
+          def real_request_allowed?(uri)
+            WebMock.net_connect_allowed?(uri)
+          end
+
+          def generate_webmock_request_signature
+            WebMock::RequestSignature.new(@method, @uri, {:body => @options[:body], :headers => @options[:headers]})
+          end
+
+          def generate_manticore_response(webmock_response)
+            raise Manticore::ConnectTimeout if webmock_response.should_timeout
+
+            Manticore::StubbedResponse.stub(
+              :code => webmock_response.status[0],
+              :body => webmock_response.body,
+              :headers => webmock_response.headers,
+              :cookies => {}
+            )
+          end
+
+          def generate_webmock_response(manticore_response)
+            webmock_response = WebMock::Response.new
+            webmock_response.status = [manticore_response.code, manticore_response.message]
+            webmock_response.body = manticore_response.body
+            webmock_response.headers = manticore_response.headers
+            webmock_response
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/manticore/manticore_spec.rb
+++ b/spec/acceptance/manticore/manticore_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+require 'acceptance/webmock_shared'
+require 'acceptance/manticore/manticore_spec_helper'
+
+describe "Manticore" do
+  include ManticoreSpecHelper
+
+  include_context "with WebMock", :no_status_message
+end

--- a/spec/acceptance/manticore/manticore_spec.rb
+++ b/spec/acceptance/manticore/manticore_spec.rb
@@ -8,5 +8,49 @@ if RUBY_PLATFORM =~ /java/
     include ManticoreSpecHelper
 
     include_context "with WebMock", :no_status_message
+
+    context "calling http methods on Manticore directly using Manticore's facade" do
+      it "handles GET" do
+        stub_request(:get, "http://example-foo.com").to_return(:status => 301)
+        response = Manticore.get("http://example-foo.com")
+        expect(response.code).to eq(301)
+      end
+
+      it "handles POST" do
+        stub_request(:post, "http://example-foo.com").to_return(:status => 201)
+        response = Manticore.post("http://example-foo.com", {hello: "world"})
+        expect(response.code).to eq(201)
+      end
+
+      it "handles PUT" do
+        stub_request(:put, "http://example-foo.com").to_return(:status => 409)
+        response = Manticore.put("http://example-foo.com", {hello: "world"})
+        expect(response.code).to eq(409)
+      end
+
+      it "handles PATCH" do
+        stub_request(:patch, "http://example-foo.com").to_return(:status => 409)
+        response = Manticore.patch("http://example-foo.com", {hello: "world"})
+        expect(response.code).to eq(409)
+      end
+
+      it "handles DELETE" do
+        stub_request(:delete, "http://example-foo.com").to_return(:status => 204)
+        response = Manticore.delete("http://example-foo.com", {id: 1})
+        expect(response.code).to eq(204)
+      end
+
+      it "handles OPTIONS" do
+        stub_request(:options, "http://example-foo.com").to_return(:status => 200)
+        response = Manticore.options("http://example-foo.com")
+        expect(response.code).to eq(200)
+      end
+
+      it "handles HEAD" do
+        stub_request(:head, "http://example-foo.com").to_return(:status => 204)
+        response = Manticore.head("http://example-foo.com")
+        expect(response.code).to eq(204)
+      end
+    end
   end
 end

--- a/spec/acceptance/manticore/manticore_spec.rb
+++ b/spec/acceptance/manticore/manticore_spec.rb
@@ -1,9 +1,12 @@
 require 'spec_helper'
 require 'acceptance/webmock_shared'
-require 'acceptance/manticore/manticore_spec_helper'
 
-describe "Manticore" do
-  include ManticoreSpecHelper
+if RUBY_PLATFORM =~ /java/
+  require 'acceptance/manticore/manticore_spec_helper'
 
-  include_context "with WebMock", :no_status_message
+  describe "Manticore" do
+    include ManticoreSpecHelper
+
+    include_context "with WebMock", :no_status_message
+  end
 end

--- a/spec/acceptance/manticore/manticore_spec_helper.rb
+++ b/spec/acceptance/manticore/manticore_spec_helper.rb
@@ -1,0 +1,31 @@
+module ManticoreSpecHelper
+  def http_request(method, uri, options = {})
+    client = Manticore::Client.new
+    response = client.http(method, uri, options)
+
+    OpenStruct.new({
+      :body => response.body || '',
+      :headers => WebMock::Util::Headers.normalize_headers(join_array_values(response.headers)),
+      :status => response.code.to_s
+    })
+  end
+
+  def join_array_values(hash)
+    hash.reduce({}) do |h, (k,v)|
+      v = v.join(', ') if v.is_a?(Array)
+      h.merge(k => v)
+    end
+  end
+
+  def client_timeout_exception_class
+    Manticore::ConnectTimeout
+  end
+
+  def connection_refused_exception_class
+    Manticore::SocketException
+  end
+
+  def http_library
+    :manticore
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,9 @@ unless RUBY_PLATFORM =~ /java/
   require 'em-http'
   require 'typhoeus'
 end
+if RUBY_PLATFORM =~ /java/
+  require 'manticore'
+end
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))

--- a/webmock.gemspec
+++ b/webmock.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'em-synchrony',    '>= 1.0.0' if RUBY_VERSION >= "1.9"
   s.add_development_dependency 'curb',            '<= 0.8.6' unless RUBY_PLATFORM =~ /java/
   s.add_development_dependency 'typhoeus',        '>= 0.5.0' unless RUBY_PLATFORM =~ /java/
+  s.add_development_dependency 'manticore',       '>= 0.4.4' if RUBY_PLATFORM =~ /java/
   s.add_development_dependency 'excon',           '>= 0.27.5'
   s.add_development_dependency 'minitest',        '~> 5.0.0'
   s.add_development_dependency 'rdoc',            ((RUBY_VERSION == '1.8.6') ? '<= 3.5.0' : '>3.5.0')


### PR DESCRIPTION
Adds an adapter for [Manticore](https://github.com/cheald/manticore), addressing #454.

I don't know if there is any functionality unique to Manticore that warrants additional tests beyond the shared "with WebMock" suite. @cheald, any thoughts?

Manticore specs pass locally on JRuby 1.7.8 and JRuby 9.0.0.0. Running the full suite on both JRuby versions yields 36 failing http_rb_adapter specs (this is also the case on master branch).

I noticed that each adapter's spec_helper is handling array values in headers in unique but similar ways. I think a helper could be added to `WebMock::Util::Headers` to address this duplication. However, rather than add that and refactor across libraries now, I figured it'd be better to keep this PR focused exclusively on Manticore. (I bring this up because this PR adds duplicate `join_array_values` methods in the adapter and spec_helper.)