### PR TITLE
Add RequestStub helper methods for accessing request signatures

### DIFF
--- a/lib/webmock/request_stub.rb
+++ b/lib/webmock/request_stub.rb
@@ -53,6 +53,28 @@ module WebMock
       end
     end
 
+    # Fetch all requests from `WebMock::RequestRegistry` which match this stubs `@request_pattern`
+    # @return [Array] the requested `WebMock::RequestSignature`s which match this stubs `@request_pattern`
+    def requests
+      request_registry = WebMock::RequestRegistry.instance
+      signatures = request_registry.requested_signatures.hash.keys()
+      return signatures.select { |signature|
+        @request_pattern.matches?(signature)
+      }
+    end
+
+    # Fetch the first request made for this stub
+    # @return [WebMock::RequestSignature|nil] the first request signature for this stub, or nil if none were made
+    def first_request
+      return requests[0]
+    end
+
+    # Fetch the last request made for this stub
+    # @return [WebMock::RequestSignature|nil] the last request signature for this stub, or nil if none were made
+    def last_request
+      return requests[-1]
+    end
+
     def has_responses?
       !@responses_sequences.empty?
     end

--- a/spec/unit/request_stub_spec.rb
+++ b/spec/unit/request_stub_spec.rb
@@ -14,6 +14,63 @@ describe WebMock::RequestStub do
     expect(@request_stub.response).to be_a(WebMock::Response)
   end
 
+  describe "requests" do
+
+    it "should have no requests" do
+      expect(@request_stub.requests).to eq([])
+    end
+
+    it "should have requests" do
+      signature = WebMock::RequestSignature.new(:get, "www.example.com")
+      WebMock::RequestRegistry.instance.requested_signatures.put(signature)
+      expect(@request_stub.requests).to eq([signature])
+    end
+
+    it "should only return matching requests" do
+      match = WebMock::RequestSignature.new(:get, "www.example.com")
+      WebMock::RequestRegistry.instance.requested_signatures.put(match)
+      non_match = WebMock::RequestSignature.new(:get, "www.example.org")
+      WebMock::RequestRegistry.instance.requested_signatures.put(non_match)
+
+      expect(@request_stub.requests).to eq([match])
+    end
+
+  end
+
+  describe "last_request" do
+
+    it "should be nil when there are no requests" do
+      expect(@request_stub.last_request).to be_nil
+    end
+
+    it "should be the last requests when there are multiple requests" do
+      first = WebMock::RequestSignature.new(:get, "www.example.com")
+      WebMock::RequestRegistry.instance.requested_signatures.put(first)
+      last = WebMock::RequestSignature.new(:get, "www.example.com")
+      WebMock::RequestRegistry.instance.requested_signatures.put(last)
+
+      expect(@request_stub.last_request).to eq(last)
+    end
+
+  end
+
+  describe "first_request" do
+
+    it "should be nil when there are no requests" do
+      expect(@request_stub.first_request).to be_nil
+    end
+
+    it "should be the first requests when there are multiple requests" do
+      first = WebMock::RequestSignature.new(:get, "www.example.com")
+      WebMock::RequestRegistry.instance.requested_signatures.put(first)
+      last = WebMock::RequestSignature.new(:get, "www.example.com")
+      WebMock::RequestRegistry.instance.requested_signatures.put(last)
+
+      expect(@request_stub.last_request).to eq(first)
+    end
+
+  end
+
   describe "with" do
 
     it "should assign body to request pattern" do


### PR DESCRIPTION
While working with `WebMock` we have found that we would like to be able to easily access the `WebMock::RequestSignature`s that correspond to a given `WebMock::RequestStub`.

The reason for this is so that we can have more generic stubs and then write our assertions in the tests against the requests that were made rather than building very specific stubs.

This PR adds in the following methods to `WebMock::RequestStub`:

- `requests` - filter the requests in `WebMock::RequestRegistry` which match `@request_pattern`
- `last_request` - the last request from `requests` (`requests[-1]`)
- `first_request` - the first request from `requests` (`requests[0]`)


This allows us to write tests similar to the following:

```ruby
let!(:stub) { WebMock::API.stub_request(:post, "elasticsearch.url/people/person/_search")
                          .to_return(File.new("response.raw")) }

before(:example) do
    visit("/endpoint")
end

it "properly queried elasticsearch" do
    request = stub.last_request
    data = JSON.load(request.body)
    expect(body["query"]).to(eq("match_all" => {}))
end
```


As we are still somewhat new to `WebMock` we are also open to suggestions on how we should be doing this.
