### PR TITLE
Correct Net::HTTP open timeout exception class

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -168,13 +168,28 @@ module WebMock
 
           response.extend Net::WebMockHTTPResponse
 
-          raise Timeout::Error, "execution expired" if webmock_response.should_timeout
+          if webmock_response.should_timeout
+            raise timeout_exception, "execution expired"
+          end
 
           webmock_response.raise_error_if_any
 
           yield response if block_given?
 
           response
+        end
+
+        def timeout_exception
+          if defined?(Net::OpenTimeout)
+            # Ruby 2.x
+            Net::OpenTimeout
+          elsif defined?(Net::HTTP::OpenTimeout)
+            # Ruby 1.9
+            Net::HTTP::OpenTimeout
+          else
+            # Fallback, if things change
+            Timeout::Error
+          end
         end
 
         def build_webmock_response(net_http_response)

--- a/spec/acceptance/net_http/net_http_spec_helper.rb
+++ b/spec/acceptance/net_http/net_http_spec_helper.rb
@@ -45,7 +45,13 @@ module NetHTTPSpecHelper
   end
 
   def client_timeout_exception_class
-    Timeout::Error
+    if defined?(Net::OpenTimeout)
+      Net::OpenTimeout
+    elsif defined?(Net::HTTP::OpenTimeout)
+      Net::HTTP::OpenTimeout
+    else
+      Timeout::Error
+    end
   end
 
   def connection_refused_exception_class


### PR DESCRIPTION
Net::HTTP raises a `Net::OpenTimeout`, a subclass of `Timeout::Error`, on open timeouts. It used a different class in 1.9 vs 2.x: https://github.com/ruby/ruby/commit/09f27873ed653bd4afb5538b669e2362f3b1bf6e

This is relevant because libraries like Faraday implement specific behavior on `Net::OpenTimeout`: https://github.com/lostisland/faraday/blob/v0.9.2/lib/faraday/adapter/net_http.rb#L28 and it can cause significantly different error handling in production vs under webmock.

This PR could may cause consumer's tests to break if they are asserting on the timeout class by name instead of hierarchy, but it implements the actual behavior of the library being stubbed.