### PR TITLE
Improve parsing of params on request

### DIFF
--- a/lib/webmock/util/query_mapper.rb
+++ b/lib/webmock/util/query_mapper.rb
@@ -143,12 +143,12 @@ module WebMock::Util
         array_value = !!(last_key =~ /\[\]$/)
         last_key = last_key.gsub(/[\[\]]/, '')
         if current_node.is_a? Array
-          container = current_node.find { |n| n.is_a?(Hash) && n.has_key?(last_key) }
-          if container
+          last_container = current_node.select { |n| n.is_a?(Hash) }.last
+          if last_container && !last_container.has_key?(last_key)
             if array_value
-              container[last_key] << value
+              last_container[last_key] << value
             else
-              container[last_key] = value
+              last_container[last_key] = value
             end
           else
             if array_value

--- a/spec/unit/request_pattern_spec.rb
+++ b/spec/unit/request_pattern_spec.rb
@@ -391,6 +391,24 @@ describe WebMock::RequestPattern do
             expect(WebMock::RequestPattern.new(:post, "www.example.com", :body => {:a => /^\d+$/, :b => {:c => /^\d{3}$/}})).
               not_to match(WebMock::RequestSignature.new(:post, "www.example.com", :body => 'a=abcde&b[c]=123'))
           end
+
+          context 'body is an hash with an array of hashes' do
+            let(:body_hash) { {:a => [{'b' => '1'}, {'b' => '2'}]} }
+
+            it "should match when hash matches body" do
+              expect(WebMock::RequestPattern.new(:post, 'www.example.com', :body => body_hash)).
+                to match(WebMock::RequestSignature.new(:post, "www.example.com", :body => 'a[][b]=1&a[][b]=2'))
+            end
+          end
+
+          context 'body is an hash with an array of hashes with multiple keys' do
+            let(:body_hash) { {:a => [{'b' => '1', 'a' => '2'}, {'b' => '3'}]} }
+
+            it "should match when hash matches body" do
+              expect(WebMock::RequestPattern.new(:post, 'www.example.com', :body => body_hash)).
+                to match(WebMock::RequestSignature.new(:post, "www.example.com", :body => 'a[][b]=1&a[][a]=2&a[][b]=3'))
+            end
+          end
         end
 
         describe "for request with json body and content type is set to json" do

--- a/spec/unit/util/query_mapper_spec.rb
+++ b/spec/unit/util/query_mapper_spec.rb
@@ -106,9 +106,16 @@ describe WebMock::Util::QueryMapper do
     expect(subject.query_to_values query).to eq values
   end
 
-  it 'converts complex nested values, vice versa' do
+  it 'converts complex nested hashes, vice versa' do
     query = "one%5B%5D[foo]=bar&one%5B%5D[zoo]=car" # one[][foo]=bar&one[][zoo]=car
-    values = {"one" => [{"foo" => "bar"}, {"zoo" => "car"}]}
+    values = {"one" => [{"foo" => "bar", "zoo" => "car"}]}
+    expect(subject.values_to_query values).to eq query
+    expect(subject.query_to_values query).to eq values
+  end
+
+  it 'converts complex nested array of hashes, vice versa' do
+    query = "one%5B%5D[foo]=bar&one%5B%5D[foo]=bar&one%5B%5D[zoo]=car" # one[][foo]=bar&one[][foo]=bar&one[][zoo]=car
+    values = {"one" => [{"foo" => "bar"}, {"foo" => "bar", "zoo" => "car"}]}
     expect(subject.values_to_query values).to eq query
     expect(subject.query_to_values query).to eq values
   end


### PR DESCRIPTION
I went through the issues and saw nothing related to this. When stubbing requests, I was having difficult when dealing with a more complex structure (array of hashes).

Here the approach followed is iterate through the params and create a new hash on the array if the key already exists in the last hash.