### PR TITLE
Clarify RSpec support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Features
 * Smart matching of the same URIs in different representations (also encoded and non encoded forms)
 * Smart matching of the same headers in different representations.
 * Support for Test::Unit
-* Support for RSpec 1.x and RSpec 2.x
+* Support for RSpec
 * Support for MiniTest
 
 Supported HTTP libraries


### PR DESCRIPTION
I've been using webmock with RSpec 3.x and it seems to work fine. Maybe it's better to just say "RSpec is supported", just like with Minitest and Test::Unit.