### PR TITLE
Fix invalid UTF-8 when unencoding uri

### DIFF
--- a/lib/webmock/util/uri.rb
+++ b/lib/webmock/util/uri.rb
@@ -87,7 +87,9 @@ module WebMock
 
       def self.uris_encoded_and_unencoded(uris)
         uris.map do |uri|
-          [ uri.to_s, Addressable::URI.unencode(uri, String).freeze ]
+          unencoded = Addressable::URI.unencode(uri, String)
+          unencoded.force_encoding(Encoding::ASCII_8BIT) if unencoded.respond_to?(:force_encoding)
+          [ uri.to_s, unencoded.freeze ]
         end.flatten
       end
 

--- a/spec/unit/util/uri_spec.rb
+++ b/spec/unit/util/uri_spec.rb
@@ -115,6 +115,16 @@ describe WebMock::Util::URI do
       end
     end
 
+    it "should find all variations of uris with https, basic auth, a non-standard port and a path" do
+      uri = "https://~%8A:pass@www.example.com:9000/foo"
+      variations = [
+        "https://~%8A:pass@www.example.com:9000/foo",
+        "https://~\x8A:pass@www.example.com:9000/foo".force_encoding(Encoding::ASCII_8BIT)
+      ]
+
+      expect(WebMock::Util::URI.variations_of_uri_as_strings(uri)).to eq(variations)
+    end
+
   end
 
   describe "normalized uri equality" do


### PR DESCRIPTION
Fixes #679

Most of the URIs that come through
`WebMock::Util::URI.variations_of_uri_as_strings` end up getting forced
`ASCII_8BIT` encoding, except for URIs that neither have a `/` path,
standard port mapping nor a http scheme.

This caters for that specific code path by forcing the encoding of the
URI string returned from `Addressable::URI.unencode`.