### PR TITLE
Implement #close on HTTP::Response::Streamer

### DIFF
--- a/lib/webmock/http_lib_adapters/http_rb/streamer.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/streamer.rb
@@ -17,6 +17,10 @@ module HTTP
         @io.read size
       end
 
+      def close
+        @io.close
+      end
+
       def sequence_id
         -1
       end

--- a/spec/acceptance/http_rb/http_rb_spec.rb
+++ b/spec/acceptance/http_rb/http_rb_spec.rb
@@ -70,4 +70,13 @@ describe "HTTP.rb" do
       expect(response.uri.to_s).to eq "http://example.com/foo"
     end
   end
+
+  context "streamer" do
+    it "can be closed" do
+      stub_request :get, "example.com/foo"
+      response = HTTP.get "http://example.com/foo"
+
+      response.connection.close
+    end
+  end
 end


### PR DESCRIPTION
Since HTTP::Response::Streamer is returned instead of a HTTP::Connection, and HTTP::Connection responds to #close, HTTP::Response::Streamer should then also respond to #close.

I encountered this error when some code wanted to manually close the connection:

```rb
response.connection.close
```