### PR TITLE
Allow curb 0.9.0

### DIFF
--- a/lib/webmock/http_lib_adapters/curb_adapter.rb
+++ b/lib/webmock/http_lib_adapters/curb_adapter.rb
@@ -5,7 +5,7 @@ rescue LoadError
 end
 
 if defined?(Curl)
-  WebMock::VersionChecker.new('Curb', Curl::CURB_VERSION, '0.7.16', '0.8.7').check_version!
+  WebMock::VersionChecker.new('Curb', Curl::CURB_VERSION, '0.7.16', '0.9.0').check_version!
 
   module WebMock
     module HttpLibAdapters

--- a/webmock.gemspec
+++ b/webmock.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'em-http-request', '>= 1.0.2'
   s.add_development_dependency 'http',            ((RUBY_VERSION <= '1.9.3') ? '0.7.3' : '>= 0.8.0')
   s.add_development_dependency 'em-synchrony',    '>= 1.0.0' if RUBY_VERSION >= "1.9"
-  s.add_development_dependency 'curb',            '<= 0.9.0' unless RUBY_PLATFORM =~ /java/
+  s.add_development_dependency 'curb',            '< 0.10.0' unless RUBY_PLATFORM =~ /java/
   s.add_development_dependency 'typhoeus',        '>= 0.5.0' unless RUBY_PLATFORM =~ /java/
   s.add_development_dependency('manticore',       manticore_version) if RUBY_PLATFORM =~ /java/
   s.add_development_dependency 'excon',           '>= 0.27.5'

--- a/webmock.gemspec
+++ b/webmock.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'em-http-request', '>= 1.0.2'
   s.add_development_dependency 'http',            ((RUBY_VERSION <= '1.9.3') ? '0.7.3' : '>= 0.8.0')
   s.add_development_dependency 'em-synchrony',    '>= 1.0.0' if RUBY_VERSION >= "1.9"
-  s.add_development_dependency 'curb',            '<= 0.8.6' unless RUBY_PLATFORM =~ /java/
+  s.add_development_dependency 'curb',            '<= 0.9.0' unless RUBY_PLATFORM =~ /java/
   s.add_development_dependency 'typhoeus',        '>= 0.5.0' unless RUBY_PLATFORM =~ /java/
   s.add_development_dependency('manticore',       manticore_version) if RUBY_PLATFORM =~ /java/
   s.add_development_dependency 'excon',           '>= 0.27.5'


### PR DESCRIPTION
So I went through the code,
and the tests pass fine with 0.9.0.

Trying to understand the issue I tried 0.8.7
and indeed it freezes the tests.

But 0.8.8 passes too.

So it seems that this was a unique issue with 0.8.7.
Perhaps we need to modify the `VersionChecker` to have a blacklist of known bad versions?