### PR TITLE
reset postion

### DIFF
--- a/lib/webmock/http_lib_adapters/httpclient_adapter.rb
+++ b/lib/webmock/http_lib_adapters/httpclient_adapter.rb
@@ -182,6 +182,10 @@ if defined?(::HTTPClient)
     end
     headers = headers_from_session(uri).merge(headers)
 
+    req.http_body.positions.each do |file, position|
+      req.http_body.positions[file] = 0
+    end
+
     signature = WebMock::RequestSignature.new(
       req.header.request_method.downcase.to_sym,
       uri.to_s,


### PR DESCRIPTION
Error occured when FILE IO's postion is END.
I think that you should reset file's position when webmock builds a request.
