### PR TITLE
prevents form adding an extra =true to urls

### DIFF
--- a/lib/webmock/util/query_mapper.rb
+++ b/lib/webmock/util/query_mapper.rb
@@ -79,7 +79,7 @@ module WebMock::Util
       def collect_query_hash(query_array, empty_accumulator, options)
         query_array.compact.inject(empty_accumulator.dup) do |accumulator, (key, value)|
           value = if value.nil?
-                    true
+                    nil
                   else
                     ::Addressable::URI.unencode_component(value.gsub(/\+/, ' '))
                   end
@@ -263,6 +263,8 @@ module WebMock::Util
             buffer << "#{to_query(new_parent, val, options)}&"
           end
           buffer.chop
+        when NilClass
+          parent
         else
           encoded_value = Addressable::URI.encode_component(
             value.to_s.dup, Addressable::URI::CharacterClasses::UNRESERVED

--- a/spec/unit/util/query_mapper_spec.rb
+++ b/spec/unit/util/query_mapper_spec.rb
@@ -52,7 +52,7 @@ describe WebMock::Util::QueryMapper do
 
   context '#to_query' do
     it 'should transform nil value' do
-      expect(subject.to_query('a', nil)).to eq('a=')
+      expect(subject.to_query('a', nil)).to eq('a')
     end
     it 'should transform string value' do
       expect(subject.to_query('a', 'b')).to eq('a=b')


### PR DESCRIPTION
  Without this fix:
    * Requests to:
      http://www.google.com?query

    * Stub registered as:
      http://www.google.com?query=true