### PR TITLE
Only raises symbol headers exception if `RUBY_VERSION` < 2.3.0

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -304,7 +304,8 @@ module WebMock
     end
 
     def self.validate_headers(headers)
-      # If you make a request with headers that are symbols Net::HTTP raises a NoMethodError
+      # For Ruby versions < 2.3.0, if you make a request with headers that are symbols
+      # Net::HTTP raises a NoMethodError
       #
       # WebMock normalizes headers when creating a RequestSignature,
       # and will update all headers from symbols to strings.
@@ -313,9 +314,11 @@ module WebMock
       #
       # So before this point, WebMock raises an ArgumentError if any of the headers are symbols
       # instead of the cryptic NoMethodError "undefined method `split' ...` from Net::HTTP
-      header_as_symbol = headers.keys.find {|header| header.is_a? Symbol}
-      if header_as_symbol
-        raise ArgumentError.new("Net:HTTP does not accept headers as symbols")
+      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0')
+        header_as_symbol = headers.keys.find {|header| header.is_a? Symbol}
+        if header_as_symbol
+          raise ArgumentError.new("Net:HTTP does not accept headers as symbols")
+        end
       end
     end
 

--- a/spec/acceptance/net_http/net_http_spec.rb
+++ b/spec/acceptance/net_http/net_http_spec.rb
@@ -106,7 +106,7 @@ describe "Net:HTTP" do
     expect(Net::HTTP.start("www.example.com") { |query| query.get("/") }.body).to eq("abc"*100000)
   end
 
-  it "raises an ArgumentError if passed headers as symbols" do
+  it "raises an ArgumentError if passed headers as symbols if RUBY_VERSION < 2.3.0" do
     uri = URI.parse("http://google.com/")
     http = Net::HTTP.new(uri.host, uri.port)
     request = Net::HTTP::Get.new(uri.request_uri)
@@ -123,9 +123,15 @@ describe "Net:HTTP" do
       end
     end
 
-    expect do
-      http.request(request)
-    end.to raise_error ArgumentError, "Net:HTTP does not accept headers as symbols"
+    if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0')
+      expect do
+        http.request(request)
+      end.to raise_error ArgumentError, "Net:HTTP does not accept headers as symbols"
+    else
+      expect do
+        http.request(request)
+      end.to_not raise_error ArgumentError, "Net:HTTP does not accept headers as symbols"
+    end
   end
 
   it "should handle multiple values for the same response header" do


### PR DESCRIPTION
Fixes #595.