### PR TITLE
vcr issue_417 - double http headers on curb redirect

### DIFF
--- a/spec/acceptance/curb/curb_spec_helper.rb
+++ b/spec/acceptance/curb/curb_spec_helper.rb
@@ -35,6 +35,8 @@ module CurbSpecHelper
     curl.password = uri.password
     curl.timeout  = 30
     curl.connect_timeout = 30
+    curl.follow_location = true
+
 
     if headers = options[:headers]
       headers.each {|k,v| curl.headers[k] = v }

--- a/spec/acceptance/shared/callbacks.rb
+++ b/spec/acceptance/shared/callbacks.rb
@@ -102,21 +102,56 @@ shared_context "callbacks" do |*adapter_info|
           WebMock.after_request(:except => [:other_lib])  do |_, response|
             @response = response
           end
-          http_request(:get, "http://httpstat.us/201")
         end
 
-        it "should pass real response to callback with status and message" do
-          expect(@response.status[0]).to eq(201)
-          expect(@response.status[1]).to eq("Created") unless adapter_info.include?(:no_status_message)
+        describe "for a 201 http status response" do
+          before do
+            http_request(:get, "http://httpstat.us/201")
+          end
+
+          it "should pass real response to callback with status and message" do
+            expect(@response.status[0]).to eq(201)
+            expect(@response.status[1]).to eq("Created") unless adapter_info.include?(:no_status_message)
+          end
+
+          it "should pass real response to callback with headers" do
+            expect(@response.headers["Content-Length"]).to eq("11")
+          end
+
+          it "should pass response to callback with body" do
+            expect(@response.body.size).to eq(11)
+          end
         end
 
-        it "should pass real response to callback with headers" do
-          expect(@response.headers["Content-Length"]).to eq("11")
+        describe "for a redirect" do
+          before do
+            http_request(:get, "http://httpstat.us/301") # redirects to / with status 200 OK
+          end
+
+          let(:headers) {@response.headers}
+          let(:date_header) {headers['Date']}
+          let(:server_header) {headers['Server']}
+          let(:status_code) {headers['status'][0]}
+          let(:status_text) {headers['status'][1]}
+
+          it "should pass the final response to callback with status and message" do
+            expect(status_code).to eq(200) #
+            expect(status_text).to eq("OK") unless adapter_info.include?(:no_status_message)
+          end
+
+          it 'should return one and only one Server http header string' do
+            expect(server_header).to be_a String
+          end
+
+          it 'should return one and only one Date http header string' do
+            expect(date_header).to be_a String
+          end
+
+          it 'should a date header string that is a valid date' do
+            expect(Time.parse(date_header)).to be_a Time
+          end
         end
 
-        it "should pass response to callback with body" do
-          expect(@response.body.size).to eq(11)
-        end
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ unless RUBY_PLATFORM =~ /java/
   require 'patron'
   require 'em-http'
   require 'typhoeus'
+  require 'time'
 end
 if RUBY_PLATFORM =~ /java/
   require 'manticore'


### PR DESCRIPTION
Hello,

I'm working on an issue in https://github.com/vcr/vcr (specifically https://github.com/vcr/vcr/issues/417) and arrived here as part of my investigation.

A user opened an issue on our issues list in vcr, reporting "double entries" for various HTTP headers when hooking vcr into webmock with curb as the underlying HTTP library.

While investigating that issue and after getting pretty deep into the weeds with `debugger` I concluded that the core of the problem is that curb is returning double HTTP headers to WebMock which is then passing those on to vcr, when an HTTP redirect (301 or 302) happens.

Based on @bblimke and @myronmarston comments on that issue it is definitely not by design in vcr or in webmock. I'm not sure about curb yet.

The issue is already open on vcr, I'm opening this issue here to track it on this end as well.

I created this fork and added failing tests to showcase the problem. The failing test output is below. 

(obviously, this PR is not ready to be pulled in, it is just a set of failing tests at the moment).

My main questions are:
1. Should this be fixed (or worked around) in webmock?
2. ..or should I take this further to Curb and see if it can be fixed there?

Thanks,
Gal

