### PR TITLE
Ensure the correct read_timeout value is used

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -257,7 +257,7 @@ module Net  #:nodoc: all
 
   class WebMockNetBufferedIO < BufferedIO
     def initialize(io, read_timeout: 60, continue_timeout: nil, debug_output: nil)
-      @read_timeout = 60
+      @read_timeout = read_timeout
       @rbuf = ''
       @debug_output = debug_output
 

--- a/spec/acceptance/net_http/net_http_shared.rb
+++ b/spec/acceptance/net_http/net_http_shared.rb
@@ -43,6 +43,17 @@ shared_examples_for "Net::HTTP" do
       end
     end
 
+    it "should pass the read_timeout value on", net_connect: true do
+      @http = Net::HTTP.new('localhost', port)
+      read_timeout = @http.read_timeout + 1
+      @http.read_timeout = read_timeout
+      @http.start {|conn|
+        conn.request(Net::HTTP::Get.new("/"))
+        socket = conn.instance_variable_get(:@socket)
+        expect(socket.read_timeout).to eq(read_timeout)
+      }
+    end
+
     describe "without start" do
       it "should close connection after a real request" do
         @http.get('/') { }


### PR DESCRIPTION
The implementation of WebMockNetBufferedIO is ignoring the read_timeout values passed during creation. With Ruby MRI 2.3.3 [1] this works, since the value is updated later on, but Ruby MRI 2.4.0 [2] is not doing that anymore.

[1] https://github.com/ruby/ruby/blob/v2_3_3/lib/net/http.rb#L904
[2] https://github.com/ruby/ruby/blob/v2_4_0/lib/net/http.rb#L955