### PR TITLE
Resolve warning about `Object#timeout`

### DIFF
--- a/spec/support/network_connection.rb
+++ b/spec/support/network_connection.rb
@@ -3,7 +3,7 @@ require 'socket'
 
 module NetworkConnection
   def self.connect_to(host, port, timeout=10)
-    timeout(timeout) do
+    Timeout.timeout(timeout) do
       TCPSocket.new(host, port)
     end
   end


### PR DESCRIPTION
`Object#timeout` is deprecated.