### PR TITLE
Suppress `warning: `&' interpreted as argument prefix`

### DIFF
--- a/lib/webmock/util/hash_counter.rb
+++ b/lib/webmock/util/hash_counter.rb
@@ -25,7 +25,7 @@ module WebMock
       def select(&block)
         return unless block_given?
         @lock.synchronize do
-          hash.select &block
+          hash.select(&block)
         end
       end
 


### PR DESCRIPTION
Here's a fix for a Ruby warning.

The following is a sample of reproduction.

```sh
% ruby -we 'def foo(&block); proc &block; end'
-e:1: warning: `&' interpreted as argument prefix
```

Thanks.