### PR TITLE
HTTPClient: Fix manually specifying Authorization header

### DIFF
--- a/lib/webmock/http_lib_adapters/httpclient_adapter.rb
+++ b/lib/webmock/http_lib_adapters/httpclient_adapter.rb
@@ -172,9 +172,6 @@ if defined?(::HTTPClient)
     uri.port = req.header.request_uri.port
     uri = uri.omit(:userinfo)
 
-    auth = www_auth.basic_auth
-    auth.challenge(req.header.request_uri, nil)
-
     @request_filter.each do |filter|
       filter.filter_request(req)
     end
@@ -186,34 +183,9 @@ if defined?(::HTTPClient)
     end
     headers = headers_from_session(uri).merge(headers)
 
-    auth_cred = nil
-    auth_cred = auth.get(req) if auth.scheme == 'Basic'
-    headers.each do |k,v|
-      if k =~ /[Aa]uthorization/
-        if v.is_a? Array
-          v.each do |v|
-            auth_cred ||= v if v =~ /^Basic /
-          end
-        elsif v.is_a? String
-          auth_cred ||= v if v =~ /^Basic /
-        end
-      end
-    end
-
-    if auth_cred
-      userinfo = WebMock::Util::Headers.decode_userinfo_from_header(auth_cred)
-      userinfo = WebMock::Util::URI.encode_unsafe_chars_in_userinfo(userinfo)
-      headers.reject! do |k, v|
-        if k =~ /[Aa]uthorization/
-          if v.is_a? Array
-            v.reject! { |v| v =~ /^Basic / }
-            v.length == 0
-          elsif v.is_a? String
-            v =~ /^Basic /
-          end
-        end
-      end
-      uri.userinfo = userinfo
+    if auth_cred = auth_cred_from_www_auth(req) || auth_cred_from_headers(headers)
+      remove_authorization_header headers
+      uri.userinfo = userinfo_from_auth_cred auth_cred
     end
 
     signature = WebMock::RequestSignature.new(
@@ -229,6 +201,38 @@ if defined?(::HTTPClient)
     end
 
     signature
+  end
+
+  def userinfo_from_auth_cred auth_cred
+    userinfo = WebMock::Util::Headers.decode_userinfo_from_header(auth_cred)
+    WebMock::Util::URI.encode_unsafe_chars_in_userinfo(userinfo)
+  end
+
+  def remove_authorization_header headers
+    headers.reject! do |k, v|
+      next unless k =~ /[Aa]uthorization/
+      if v.is_a? Array
+        v.reject! { |v| v =~ /^Basic / }
+        v.length == 0
+      elsif v.is_a? String
+        v =~ /^Basic /
+      end
+    end
+  end
+
+  def auth_cred_from_www_auth(req)
+    auth = www_auth.basic_auth
+    auth.challenge(req.header.request_uri, nil)
+    auth.get(req) if auth.scheme == 'Basic'
+  end
+
+  def auth_cred_from_headers(headers)
+    headers.each do |k,v|
+      next unless k =~ /[Aa]uthorization/
+      return v if v.is_a?(String) && v =~ /^Basic /
+      v.each { |v| return v if v =~ /^Basic / } if v.is_a? Array
+    end
+    nil
   end
 
   def webmock_responses

--- a/spec/acceptance/httpclient/httpclient_spec.rb
+++ b/spec/acceptance/httpclient/httpclient_spec.rb
@@ -186,4 +186,12 @@ describe "HTTPClient" do
       expect(@response.body).to eq body
     end
   end
+
+  context 'credentials' do
+    it 'are detected when manually specifying Authorization header' do
+      stub_request(:get, 'username:password@www.example.com').to_return(:status => 200)
+      headers = {'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ='}
+      expect(http_request(:get, 'http://www.example.com/', {:headers => headers}).status).to eql('200')
+    end
+  end
 end


### PR DESCRIPTION
## Problem

When manually specifying the Authorization header like
```Ruby
c = HTTPClient.new
c.request :get, uri.omit(:userinfo, :query), query, body, {'Authorization' => 'Basic #{digest}'}
```
instead of like:
```Ruby
c = HTTPClient.new
c.set_basic_auth(nil, 'username', 'password')
c.request :get, uri.omit(:userinfo, :query), query, body, headers
```
WebMock does not catch the username and password and does not put it in the uri. (not the missing username and password in the url)
```
WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request: GET http://localhost/some/endpoint
```
I would expect (note the username and password being present in the url):
```
WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request: GET http://username:password@localhost/some/endpoint
```

## Why don't i just use `set_basic_auth()`?

`set_basic_auth()` is not thread-safe, and specifying it in the URI is also not supported (from what I read from the code and tried). So, the only way for me to specify the credentials in a thread-safe way is to specify the header myself.

## But, HTTPClient advertises to be thread-safe!

Yes they do, and yes they are, but setting credentials is not.

When using `HTTPClient::IncludeClient`'s `include_http_client()` (singleton behaviour for HTTPClient), it serves the same instance of HTTPClient to every thread. This causes `HTTPClient`'s instance variable `@www_auth` to be an singleton, which causes the `WWWAuth`'s instance variable `@basic_auth` to be a singleton, which causes `BasicAuth`'s instance variable `@cred` to be a singleton. 

`BasicAuth`'s instance variable `@cred` being a singleton causes the usernames and passwords to mix up in the following example

```Ruby
class FunkyClient
  extend HTTPClient::IncludeClient
  include_http_client(:method_name => :my_client)

  def do_authenticated_call(method, username, password, uri, query = nil, body = nil)
    my_client.set_basic_auth(uri, username, password) #this sets the 'singleton' `@cred`
    my_client.request method, uri, query, body # this risks executing with @cred from another thread
  end
end

# say, the following two lines are executed in their own threads, simultaniously
FunkyClient.new.do_authenticated_call(:get, 'user1', 'pass1', URI('http://localhost/')
FunkyClient.new.do_authenticated_call(:get, 'user2', 'pass2', URI('http://localhost/')
```

I tried solving this in HTTPClient, but as far as I can see, this might actually be unsolvable, because of how authentication is handled (binding credentials to an url, instead of to a session). This makes it impossible to do multi-threading/keepalive with different credentials to the same url.

## The step back to WebMock

This makes `set_basic_auth()` unsafe for multi-threading and unusable in my use-case. So i set the authentication header manually, which causes WebMock to not recognise the credentials. 

Do exactly the same in Net::HTTP and it works as expected, so i decided to fix WebMock.

## Solution

Have WebMock's `httpclient_adapter.rb` support reading the credentials directly from the header, instead of relying on HTTPClient -> WWWAuth -> BasicAuth having credentials set.

This pull request makes the changed needed to do that, plus it fixes the clearing of that header when credentials are found.