### PR TITLE
Fix issue regarding hash with nested array

### DIFF
--- a/lib/webmock/util/query_mapper.rb
+++ b/lib/webmock/util/query_mapper.rb
@@ -146,6 +146,7 @@ module WebMock::Util
           last_container = current_node.select { |n| n.is_a?(Hash) }.last
           if last_container && !last_container.has_key?(last_key)
             if array_value
+              last_container[last_key] ||= []
               last_container[last_key] << value
             else
               last_container[last_key] = value
@@ -159,7 +160,7 @@ module WebMock::Util
           end
         else
           if array_value
-            current_node[last_key] = [] unless current_node[last_key]
+            current_node[last_key] ||= []
             current_node[last_key] << value
           else
             current_node[last_key] = value

--- a/spec/unit/util/query_mapper_spec.rb
+++ b/spec/unit/util/query_mapper_spec.rb
@@ -48,6 +48,22 @@ describe WebMock::Util::QueryMapper do
       expect(hsh['a'][0]['b'][0]['c'][0]['d'][0]).to eq('1')
       expect(hsh['a'][0]['b'][0]['c'][0]['d'][1]['e']).to eq('2')
     end
+
+    it "should parse nested repeated correctly" do
+      query = "a[][b][]=one&a[][b][]=two"
+      hsh = subject.query_to_values(query)
+      expect(hsh['a']).to be_a(Array)
+      expect(hsh['a'][0]).to eq({"b" => ['one']})
+      expect(hsh['a'][1]).to eq({"b" => ['two']})
+    end
+
+    it "should parse nested non-repeated correctly" do
+      query = "a[][b][]=one&a[][c][]=two"
+      hsh = subject.query_to_values(query)
+      expect(hsh['a']).to be_a(Array)
+      expect(hsh['a'][0]['b']).to eq(['one'])
+      expect(hsh['a'][0]['c']).to eq(['two'])
+    end
   end
 
   context '#to_query' do


### PR DESCRIPTION
Fix the issue correctly raised by @timdiggins [here](https://github.com/bblimke/webmock/pull/590#commitcomment-16873516).

I took the specs that @timdiggins created and fix the issue.

One change was made to one of the specs since:
```
Rack::Utils.parse_nested_query("a[][b][]=one&a[][c][]=two") #=> {"a"=>[{"b"=>["one"], "c"=>["two"]}]}
```