### PR TITLE
Some tests require network connectivity.

### DIFF
--- a/spec/acceptance/httpclient/httpclient_spec.rb
+++ b/spec/acceptance/httpclient/httpclient_spec.rb
@@ -182,7 +182,7 @@ describe "HTTPClient" do
     end
   end
 
-  context 'httpclient streams response' do
+  context 'httpclient streams response', net_connect: true do
     before do
       WebMock.allow_net_connect!
       WebMock.after_request(except: [:other_lib])  do |_, response|
@@ -199,7 +199,7 @@ describe "HTTPClient" do
     end
   end
 
-  context 'credentials' do
+  context 'credentials', net_connect: true do
     it 'are detected when manually specifying Authorization header' do
       stub_request(:get, 'username:password@www.example.com').to_return(status: 200)
       headers = {'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ='}

--- a/spec/acceptance/httpclient/httpclient_spec.rb
+++ b/spec/acceptance/httpclient/httpclient_spec.rb
@@ -199,9 +199,10 @@ describe "HTTPClient" do
     end
   end
 
-  context 'credentials', net_connect: true do
+  context 'credentials' do
     it 'are detected when manually specifying Authorization header' do
-      stub_request(:get, 'username:password@www.example.com').to_return(status: 200)
+      stub_request(:get, "http://www.example.com/").with(basic_auth: ['username', 'password']).to_return(status: 200)
+
       headers = {'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ='}
       expect(http_request(:get, 'http://www.example.com/', {headers: headers}).status).to eql('200')
     end


### PR DESCRIPTION
There are two tests which fails without network connection:

~~~
Failures:

  1) HTTPClient httpclient streams response sets the full body on the webmock response
     Failure/Error:
       do_get_block_without_webmock(req, proxy, conn) do |http_res, chunk|
         body += chunk
         block.call(http_res, chunk)
       end

     SocketError:
       getaddrinfo: Name or service not known (www.example.com:80)
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient/session.rb:597:in `initialize'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient/session.rb:597:in `new'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient/session.rb:597:in `create_socket'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient/session.rb:742:in `block in connect'
     # /usr/share/ruby/timeout.rb:93:in `block in timeout'
     # /usr/share/ruby/timeout.rb:103:in `timeout'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient/session.rb:735:in `connect'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient/session.rb:497:in `query'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient/session.rb:170:in `query'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient.rb:1238:in `do_get_block'
     # ./lib/webmock/http_lib_adapters/httpclient_adapter.rb:77:in `do_get'
     # ./lib/webmock/http_lib_adapters/httpclient_adapter.rb:47:in `do_get_block'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient.rb:1021:in `block in do_request'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient.rb:1129:in `protect_keep_alive_disconnected'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient.rb:1016:in `do_request'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient.rb:858:in `request'
     # ./spec/acceptance/httpclient/httpclient_spec.rb:195:in `block (3 levels) in <top (required)>'

  2) HTTPClient credentials are detected when manually specifying Authorization header
     Failure/Error: do_get_block_without_webmock(req, proxy, conn)

     SocketError:
       getaddrinfo: Name or service not known (www.example.com:80)
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient/session.rb:597:in `initialize'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient/session.rb:597:in `new'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient/session.rb:597:in `create_socket'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient/session.rb:742:in `block in connect'
     # /usr/share/ruby/timeout.rb:93:in `block in timeout'
     # /usr/share/ruby/timeout.rb:103:in `timeout'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient/session.rb:735:in `connect'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient/session.rb:497:in `query'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient/session.rb:170:in `query'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient.rb:1238:in `do_get_block'
     # ./lib/webmock/http_lib_adapters/httpclient_adapter.rb:82:in `do_get'
     # ./lib/webmock/http_lib_adapters/httpclient_adapter.rb:47:in `do_get_block'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient.rb:1021:in `block in do_request'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient.rb:1129:in `protect_keep_alive_disconnected'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient.rb:1016:in `do_request'
     # /usr/share/gems/gems/httpclient-2.8.0/lib/httpclient.rb:858:in `request'
     # ./spec/acceptance/httpclient/httpclient_spec_helper.rb:22:in `http_request'
     # ./spec/acceptance/httpclient/httpclient_spec.rb:206:in `block (3 levels) in <top (required)>'
~~~

This PR marks them to require network connection, but may be the stub should be different? Not really sure ....