### PR TITLE
Don't shadow outer variable in reject! block.

### DIFF
--- a/lib/webmock/http_lib_adapters/httpclient_adapter.rb
+++ b/lib/webmock/http_lib_adapters/httpclient_adapter.rb
@@ -209,13 +209,13 @@ if defined?(::HTTPClient)
   end
 
   def remove_authorization_header headers
-    headers.reject! do |k, v|
-      next unless k =~ /[Aa]uthorization/
-      if v.is_a? Array
-        v.reject! { |v| v =~ /^Basic / }
-        v.length == 0
-      elsif v.is_a? String
-        v =~ /^Basic /
+    headers.reject! do |name, value|
+      next unless name =~ /[Aa]uthorization/
+      if value.is_a? Array
+        value.reject! { |v| v =~ /^Basic / }
+        value.length == 0
+      elsif value.is_a? String
+        value =~ /^Basic /
       end
     end
   end


### PR DESCRIPTION
This emits a warning when running a test suite with warnings enabled. Renaming the outer variables to name and value make it slightly more readable and removes the warning.