### PR TITLE
Synchronous hash counter access from request registry.

### DIFF
--- a/lib/webmock/request_registry.rb
+++ b/lib/webmock/request_registry.rb
@@ -14,11 +14,9 @@ module WebMock
     end
 
     def times_executed(request_pattern)
-      self.requested_signatures.lock.synchronize do
-        self.requested_signatures.hash.select { |request_signature, times_executed|
-          request_pattern.matches?(request_signature)
-        }.inject(0) {|sum, (_, times_executed)| sum + times_executed }
-      end
+      self.requested_signatures.select do |request_signature|
+        request_pattern.matches?(request_signature)
+      end.inject(0) { |sum, (_, times_executed)| sum + times_executed }
     end
 
     def to_s

--- a/lib/webmock/request_registry.rb
+++ b/lib/webmock/request_registry.rb
@@ -14,9 +14,11 @@ module WebMock
     end
 
     def times_executed(request_pattern)
-      self.requested_signatures.hash.select { |request_signature, times_executed|
-        request_pattern.matches?(request_signature)
-      }.inject(0) {|sum, (_, times_executed)| sum + times_executed }
+      self.requested_signatures.lock.synchronize do
+        self.requested_signatures.hash.select { |request_signature, times_executed|
+          request_pattern.matches?(request_signature)
+        }.inject(0) {|sum, (_, times_executed)| sum + times_executed }
+      end
     end
 
     def to_s

--- a/lib/webmock/util/hash_counter.rb
+++ b/lib/webmock/util/hash_counter.rb
@@ -4,6 +4,7 @@ module WebMock
   module Util
     class Util::HashCounter
       attr_accessor :hash
+      attr_accessor :lock
       def initialize
         self.hash = {}
         @order = {}

--- a/lib/webmock/util/hash_counter.rb
+++ b/lib/webmock/util/hash_counter.rb
@@ -4,7 +4,6 @@ module WebMock
   module Util
     class Util::HashCounter
       attr_accessor :hash
-      attr_accessor :lock
       def initialize
         self.hash = {}
         @order = {}
@@ -20,6 +19,13 @@ module WebMock
       def get key
         @lock.synchronize do
           hash[key] || 0
+        end
+      end
+
+      def select(&block)
+        return unless block_given?
+        @lock.synchronize do
+          hash.select &block
         end
       end
 


### PR DESCRIPTION
Fixes https://github.com/bblimke/webmock/issues/606

We had the same
```
can't add a new key into hash during iteration
```
issue in our specs, and I think the [issue](https://github.com/bblimke/webmock/issues/606) above did capture the cause.

My naive try here seemed to fix the problem for us, but as I don't fully understand the details, this may not be a good solution. Still thought I would PR it and get feedback. Happy to iterate on this and add some specs.