### PR TITLE
use Base64.strict_encode64 to avoid trying to match against a multiline Authorization: header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
   or
 
         stub_request(:get, "www.example.com").
-          with(headers: 'Authorization' => "Basic #{ Base64.encode64('user:pass').chomp}")
+          with(headers: 'Authorization' => "Basic #{ Base64.strict_encode64('user:pass').chomp}")
 
   In order to stub a request with basic authentication credentials provided in the url, please use the following code:
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ RestClient.post('www.example.com', 'abc')    # ===> Success
 stub_request(:get, "www.example.com").with(basic_auth: ['user', 'pass'])
 # or
 # stub_request(:get, "www.example.com").
-#   with(headers: 'Authorization' => "Basic #{ Base64.encode64('user:pass').chomp}")
+#   with(headers: 'Authorization' => "Basic #{ Base64.strict_encode64('user:pass').chomp}")
 
 Net::HTTP.start('www.example.com') do |http|
   req = Net::HTTP::Get.new('/')

--- a/lib/webmock/util/headers.rb
+++ b/lib/webmock/util/headers.rb
@@ -39,7 +39,7 @@ module WebMock
       end
 
       def self.basic_auth_header(*credentials)
-        "Basic #{Base64.encode64(credentials.join(':')).chomp}"
+        "Basic #{Base64.strict_encode64(credentials.join(':')).chomp}"
       end
 
     end

--- a/spec/acceptance/shared/stubbing_requests.rb
+++ b/spec/acceptance/shared/stubbing_requests.rb
@@ -403,6 +403,11 @@ shared_examples_for "stubbing requests" do |*adapter_info|
         expect(http_request(:get, "http://www.example.com/", basic_auth: ['user', 'pass']).status).to eq("200")
       end
 
+      it "should match if credentials are the same and encode to more than one line" do
+        stub_request(:get, "www.example.com").with(basic_auth: ['user' * 5, 'pass' * 5])
+        expect(http_request(:get, "http://www.example.com/", basic_auth: ['user' * 5, 'pass' * 5]).status).to eq("200")
+      end
+
       it "should match if credentials are the same and were provided directly as authentication headers in request" do
         stub_request(:get, "www.example.com").with(basic_auth: ['user', 'pass'])
         expect(http_request(:get, "http://www.example.com/", headers: {'Authorization'=>'Basic dXNlcjpwYXNz'}).status).to eq("200")


### PR DESCRIPTION
if your `user:pass` string is long enough `Base64.encode64` will return a multiline value which breaks matching:
```
stub_request(:post, "https://example.com").with(basic_auth: [ 'useruseruseruseruseruseruseruseruseruser', 'passpasspasspasspasspasspasspass'])

# then in our test
Real HTTP connections are disabled. Unregistered request: POST https://example.com with headers {'Authorization'=>'Basic dXNlcnVzZXJ1c2VydXNlcnVzZXJ1c2VydXNlcnVzZXJ1c2VydXNlcjpwYXNzcGFzc3Bhc3NwYXNzcGFzc3Bhc3NwYXNzcGFzcw=='}

You can stub this request with the following snippet:

stub_request(:post, "https://example.com").
  with(:headers => { 'Authorization'=>'Basic dXNlcnVzZXJ1c2VydXNlcnVzZXJ1c2VydXNlcnVzZXJ1c2VydXNlcjpwYXNzcGFzc3Bhc3NwYXNzcGFzc3Bhc3NwYXNzcGFzcw=='}).
  to_return(:status => 200, :body => "", :headers => {})

registered request stubs:
stub_request(:post, "https://example.com").
  with(:headers => { 'Authorization'=>'Basic dXNlcnVzZXJ1c2VydXNlcnVzZXJ1c2VydXNlcnVzZXJ1c2VydXNlcjpwYXNz
cGFzc3Bhc3NwYXNzcGFzc3Bhc3NwYXNzcGFzcw=='})
```