### PR TITLE
hash_counter: avoid possible RuntimeErrors on JRuby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.22.4
+
+  * Fix the "can't add a new key into hash during iteration" message in hash_counter.rb in JRuby 1.7
+
+    Thanks to [kyrylo](https://github.com/kyrylo)
+
 ## 1.22.3
 
   * Return "effective_url" attribute in Typhoeus::Response

--- a/lib/webmock/util/hash_counter.rb
+++ b/lib/webmock/util/hash_counter.rb
@@ -14,8 +14,7 @@ module WebMock
         @lock.synchronize do
           val = hash[key]
           hash[key] = (val || 0) + num
-          @max += 1
-          @order[key] = @max
+          @order[key] = @max = @max + 1
         end
       end
       def get key

--- a/lib/webmock/util/hash_counter.rb
+++ b/lib/webmock/util/hash_counter.rb
@@ -12,7 +12,8 @@ module WebMock
       end
       def put key, num=1
         @lock.synchronize do
-          hash[key] = (hash[key] || 0) + num
+          val = hash[key]
+          hash[key] = (val || 0) + num
           @order[key] = @max = @max + 1
         end
       end

--- a/lib/webmock/util/hash_counter.rb
+++ b/lib/webmock/util/hash_counter.rb
@@ -14,7 +14,8 @@ module WebMock
         @lock.synchronize do
           val = hash[key]
           hash[key] = (val || 0) + num
-          @order[key] = @max = @max + 1
+          @max += 1
+          @order[key] = @max
         end
       end
       def get key


### PR DESCRIPTION
I stumbled upon this exception while running my tests on JRuby 1.7:

```
RuntimeError:
       can't add a new key into hash during iteration
     # ./vendor/jruby/1.9/bundler/gems/webmock-4d40934217e8/lib/webmock/util/hash_counter.rb:15:in `put'
     # ./vendor/jruby/1.9/bundler/gems/webmock-4d40934217e8/lib/webmock/util/hash_counter.rb:14:in `put'
     # ./vendor/jruby/1.9/bundler/gems/webmock-4d40934217e8/lib/webmock/http_lib_adapters/net_http.rb:77:in `request'
     ...my_frames...
```

Even though we don't iterate anything here, this simple change was able
to fix my problems.

**EDIT:** don't mind the webmock version in my backtrace, I was just testing things and depended on my fork.