### PR TITLE
Don't mutate the query argument

### DIFF
--- a/lib/webmock/util/query_mapper.rb
+++ b/lib/webmock/util/query_mapper.rb
@@ -39,7 +39,7 @@ module WebMock::Util
       #   #=> [['one', 'two'], ['one', 'three']]
       def query_to_values(query, options={})
         return nil if query.nil?
-        query.force_encoding('utf-8') if query.respond_to?(:force_encoding)
+        query = query.dup.force_encoding('utf-8') if query.respond_to?(:force_encoding)
 
         options[:notation] ||= :subscript
 

--- a/spec/unit/util/query_mapper_spec.rb
+++ b/spec/unit/util/query_mapper_spec.rb
@@ -64,6 +64,12 @@ describe WebMock::Util::QueryMapper do
       expect(hsh['a'][0]['b']).to eq(['one'])
       expect(hsh['a'][0]['c']).to eq(['two'])
     end
+
+    it 'should not attempt to mutate its query argument' do
+      query = "a=foo".freeze
+      hsh = subject.query_to_values(query)
+      expect(hsh['a']).to eq('foo')
+    end
   end
 
   context '#to_query' do


### PR DESCRIPTION
@bblimke 

People who have opted in to the `frozen_string_literal: true` Ruby 2.3 option, which makes all string literals frozen/immutable by default, will run into an error when attempting to use the `query` option in `webmock`.

This option causes all string literals to be frozen. I've imitated this in the test with an explicit `freeze` call on the argument. This will be the default on Ruby 3. More details on this Ruby 2.3 option are at https://wyeworks.com/blog/2015/12/1/immutable-strings-in-ruby-2-dot-3.

The `force_encoding` call here was causing a `can't modify frozen String` error when this setting was enabled because, like the webmock docs, I was passing in a string literal for the query.

Running the new test locally without the query mapper change results in this error:

```
Failures:

  1) WebMock::Util::QueryMapper#query_to_values should not attempt to mutate its query argument
     Failure/Error: query.force_encoding('utf-8') if query.respond_to?(:force_encoding)

     RuntimeError:
       can't modify frozen String
     # ./lib/webmock/util/query_mapper.rb:42:in `force_encoding'
     # ./lib/webmock/util/query_mapper.rb:42:in `query_to_values'
     # ./spec/unit/util/query_mapper_spec.rb:70:in `block (3 levels) in <top (required)>'
```

Admittedly I don't really understand the case where `query` does _not_ respond to `force_encoding` here, so careful eyes would be appreciated.