### PR TITLE
restricts HTTP rb version to < 1.0.0

### DIFF
--- a/webmock.gemspec
+++ b/webmock.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'httpclient',      '>= 2.2.4'
   s.add_development_dependency('patron',          patron_version) unless RUBY_PLATFORM =~ /java/
   s.add_development_dependency 'em-http-request', '>= 1.0.2'
-  s.add_development_dependency 'http',            ((RUBY_VERSION <= '1.9.3') ? '0.7.3' : '>= 0.8.0')
+  s.add_development_dependency 'http',            ((RUBY_VERSION <= '1.9.3') ? '0.7.3' : '~> 0.8.0')
   s.add_development_dependency 'em-synchrony',    '>= 1.0.0' if RUBY_VERSION >= "1.9"
   s.add_development_dependency 'curb',            '<= 0.8.6' unless RUBY_PLATFORM =~ /java/
   s.add_development_dependency 'typhoeus',        '>= 0.5.0' unless RUBY_PLATFORM =~ /java/


### PR DESCRIPTION
  until we can update WebMock to support it