### PR TITLE
Support Ruby 2.4

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -248,6 +248,9 @@ class StubSocket #:nodoc:
     @closed ||= true
   end
 
+  def close
+  end
+
   def readuntil(*args)
   end
 
@@ -256,7 +259,7 @@ end
 module Net  #:nodoc: all
 
   class WebMockNetBufferedIO < BufferedIO
-    def initialize(io, debug_output = nil)
+    def initialize(io, read_timeout: 60, continue_timeout: nil, debug_output: nil)
       @read_timeout = 60
       @rbuf = ''
       @debug_output = debug_output

--- a/lib/webmock/request_stub.rb
+++ b/lib/webmock/request_stub.rb
@@ -62,7 +62,7 @@ module WebMock
     end
 
     def times(number)
-      raise "times(N) accepts integers >= 1 only" if !number.is_a?(Fixnum) || number < 1
+      raise "times(N) accepts integers >= 1 only" if !number.is_a?(Integer) || number < 1
       if @responses_sequences.empty?
         raise "Invalid WebMock stub declaration." +
           " times(N) can be declared only after response declaration."


### PR DESCRIPTION
This PR made the following changes in preparation Ruby 2.4.

- Fix deprecated warnings caused by [unifies Fixnum and Bignum into Integer](https://bugs.ruby-lang.org/issues/12005)
- Fix failure test caused by [add keyword arguments for Net::BufferedIO#initial attributes](https://github.com/ruby/ruby/commit/dad2382270b8bcfc56a0e2dd73c6201e63ed1a7c#diff-00a99d8c71daaf5fc60a050da41f7261L82)