### PR TITLE
Http.rb 2.2 fix

### DIFF
--- a/lib/webmock/http_lib_adapters/http_rb/response.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/response.rb
@@ -14,7 +14,7 @@ module HTTP
       def from_webmock(webmock_response, request_signature = nil)
         status  = Status.new(webmock_response.status.first)
         headers = webmock_response.headers || {}
-        body    = Body.new Streamer.new webmock_response.body
+        body    = Body.new(webmock_response.body, Streamer.new(webmock_response.body))
         uri     = normalize_uri(request_signature && request_signature.uri)
 
         return new(status, "1.1", headers, body, uri) if HTTP::VERSION < "1.0.0"

--- a/webmock.gemspec
+++ b/webmock.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency 'typhoeus', '>= 0.5.0'
   end
 
-  s.add_development_dependency 'http',            '>= 0.8.0'
+  s.add_development_dependency 'http',            '>= 2.2.0'
   s.add_development_dependency 'manticore',       '>= 0.5.1' if RUBY_PLATFORM =~ /java/
   s.add_development_dependency 'rack',            ((RUBY_VERSION < '2.2.2') ? '1.6.0' : '> 1.6')
   s.add_development_dependency 'rspec',           '>= 3.1.0'


### PR DESCRIPTION
So, it turns out that Http.rb changed constructor for the `Http::Response::Body` class, which now requires 2, instead of one parameter.

This change broke WebMock, resulting that when you’re trying to call stubbed request, you’ll get following error:

```
require 'http'
HTTP::VERSION # => 2.2.0
HTTP.get("https://google.com") # => #<HTTP::Response/1.1 302 Found {"Cache-Control"=>"private", "Content-Type"=>"text/html; charset=UTF-8", "Location"=>"https://www.google.pl/?gfe_rd=cr&ei=75mUWLDZJMLi8Af7_6HYCA", "Content-Length"=>"259", "Date"=>"Fri, 03 Feb 2017 14:55:43 GMT", "Alt-Svc"=>"quic=\":443\"; ma=2592000; v=\"35,34\"", "Connection"=>"close"}>

require "webmock/rspec"
include WebMock::API
stub_request(:get, "https://google.com/").to_return(body: "hello!")
WebMock::VERSION #=>  => 2.3.2
HTTP.get("https://google.com")
ArgumentError: wrong number of arguments (given 1, expected 2..3)
```


This pull request bumps http.rb dependency to `>= 2.2.0` *and* fixes that behaviour.


