### PR TITLE
Fix warnings

### DIFF
--- a/lib/webmock/http_lib_adapters/excon_adapter.rb
+++ b/lib/webmock/http_lib_adapters/excon_adapter.rb
@@ -19,6 +19,11 @@ if defined?(Excon)
 
         adapter_for :excon
 
+        instance_exec do
+          @original_excon_mock_default = nil
+          @stub = nil
+        end
+
         def self.enable!
           self.add_excon_stub
         end

--- a/lib/webmock/request_body_diff.rb
+++ b/lib/webmock/request_body_diff.rb
@@ -15,9 +15,10 @@ module WebMock
       HashDiff.diff(request_signature_body_hash, request_stub_body_hash)
     end
 
-    private
-
     attr_reader :request_signature, :request_stub
+    private :request_signature, :request_stub
+
+    private
 
     def request_signature_diffable?
       request_signature.json_headers? && request_signature_parseable_json?

--- a/lib/webmock/util/version_checker.rb
+++ b/lib/webmock/util/version_checker.rb
@@ -31,7 +31,11 @@ module WebMock
 
       @major,     @minor,     @patch     = parse_version(library_version)
       @min_major, @min_minor, @min_patch = parse_version(min_patch_level)
-      @max_major, @max_minor             = parse_version(max_minor_version) if max_minor_version
+      if max_minor_version
+        @max_major, @max_minor           = parse_version(max_minor_version)
+      else
+        @max_major, @max_minor           = nil, nil
+      end
 
       @comparison_result = compare_version
     end

--- a/spec/acceptance/em_http_request/em_http_request_spec.rb
+++ b/spec/acceptance/em_http_request/em_http_request_spec.rb
@@ -274,12 +274,12 @@ unless RUBY_PLATFORM =~ /java/
           err = :success_from_timeout
           EM.stop
         end.errback do |resp|
-          conn.get(:path => "/foo").callback do |resp|
-            expect(resp.response_header.status).to eq(200)
-            body = resp.response
+          conn.get(:path => "/foo").callback do |retry_resp|
+            expect(retry_resp.response_header.status).to eq(200)
+            body = retry_resp.response
             EM.stop
-          end.errback do |resp|
-            err = resp.error
+          end.errback do |retry_resp|
+            err = retry_resp.error
             EM.stop
           end
         end

--- a/spec/acceptance/httpclient/httpclient_spec.rb
+++ b/spec/acceptance/httpclient/httpclient_spec.rb
@@ -188,7 +188,7 @@ describe "HTTPClient" do
 
     it 'sets the full body on the webmock response' do
       body = ''
-      result = HTTPClient.new.request(:get, 'http://www.example.com/') do |http_res, chunk|
+      HTTPClient.new.request(:get, 'http://www.example.com/') do |http_res, chunk|
         body += chunk
       end
       expect(@response.body).to eq body

--- a/spec/acceptance/httpclient/httpclient_spec_helper.rb
+++ b/spec/acceptance/httpclient/httpclient_spec_helper.rb
@@ -20,14 +20,7 @@ module HTTPClientSpecHelper
     else
       response = c.request(*params, &block)
     end
