### PR TITLE
Generic `:allow` descriptor

### DIFF
--- a/lib/webmock/webmock.rb
+++ b/lib/webmock/webmock.rb
@@ -72,6 +72,8 @@ module WebMock
     when String
       allowed == uri.host ||
       allowed == "#{uri.host}:#{uri.port}"
+    when ->(x){ x.respond_to?(:call) }
+      allowed.call(uri)
     end
   end
 

--- a/lib/webmock/webmock.rb
+++ b/lib/webmock/webmock.rb
@@ -72,8 +72,10 @@ module WebMock
     when String
       allowed == uri.host ||
       allowed == "#{uri.host}:#{uri.port}"
-    when ->(x){ x.respond_to?(:call) }
-      allowed.call(uri)
+    else
+      if allowed.respond_to?(:call)
+        allowed.call(uri)
+      end
     end
   end
 

--- a/spec/acceptance/shared/allowing_and_disabling_net_connect.rb
+++ b/spec/acceptance/shared/allowing_and_disabling_net_connect.rb
@@ -88,64 +88,141 @@ shared_context "allowing and disabling net connect" do |*adapter_info|
       end
     end
 
-    describe "is not allowed with exception for allowed domains" do
-      let(:host_with_port){ WebMockServer.instance.host_with_port }
-
-      before(:each) do
-        WebMock.disable_net_connect!(:allow => ["www.example.org", "httpstat.us", host_with_port])
-      end
-
-      context "when the host is not allowed" do
-        it "should return stubbed response if request was stubbed" do
-          stub_request(:get, "www.example.com").to_return(:body => "abc")
-          expect(http_request(:get, "http://www.example.com/").body).to eq("abc")
+    describe "is not allowed, with exceptions" do
+      describe "allowing by host string" do
+        before :each do
+          WebMock.disable_net_connect!(:allow => 'httpstat.us')
         end
 
