### PR TITLE
WebMock should load "base64"

### DIFF
--- a/lib/webmock/util/headers.rb
+++ b/lib/webmock/util/headers.rb
@@ -1,3 +1,5 @@
+require 'base64'
+
 module WebMock
 
   module Util


### PR DESCRIPTION
WebMock uses base64 but it doe not load base64 by itself. It may cause `NameError: uninitialized constant WebMock::Util::Headers::Base64`.