### PR TITLE
[WIP] Fix specs

### DIFF
--- a/spec/acceptance/http_rb/http_rb_spec.rb
+++ b/spec/acceptance/http_rb/http_rb_spec.rb
@@ -49,7 +49,7 @@ describe "HTTP.rb" do
   end
 
   it "restores request uri on replayed response object" do
-    uri = URI "http://example.com/foo"
+    uri = Addressable::URI.parse "http://example.com/foo"
 
     stub_request :get, "example.com/foo"
     response = HTTP.get uri

--- a/spec/acceptance/http_rb/http_rb_spec_helper.rb
+++ b/spec/acceptance/http_rb/http_rb_spec_helper.rb
@@ -7,7 +7,7 @@ module HttpRbSpecHelper
     OpenStruct.new({
       :body       => response.body.to_s,
       :headers    => normalize_headers(response.headers.to_h),
-      :status     => response.status.to_s,
+      :status     => response.status.code.to_s,
       :message    => response.reason
     })
   end

--- a/spec/acceptance/httpclient/httpclient_spec.rb
+++ b/spec/acceptance/httpclient/httpclient_spec.rb
@@ -113,13 +113,8 @@ describe "HTTPClient" do
         nil # to let the request be made for real
       end
 
-      # To make two requests that have the same request signature, the headers must match.
-      # Since the webmock server has a Set-Cookie header, the 2nd request will automatically
-      # include a Cookie header (due to how httpclient works), so we have to set the header
-      # manually on the first request but not on the 2nd request.
-      http_request(:get, webmock_server_url, :client => client,
-                         :headers => { "Cookie" => "bar=; foo=" })
-      http_request(:get, webmock_server_url, :client => client)
+      http_request(:get, webmock_server_url, :client => client, :headers => { "Cookie" => "bar=; foo=" })
+      http_request(:get, webmock_server_url, :client => client, :headers => { "Cookie" => "bar=; foo=" })
 
       expect(request_signatures.size).to eq(2)
       # Verify the request signatures were identical as needed by this example

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,7 @@ RSpec.configure do |config|
   config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
 end
+RSpec::Expectations.configuration.warn_about_potential_false_positives = false
 
 def fail()
   raise_error(RSpec::Expectations::ExpectationNotMetError)


### PR DESCRIPTION
## Work in progress - fixing specs

State of the world at d72af3d:
- Specs all pass on MRI 2.2.2 and JRuby 9000
- Two failures on MRI 1.9.3
- Three failures on JRuby 1.7.8

These are the only four versions I've been testing locally. I use rbenv instead of rvm and haven't implemented a way to run all specs across multiple versions in this project with my setup.

### Problematic specs
`spec/acceptance/http_rb/http_rb_spec.rb:57`
- 2-2-2 versions: `response.uri` is an `Addressable::URI` object
- 1.9.3 versions: `response.uri` is a `URI::HTTP` object

The spec could just call `#to_s` on both to pass, but that seems like a cop-out.

`spec/acceptance/httpclient/httpclient_spec.rb:121`
- 2.2.2 versions
  - stubbing cookie header in first only => one request_signature has cookie header, other does not
  - stubbing no headers => green
  - stubbing cookie header in both => green
- 1.9.3 versions
  - stubbing cookie header in first only => green
  - stubbing no headers => one request_signature has no headers, the other has a cookie header
  - stubbing cookie header in both => one request_signature has single cookie header, the other has array of duplicate cookie headers

cc #494, #503 