### PR TITLE
Resolve RSpec warning

### DIFF
--- a/spec/acceptance/net_http/net_http_spec.rb
+++ b/spec/acceptance/net_http/net_http_spec.rb
@@ -137,9 +137,10 @@ describe "Net:HTTP" do
         http.request(request)
       end.to raise_error ArgumentError, "Net:HTTP does not accept headers as symbols"
     else
+      stub_http_request(:get, "google.com").with(headers: { InvalidHeaderSinceItsASymbol: "this will not be valid" })
       expect do
         http.request(request)
-      end.to_not raise_error ArgumentError, "Net:HTTP does not accept headers as symbols"
+      end.not_to raise_error
     end
   end
 


### PR DESCRIPTION
RSpec warns:

WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass,
message)` risks false positives, since literally any other error
would cause the expectation to pass, including those raised by Ruby
(e.g. NoMethodError, NameError and ArgumentError), meaning the code you
are intending to test may not even get reached. Instead consider using
`expect {}.not_to raise_error`. This message can be supressed by setting:
`RSpec::Expectations.configuration.warn_about_potential_false_positives = false`