-        it "should raise exception if request was not stubbed" do
-          expect {
-            http_request(:get, "http://www.example.com/")
-          }.to raise_error(WebMock::NetConnectNotAllowedError, %r(Real HTTP connections are disabled. Unregistered request: GET http://www.example.com/))
-        end
-      end
+        context "when the host is not allowed" do
+          it "should return stubbed response if request was stubbed" do
+            stub_request(:get, 'disallowed.example.com/foo').to_return(:body => "abc")
+            expect(http_request(:get, 'http://disallowed.example.com/foo').body).to eq("abc")
+          end
 
-      context "when the host with port is not allowed" do
-        it "should return stubbed response if request was stubbed" do
-          stub_request(:get, "http://localhost:2345").to_return(:body => "abc")
-          expect(http_request(:get, "http://localhost:2345/").body).to eq("abc")
-        end
-
-        it "should raise exception if request was not stubbed" do
-          expect {
-            http_request(:get, "http://localhost:2345/")
-          }.to raise_error(WebMock::NetConnectNotAllowedError, %r(Real HTTP connections are disabled. Unregistered request: GET http://localhost:2345/))
-        end
-      end
-
-      context "when the host is allowed" do
-        it "should raise exception if request was not stubbed" do
-          expect {
-            http_request(:get, "http://www.example.com/")
-          }.to raise_error(WebMock::NetConnectNotAllowedError, %r(Real HTTP connections are disabled. Unregistered request: GET http://www.example.com/))
+          it "should raise exception if request was not stubbed" do
+            expect {
+              http_request(:get, 'http://disallowed.example.com/')
+            }.to raise_error(WebMock::NetConnectNotAllowedError, %r(Real HTTP connections are disabled. Unregistered request: GET http://disallowed.example.com))
+          end
         end
 
-        it "should make a real request to allowed host", :net_connect => true do
-          expect(http_request(:get, "http://httpstat.us/200").status).to eq("200")
+        context "when the host is allowed" do
+          it "should return stubbed response if request was stubbed" do
+            stub_request(:get, 'httpstat.us/200').to_return(:body => "abc")
+            expect(http_request(:get, "http://httpstat.us/200").body).to eq("abc")
+          end
+
+          # WARNING: this makes a real HTTP request!
+          it "should make a real request to allowed host", :net_connect => true do
+            expect(http_request(:get, "http://httpstat.us/200").status).to eq('200')
+          end
         end
       end
 
-      context "when the host with port is allowed" do
-        it "should make a real request to allowed host", :net_connect => true do
-          expect(http_request(:get, "http://#{host_with_port}/").status).to eq("200")
+      describe "allowing by host:port string" do
+        def replace_with_different_port(uri)
+          uri.sub(%r{:(\d+)}){|m0, m1| ':' + ($~[1].to_i + 1).to_s }
+        end
+
+        let(:allowed_host_with_port) { WebMockServer.instance.host_with_port }
+        let(:disallowed_host_with_port) { replace_with_different_port(allowed_host_with_port) }
+
+        before :each do
+          WebMock.disable_net_connect!(:allow => allowed_host_with_port)
+        end
+
+        context "when the host is not allowed" do
+          it "should return stubbed response if request was stubbed" do
+            request_url = "http://#{disallowed_host_with_port}/foo"
+            stub_request(:get, request_url).to_return(:body => "abc")
+            expect(http_request(:get, request_url).body).to eq("abc")
+          end
+
+          it "should raise exception if request was not stubbed" do
+            request_url = "http://#{disallowed_host_with_port}/foo"
+            expect {
+              http_request(:get, request_url)
+            }.to raise_error(WebMock::NetConnectNotAllowedError, %r(Real HTTP connections are disabled. Unregistered request: GET #{request_url}))
+          end
+        end
+
+        context "when the host is allowed" do
+          it "should return stubbed response if request was stubbed" do
+            request_url = "http://#{allowed_host_with_port}/foo"
+            stub_request(:get, request_url).to_return(:body => "abc")
+            expect(http_request(:get, request_url).body).to eq('abc')
+          end
+
+          it "should make a real request to allowed host", :net_connect => true do
+            request_url = "http://#{allowed_host_with_port}/foo"
+            expect(http_request(:get, request_url).status).to eq('200')
+          end
         end
       end
 
-      context "when the host is allowed but not port" do
-        it "should make a real request to allowed host", :net_connect => true do
-          expect {
-            http_request(:get, "http://localhost:123/")
-          }.to raise_error(WebMock::NetConnectNotAllowedError, %r(Real HTTP connections are disabled. Unregistered request: GET http://localhost:123/))
+      describe "allowing by regular expression" do
+        before :each do
+          WebMock.disable_net_connect!(:allow => %r{httpstat})
+        end
+
+        context "when the host is not allowed" do
+          it "should return stubbed response if request was stubbed" do
+            stub_request(:get, 'disallowed.example.com/foo').to_return(:body => "abc")
+            expect(http_request(:get, 'http://disallowed.example.com/foo').body).to eq("abc")
+          end
+
+          it "should raise exception if request was not stubbed" do
+            expect {
+              http_request(:get, 'http://disallowed.example.com/')
+            }.to raise_error(WebMock::NetConnectNotAllowedError, %r(Real HTTP connections are disabled. Unregistered request: GET http://disallowed.example.com))
+          end
+        end
+
+        context "when the host is allowed" do
+          it "should return stubbed response if request was stubbed" do
+            stub_request(:get, 'httpstat.us/200').to_return(:body => "abc")
+            expect(http_request(:get, "http://httpstat.us/200").body).to eq("abc")
+          end
+
+          # WARNING: this makes a real HTTP request!
+          it "should make a real request to allowed host", :net_connect => true do
+            expect(http_request(:get, "http://httpstat.us/200").status).to eq('200')
+          end
         end
       end
+
+      describe "allowing by a list of the above" do
+        before :each do
+          WebMock.disable_net_connect!(:allow => [%r{foobar}, 'httpstat.us'])
+        end
+
+        context "when the host is not allowed" do
+          it "should return stubbed response if request was stubbed" do
+            stub_request(:get, 'disallowed.example.com/foo').to_return(:body => "abc")
+            expect(http_request(:get, 'http://disallowed.example.com/foo').body).to eq("abc")
+          end
+
+          it "should raise exception if request was not stubbed" do
+            expect {
+              http_request(:get, 'http://disallowed.example.com/')
+            }.to raise_error(WebMock::NetConnectNotAllowedError, %r(Real HTTP connections are disabled. Unregistered request: GET http://disallowed.example.com))
+          end
+        end
+
+        context "when the host is allowed" do
+          it "should return stubbed response if request was stubbed" do
+            stub_request(:get, 'httpstat.us/200').to_return(:body => "abc")
+            expect(http_request(:get, "http://httpstat.us/200").body).to eq("abc")
+          end
+
+          # WARNING: this makes a real HTTP request!
+          it "should make a real request to allowed host", :net_connect => true do
+            expect(http_request(:get, "http://httpstat.us/200").status).to eq('200')
+          end
+        end
+      end
+
     end
   end
 end

--- a/spec/acceptance/shared/allowing_and_disabling_net_connect.rb
+++ b/spec/acceptance/shared/allowing_and_disabling_net_connect.rb
@@ -194,7 +194,7 @@ shared_context "allowing and disabling net connect" do |*adapter_info|
 
       describe "allowing by a callable" do
         before :each do
-          WebMock.disable_net_connect!(:allow => ->(url){ url.to_str.include?('httpstat') })
+          WebMock.disable_net_connect!(:allow => lambda{|url| url.to_str.include?('httpstat') })
         end
 
         context "when the host is not allowed" do
@@ -225,7 +225,7 @@ shared_context "allowing and disabling net connect" do |*adapter_info|
 
       describe "allowing by a list of the above" do
         before :each do
-          WebMock.disable_net_connect!(:allow => [->(_){ false }, %r{foobar}, 'httpstat.us'])
+          WebMock.disable_net_connect!(:allow => [lambda{|_| false }, %r{foobar}, 'httpstat.us'])
         end
 
         context "when the host is not allowed" do


### PR DESCRIPTION
I have a situation where I would like Webmock to allow connections, except to **a number** of sites.

I could do that with a regular expression, but it can become quite unwieldy, and more as more sites are added to the list. Instead, I thought it would be better if I can pass a `call`-able (eg: Proc or lambda) as the `:allow` in `disable_net_connect!`. For example:

```Ruby
WebMock.disable_net_connect!(:allow => ->(url){ url.to_str.include?('httpstat') })
```

Does this make sense? Is this desiderable?

While implementing this, I noticed that there aren't good specs to cover the different formats accepted for `allow`, so I added that, then added a case for my proposal, as above.

The resulting spec (actually, shared example: `spec/acceptance/shared/allowing_and_disabling_net_connect.rb
`) works well, but it is a far cry from DRY. I was thinking the facility to say whether a URL is allowed or not could be factored out and unit-tested separately. Then the acceptance tests could rely on a stubbed true/false response from this separate component.

If you think this new feature is acceptable, I could provide such refactoring in the future. (Unfortunately not just now; I have duties to attend).