### PR TITLE
Fix regex comparison

### DIFF
--- a/lib/webmock/webmock.rb
+++ b/lib/webmock/webmock.rb
@@ -68,8 +68,8 @@ module WebMock
     when Array
       allowed.any? { |allowed_item| net_connect_explicit_allowed?(allowed_item, uri) }
     when Regexp
-      uri.to_s =~ allowed ||
-      uri.omit(:port).to_s =~ allowed && uri.port == uri.default_port
+      (uri.to_s =~ allowed) != nil ||
+      (uri.omit(:port).to_s =~ allowed) != nil && uri.port == uri.default_port
     when String
       allowed == uri.to_s ||
       allowed == uri.host ||


### PR DESCRIPTION
Before this change:

```
> WebMock.net_connect_explicit_allowed?(/.*example.*/, 'http://example.com')
0
```

After:

```
> WebMock.net_connect_explicit_allowed?(/.*example.*/, 'http://example.com')
true
```

I was having trouble with some non-shareable case, this change fixes it.

