### PR TITLE
add rack dependency

### DIFF
--- a/webmock.gemspec
+++ b/webmock.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'addressable', '>= 2.3.6'
   s.add_dependency 'crack', '>=0.3.2'
   s.add_dependency 'hashdiff'
+  s.add_dependency 'rack'
 
   patron_version = (RUBY_VERSION <= '1.8.7') ? '0.4.18' : '>= 0.4.18'
 


### PR DESCRIPTION
Hello,

I think `v1.22.0` added a dependency to `rack`.

My build just failed in travis when it upgraded from webmock `v1.21.0` to `v1.22.0`

```
/Users/kbrock/.gem/ruby/2.2.3/gems/webmock-1.22.0/lib/webmock.rb:33:in `require': cannot load such file -- rack/utils (LoadError)
	from /Users/kbrock/.gem/ruby/2.2.3/gems/webmock-1.22.0/lib/webmock.rb:33:in `<top (required)>'
	from /Users/kbrock/.gem/ruby/2.2.3/gems/vcr-2.9.3/lib/vcr/library_hooks/webmock.rb:3:in `require'
	from /Users/kbrock/.gem/ruby/2.2.3/gems/vcr-2.9.3/lib/vcr/library_hooks/webmock.rb:3:in `<top (required)>'
	from /Users/kbrock/.gem/ruby/2.2.3/gems/vcr-2.9.3/lib/vcr/configuration.rb:503:in `require'
	from /Users/kbrock/.gem/ruby/2.2.3/gems/vcr-2.9.3/lib/vcr/configuration.rb:503:in `load_library_hook'
	from /Users/kbrock/.gem/ruby/2.2.3/gems/vcr-2.9.3/lib/vcr/configuration.rb:68:in `block in hook_into'
	from /Users/kbrock/.gem/ruby/2.2.3/gems/vcr-2.9.3/lib/vcr/configuration.rb:68:in `each'
	from /Users/kbrock/.gem/ruby/2.2.3/gems/vcr-2.9.3/lib/vcr/configuration.rb:68:in `hook_into'
```

If you have a different suggestion, just let me know. thanks

Thanks for the great tool,
Keenan