### PR TITLE
make easier to run non-network specs quickly.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,11 +23,9 @@ require 'support/my_rack_app'
 CURL_EXAMPLE_OUTPUT_PATH = File.expand_path('../support/example_curl_output.txt', __FILE__)
 
 RSpec.configure do |config|
-  unless NetworkConnection.is_network_available?
+  no_network_connection = ENV["NO_CONNECTION"] || ! NetworkConnection.is_network_available?
+  if no_network_connection
     warn("No network connectivity. Only examples which do not make real network connections will run.")
-    no_network_connection = true
-  end
-  if ENV["NO_CONNECTION"] || no_network_connection
     config.filter_run_excluding :net_connect => true
   end
 


### PR DESCRIPTION
spec_helper does potentially expensive check every time rspec starts
(waits for non responsive server 173.194.113.176, in theory only 5s, but in my experience a lot longer)
but if you want to repeatedly run a single non-network (e.g. unit) spec this is tiresome. In this modificatiion it will skip this expensive check if the env var NO_CONNECTION is already set.