### PR TITLE
Add RequestStub helper methods for accessing request signatures

### DIFF
--- a/lib/webmock/request_stub.rb
+++ b/lib/webmock/request_stub.rb
@@ -53,6 +53,28 @@ module WebMock
       end
     end
 
+    # Fetch all requests from `WebMock::RequestRegistry` which match this stubs `@request_pattern`
+    # @return [Array] the requested `WebMock::RequestSignature`s which match this stubs `@request_pattern`
+    def requests
+      request_registry = WebMock::RequestRegistry.instance
+      signatures = request_registry.requested_signatures.ary
+      return signatures.select { |signature|
+        @request_pattern.matches?(signature)
+      }
+    end
+
+    # Fetch the first request made for this stub
+    # @return [WebMock::RequestSignature|nil] the first request signature for this stub, or nil if none were made
+    def first_request
+      return requests[0]
+    end
+
+    # Fetch the last request made for this stub
+    # @return [WebMock::RequestSignature|nil] the last request signature for this stub, or nil if none were made
+    def last_request
+      return requests[-1]
+    end
+
     def has_responses?
       !@responses_sequences.empty?
     end

--- a/lib/webmock/util/hash_counter.rb
+++ b/lib/webmock/util/hash_counter.rb
@@ -3,8 +3,10 @@ require 'thread'
 module WebMock
   module Util
     class Util::HashCounter
+      attr_accessor :ary
       attr_accessor :hash
       def initialize
+        self.ary = []
         self.hash = {}
         @order = {}
         @max = 0
@@ -13,6 +15,7 @@ module WebMock
       def put key, num=1
         @lock.synchronize do
           hash[key] = (hash[key] || 0) + num
+          ary << key
           @order[key] = @max = @max + 1
         end
       end

--- a/spec/unit/request_stub_spec.rb
+++ b/spec/unit/request_stub_spec.rb
@@ -14,6 +14,71 @@ describe WebMock::RequestStub do
     expect(@request_stub.response).to be_a(WebMock::Response)
   end
 
+  describe "requests" do
+
+    it "should have no requests" do
+      expect(@request_stub.requests).to eq([])
+    end
+
+    it "should have requests" do
+      signature = WebMock::RequestSignature.new(:get, "www.example.com")
+      WebMock::RequestRegistry.instance.requested_signatures.put(signature)
+      expect(@request_stub.requests).to eq([signature])
+    end
+
+    it "should only return matching requests" do
+      match = WebMock::RequestSignature.new(:get, "www.example.com")
+      WebMock::RequestRegistry.instance.requested_signatures.put(match)
+      non_match = WebMock::RequestSignature.new(:get, "www.example.org")
+      WebMock::RequestRegistry.instance.requested_signatures.put(non_match)
+
+      expect(@request_stub.requests).to eq([match])
+    end
+
+    it "should not combine identical requests" do
+      signature1 = WebMock::RequestSignature.new(:get, "www.example.com")
+      signature2 = WebMock::RequestSignature.new(:get, "www.example.com")
+      WebMock::RequestRegistry.instance.requested_signatures.put(signature1)
+      WebMock::RequestRegistry.instance.requested_signatures.put(signature2)
+      expect(@request_stub.requests).to eq([signature1, signature2])
+    end
+
+  end
+
+  describe "last_request" do
+
+    it "should be nil when there are no requests" do
+      expect(@request_stub.last_request).to be_nil
+    end
+
+    it "should be the last requests when there are multiple requests" do
+      first = WebMock::RequestSignature.new(:get, "www.example.com")
+      WebMock::RequestRegistry.instance.requested_signatures.put(first)
+      last = WebMock::RequestSignature.new(:get, "www.example.com")
+      WebMock::RequestRegistry.instance.requested_signatures.put(last)
+
+      expect(@request_stub.last_request).to eq(last)
+    end
+
+  end
+
+  describe "first_request" do
+
+    it "should be nil when there are no requests" do
+      expect(@request_stub.first_request).to be_nil
+    end
+
+    it "should be the first requests when there are multiple requests" do
+      first = WebMock::RequestSignature.new(:get, "www.example.com")
+      WebMock::RequestRegistry.instance.requested_signatures.put(first)
+      last = WebMock::RequestSignature.new(:get, "www.example.com")
+      WebMock::RequestRegistry.instance.requested_signatures.put(last)
+
+      expect(@request_stub.last_request).to eq(first)
+    end
+
+  end
+
   describe "with" do
 
     it "should assign body to request pattern" do


### PR DESCRIPTION
In #544 @brettlangdon submitted a proposal to add `requests` to `RequestStub` instances. It was declined for legitimate concerns of overlapping requests. We have naively been using the forked version in our own repo, finally ran into the issue, and found a way to solve the concerns.

We have added a new test to guarantee separate request signatures are not combined via `matches?` (i.e. "should not combine identical requests").

This solution is more/less the same as our #544 (use the same approach as `times(n)` matcher) but instead of losing request ordering and cardinality by storing request counts on a `hash`. We moved to storing request signatures on an array.

I'm pretty confident we have no overlap issues now since any issues would mean that `times(n)` has those same issues.

In this PR:

- Revived #544 
    - Addition of `requests`, `first_request`, and `last_request` to request stubs
- Added test for request overlap
- Patched request overlap by adding array for `HashCounter`

**Notes:**

The initial revision of this PR is more of a proposal than a final product. There need to be some things that will be changed if accepted (e.g. rename `HashCounter`). But the concepts are here.

**Reference code used from `times(n):**

https://github.com/bblimke/webmock/blob/v1.22.6/lib/webmock/rspec/matchers/request_pattern_matcher.rb#L18-L21

https://github.com/bblimke/webmock/blob/v1.22.6/lib/webmock/request_execution_verifier.rb#L15-L18

https://github.com/bblimke/webmock/blob/v1.22.6/lib/webmock/request_registry.rb#L16-L20

https://github.com/bblimke/webmock/blob/v1.22.6/lib/webmock/util/hash_counter.rb#L6-L18

https://github.com/bblimke/webmock/blob/v1.22.6/lib/webmock/http_lib_adapters/net_http.rb#L75-L77