-    headers = response.header.all.inject({}) do |headers, header|
-      if !headers.has_key?(header[0])
-        headers[header[0]] = header[1]
-      else
-        headers[header[0]] = [headers[header[0]], header[1]].join(', ')
-      end
-      headers
-    end
+    headers = merge_headers(response)
     OpenStruct.new({
       :body => HTTPClientSpecHelper.async_mode ? response.content.read : response.content,
       :headers => headers,
@@ -48,4 +41,16 @@ module HTTPClientSpecHelper
     :httpclient
   end
 
+private
+
+  def merge_headers(response)
+    response.header.all.inject({}) do |headers, header|
+      if !headers.has_key?(header[0])
+        headers[header[0]] = header[1]
+      else
+        headers[header[0]] = [headers[header[0]], header[1]].join(', ')
+      end
+      headers
+    end
+  end
 end

--- a/spec/acceptance/net_http/net_http_spec_helper.rb
+++ b/spec/acceptance/net_http/net_http_spec_helper.rb
@@ -10,8 +10,8 @@ module NetHTTPSpecHelper
     req = clazz.new("#{uri.path}#{uri.query ? '?' : ''}#{uri.query}", nil)
     options[:headers].each do |k,v|
       if v.is_a?(Array)
-        v.each_with_index do |v,i|
-          i == 0 ? (req[k] = v) : req.add_field(k, v)
+        v.each_with_index do |e,i|
+          i == 0 ? (req[k] = e) : req.add_field(k, e)
         end
       else
         req[k] = v
@@ -31,8 +31,8 @@ module NetHTTPSpecHelper
       http.read_timeout = 60
     end
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-    response = http.start {|http|
-      http.request(req, options[:body], &block)
+    response = http.start {|open_http|
+      open_http.request(req, options[:body], &block)
     }
     headers = {}
     response.each_header {|name, value| headers[name] = value}

--- a/spec/acceptance/shared/returning_declared_responses.rb
+++ b/spec/acceptance/shared/returning_declared_responses.rb
@@ -1,5 +1,11 @@
 class MyException < StandardError; end;
 
+class Responder
+  def call(request)
+    {:body => request.body}
+  end
+end
+
 shared_context "declared responses" do |*adapter_info|
   describe "when request stub declares that request should raise exception" do
     it "should raise exception" do
@@ -128,12 +134,6 @@ shared_context "declared responses" do |*adapter_info|
     end
 
     describe "when response was declared as lambda" do
-      class Responder
-        def call(request)
-          {:body => request.body}
-        end
-      end
-
       it "should return evaluated response body" do
         stub_request(:post, "www.example.com").to_return(lambda {|request|
                                                                 {:body => request.body}

--- a/spec/acceptance/shared/stubbing_requests.rb
+++ b/spec/acceptance/shared/stubbing_requests.rb
@@ -34,8 +34,8 @@ shared_examples_for "stubbing requests" do |*adapter_info|
         begin
           http_request(:get, "http://www.example.com/hello+/?#{NOT_ESCAPED_PARAMS}")
         rescue WebMock::NetConnectNotAllowedError => e
-          expect(e.message).to match /Unregistered request: GET http:\/\/www\.example\.com\/hello\+\/\?x=ab%20c&z='Stop!'%20said%20Fred%20m/m
-          expect(e.message).to match /stub_request\(:get, "http:\/\/www\.example\.com\/hello\+\/\?x=ab%20c&z='Stop!'%20said%20Fred%20m"\)/m
+          expect(e.message).to match(/Unregistered request: GET http:\/\/www\.example\.com\/hello\+\/\?x=ab%20c&z='Stop!'%20said%20Fred%20m/m)
+          expect(e.message).to match(/stub_request\(:get, "http:\/\/www\.example\.com\/hello\+\/\?x=ab%20c&z='Stop!'%20said%20Fred%20m"\)/m)
         end
 
         stub_request(:get, "http://www.example.com/hello+/?x=ab%20c&z='Stop!'%20said%20Fred%20m")

--- a/spec/acceptance/typhoeus/typhoeus_hydra_spec.rb
+++ b/spec/acceptance/typhoeus/typhoeus_hydra_spec.rb
@@ -104,8 +104,8 @@ unless RUBY_PLATFORM =~ /java/
           test_body = nil
           test_complete = nil
           skip("This test requires a newer version of Typhoeus") unless @request.respond_to?(:on_body)
-          @request.on_body do |body, response|
-            test_body = body
+          @request.on_body do |body_chunk, response|
+            test_body = body_chunk
           end
           @request.on_complete do |response|
             test_complete = response.body


### PR DESCRIPTION
This is a collection of minor updates to remove Ruby warnings from the gem. These should all be very low risk changes. By fixing these warnings it helps to eliminate noise in projects which use the gem and have warnings enabled. It's always kind for gems to produce zero warnings if possible.

The most visible to projects that use `webmock` are the warnings coming from the `lib` directory. While I was running the specs I noticed that several additional warnings came from some spec support files. I went ahead and cleaned those up as well.

I left off the local changes I made to the `spec/spec_helper.rb` which expose the warnings when running the specs as that's more a decision the core team needs to make. Also, JRuby has some gems like `manticore` and `cookiejar` which produce a lot of warnings making those builds very noisy. I'm happy to add them back and re-submit the PR if you'd like.