```
→ rspec spec/acceptance/curb/curb_spec.rb
Run options:
  include {:focus=>true}
  exclude {:without_webmock=>true}

All examples were filtered out; ignoring {:focus=>true}
......................................................................................................................................................................................................................................................................................FFFF.................................................................................................................................................................................................................................................................................FFFF................................................................................................................................................................................................................................................................................FFFF.............................................................................................................................................................................................................................................................................FFFF.............................................................................................................................................................................................................................................................................FFFF.................

Failures:

  1) Webmock with Curb using #http for requests it should behave like Curb with WebMock when after_request callback is declared passing response to callback when request is not stubbed for a redirect should return one and only one Server http header string
     Failure/Error: expect(server_header).to be_a String
       expected ["Microsoft-IIS/8.0", "Microsoft-IIS/8.0"] to be a kind of String
     Shared Example Group: "callbacks" called from ./spec/acceptance/webmock_shared.rb:35
     Shared Example Group: "with WebMock" called from ./spec/acceptance/curb/curb_spec.rb:10
     Shared Example Group: "Curb" called from ./spec/acceptance/curb/curb_spec.rb:341
     # ./spec/acceptance/shared/callbacks.rb:143:in `block (6 levels) in <top (required)>'

  2) Webmock with Curb using #http for requests it should behave like Curb with WebMock when after_request callback is declared passing response to callback when request is not stubbed for a redirect should return one and only one Date http header string
     Failure/Error: expect(date_header).to be_a String
       expected ["Sun, 29 Nov 2015 10:43:18 GMT", "Sun, 29 Nov 2015 10:43:18 GMT"] to be a kind of String
     Shared Example Group: "callbacks" called from ./spec/acceptance/webmock_shared.rb:35
     Shared Example Group: "with WebMock" called from ./spec/acceptance/curb/curb_spec.rb:10
     Shared Example Group: "Curb" called from ./spec/acceptance/curb/curb_spec.rb:341
     # ./spec/acceptance/shared/callbacks.rb:147:in `block (6 levels) in <top (required)>'

  3) Webmock with Curb using #http for requests it should behave like Curb with WebMock when after_request callback is declared passing response to callback when request is not stubbed for a redirect should a date header string that is a valid date
     Failure/Error: expect(Time.parse(date_header)).to be_a Time

     TypeError:
       no implicit conversion of Array into String
     Shared Example Group: "callbacks" called from ./spec/acceptance/webmock_shared.rb:35
     Shared Example Group: "with WebMock" called from ./spec/acceptance/curb/curb_spec.rb:10
     Shared Example Group: "Curb" called from ./spec/acceptance/curb/curb_spec.rb:341
     # ./spec/acceptance/shared/callbacks.rb:151:in `block (6 levels) in <top (required)>'

  4) Webmock with Curb using #http_* methods for requests it should behave like Curb with WebMock when after_request callback is declared passing response to callback when request is not stubbed for a redirect should pass the final response to callback with status and message
     Failure/Error: let(:status_code) {headers['status'][0]}

     NoMethodError:
       undefined method `[]' for nil:NilClass
     Shared Example Group: "callbacks" called from ./spec/acceptance/webmock_shared.rb:35
     Shared Example Group: "with WebMock" called from ./spec/acceptance/curb/curb_spec.rb:10
     Shared Example Group: "Curb" called from ./spec/acceptance/curb/curb_spec.rb:364
     # ./spec/acceptance/shared/callbacks.rb:134:in `block (6 levels) in <top (required)>'
     # ./spec/acceptance/shared/callbacks.rb:138:in `block (6 levels) in <top (required)>'

  5) Webmock with Curb using #http_* methods for requests it should behave like Curb with WebMock when after_request callback is declared passing response to callback when request is not stubbed for a redirect should return one and only one Server http header string
     Failure/Error: expect(server_header).to be_a String
       expected ["Microsoft-IIS/8.0", "Microsoft-IIS/8.0"] to be a kind of String
     Shared Example Group: "callbacks" called from ./spec/acceptance/webmock_shared.rb:35
     Shared Example Group: "with WebMock" called from ./spec/acceptance/curb/curb_spec.rb:10
     Shared Example Group: "Curb" called from ./spec/acceptance/curb/curb_spec.rb:364
     # ./spec/acceptance/shared/callbacks.rb:143:in `block (6 levels) in <top (required)>'

  6) Webmock with Curb using #http_* methods for requests it should behave like Curb with WebMock when after_request callback is declared passing response to callback when request is not stubbed for a redirect should return one and only one Date http header string
     Failure/Error: expect(date_header).to be_a String
       expected ["Sun, 29 Nov 2015 10:43:20 GMT", "Sun, 29 Nov 2015 10:43:20 GMT"] to be a kind of String
     Shared Example Group: "callbacks" called from ./spec/acceptance/webmock_shared.rb:35
     Shared Example Group: "with WebMock" called from ./spec/acceptance/curb/curb_spec.rb:10
     Shared Example Group: "Curb" called from ./spec/acceptance/curb/curb_spec.rb:364
     # ./spec/acceptance/shared/callbacks.rb:147:in `block (6 levels) in <top (required)>'

  7) Webmock with Curb using #http_* methods for requests it should behave like Curb with WebMock when after_request callback is declared passing response to callback when request is not stubbed for a redirect should a date header string that is a valid date
     Failure/Error: expect(Time.parse(date_header)).to be_a Time

     TypeError:
       no implicit conversion of Array into String
     Shared Example Group: "callbacks" called from ./spec/acceptance/webmock_shared.rb:35
     Shared Example Group: "with WebMock" called from ./spec/acceptance/curb/curb_spec.rb:10
     Shared Example Group: "Curb" called from ./spec/acceptance/curb/curb_spec.rb:364
     # ./spec/acceptance/shared/callbacks.rb:151:in `block (6 levels) in <top (required)>'


  8) Webmock with Curb using #perform for requests it should behave like Curb with WebMock when after_request callback is declared passing response to callback when request is not stubbed for a redirect should return one and only one Server http header string
      Failure/Error: expect(server_header).to be_a String
        expected ["Microsoft-IIS/8.0", "Microsoft-IIS/8.0"] to be a kind of String
      Shared Example Group: "callbacks" called from ./spec/acceptance/webmock_shared.rb:35
      Shared Example Group: "with WebMock" called from ./spec/acceptance/curb/curb_spec.rb:10
      Shared Example Group: "Curb" called from ./spec/acceptance/curb/curb_spec.rb:429
      # ./spec/acceptance/shared/callbacks.rb:143:in `block (6 levels) in <top (required)>'

  9) Webmock with Curb using #perform for requests it should behave like Curb with WebMock when after_request callback is declared passing response to callback when request is not stubbed for a redirect should return one and only one Date http header string
      Failure/Error: expect(date_header).to be_a String
        expected ["Sun, 29 Nov 2015 10:43:22 GMT", "Sun, 29 Nov 2015 10:43:22 GMT"] to be a kind of String
      Shared Example Group: "callbacks" called from ./spec/acceptance/webmock_shared.rb:35
      Shared Example Group: "with WebMock" called from ./spec/acceptance/curb/curb_spec.rb:10
      Shared Example Group: "Curb" called from ./spec/acceptance/curb/curb_spec.rb:429
      # ./spec/acceptance/shared/callbacks.rb:147:in `block (6 levels) in <top (required)>'

  10) Webmock with Curb using #perform for requests it should behave like Curb with WebMock when after_request callback is declared passing response to callback when request is not stubbed for a redirect should a date header string that is a valid date
      Failure/Error: expect(Time.parse(date_header)).to be_a Time

      TypeError:
        no implicit conversion of Array ["Sun, 29 Nov 2015 10:43:22 GMT", "Sun, 29 Nov 2015 10:43:22 GMT"] into String
      Shared Example Group: "callbacks" called from ./spec/acceptance/webmock_shared.rb:35
      Shared Example Group: "with WebMock" called from ./spec/acceptance/curb/curb_spec.rb:10
      Shared Example Group: "Curb" called from ./spec/acceptance/curb/curb_spec.rb:429
      # ./spec/acceptance/shared/callbacks.rb:151:in `block (6 levels) in <top (required)>'

  11) Webmock with Curb using .http_* methods for requests it should behave like Curb with WebMock when after_request callback is declared passing response to callback when request is not stubbed for a redirect should return one and only one Server http header string
      Failure/Error: expect(server_header).to be_a String
        expected ["Microsoft-IIS/8.0", "Microsoft-IIS/8.0"] to be a kind of String
      Shared Example Group: "callbacks" called from ./spec/acceptance/webmock_shared.rb:35
      Shared Example Group: "with WebMock" called from ./spec/acceptance/curb/curb_spec.rb:10
      Shared Example Group: "Curb" called from ./spec/acceptance/curb/curb_spec.rb:434
      # ./spec/acceptance/shared/callbacks.rb:143:in `block (6 levels) in <top (required)>'

  12) Webmock with Curb using .http_* methods for requests it should behave like Curb with WebMock when after_request callback is declared passing response to callback when request is not stubbed for a redirect should return one and only one Date http header string
      Failure/Error: expect(date_header).to be_a String
        expected ["Sun, 29 Nov 2015 10:43:22 GMT", "Sun, 29 Nov 2015 10:43:22 GMT"] to be a kind of String
      Shared Example Group: "callbacks" called from ./spec/acceptance/webmock_shared.rb:35
      Shared Example Group: "with WebMock" called from ./spec/acceptance/curb/curb_spec.rb:10
      Shared Example Group: "Curb" called from ./spec/acceptance/curb/curb_spec.rb:434
      # ./spec/acceptance/shared/callbacks.rb:147:in `block (6 levels) in <top (required)>'
.
.
.

Finished in 8.14 seconds (files took 0.77305 seconds to load)
1398 examples, 20 failures

```
