### PR TITLE
Add config notice for codeclimate

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ include WebMock::API
 WebMock.enable!
 ```
 
+### Using Codeclimate?
+
+ Add this to your helper file (wherever you added the above):
+ 
+ ```ruby
+ WebMock.disable_net_connect!(allow: 'codeclimate.com')
+ ```
+
 ## Examples
 
 


### PR DESCRIPTION
Adding webmock to a project using codeclimate breaks the codeclimate reporter: https://github.com/codeclimate/ruby-test-reporter/issues/23

Add a line in the docs to give the solution.