### PR TITLE
Allow advanced matchers

### DIFF
--- a/lib/webmock/matchers/hash_including_matcher.rb
+++ b/lib/webmock/matchers/hash_including_matcher.rb
@@ -4,7 +4,17 @@ module WebMock
     # https://github.com/rspec/rspec-mocks/blob/master/lib/rspec/mocks/argument_matchers.rb
     class HashIncludingMatcher < HashArgumentMatcher
       def ==(actual)
-        super { |key, value| actual.key?(key) && value === actual[key] }
+        super do |key, value|
+          case value
+          when Array
+            zipped = value.zip(actual[key])
+            zipped.any? { |expected, actual| HashIncludingMatcher.new(expected) === actual }
+          when Hash
+            HashIncludingMatcher.new(value) === actual[key]
+          else
+            actual.key?(key) && value === actual[key]
+          end
+        end
       rescue NoMethodError
         false
       end

--- a/spec/unit/matchers/hash_including_matcher_spec.rb
+++ b/spec/unit/matchers/hash_including_matcher_spec.rb
@@ -26,6 +26,46 @@ module WebMock
           expect(HashIncludingMatcher.new(a: 1)).to eq("a" => 1, "b" => 2)
         end
 
+        it "matches a hash for its types" do
+          expect(HashIncludingMatcher.new(a: Fixnum, b: String, c: /f\w+/)).to eq("a" => 1, "b" => "string", "c" => "foo")
+        end
+
+        it "matches a hash nested inside another hash" do
+          expect(HashIncludingMatcher.new(a: { a: 1 })).to eq("a" => { "a" => 1 })
+        end
+
+        it "matches a hash nested deep inside another hash" do
+          expect(HashIncludingMatcher.new(a: { a: { a: 1 } })).to eq("a" => { "a" => { "a" => 1 } })
+        end
+
+        it "matches a hash nested inside an array of hashes" do
+          expect(HashIncludingMatcher.new(a: [{ a: 1 }])).to eq("a" => [{ "a" => 1 }])
+        end
+
+        it "matches a hash with more stuff nested inside an array of hashes" do
+          expect(HashIncludingMatcher.new(a: [{ a: 1 }])).to eq("a" => [{ "a" => 1, "b" => 1 }, { "a" => 2, "b" => 2 }])
+        end
+
+        it "matches a hash for its types nested inside an array of hashes" do
+          expect(HashIncludingMatcher.new(a: [{ a: Fixnum, b: String, c: /f\w+/ }])).to eq("a" => [{ "a" => 1, "b" => "string", "c" => "foo" }])
+        end
+
+        it "matches a hash inside a hash inside an array of hashes" do
+          expect(HashIncludingMatcher.new(a: [{ a: { a: 1 } }])).to eq("a" => [{ "a" => { "a" => 1 } }])
+        end
+
+        it "matches a hash with more stuff inside a hash inside an array of hashes" do
+          expect(HashIncludingMatcher.new(a: [{ a: { a: 1 } }])).to eq("a" => [{ "a" => { "a" => 1, "b" => 2 } }])
+        end
+
+        it "matches complex structures" do
+          expect(HashIncludingMatcher.new(a: [{ a: [{ a: 1 }] }])).to eq("a" => [{ "a" => [{ "a" => 1 }] }])
+        end
+
+        it "matches complex structures with more stuff" do
+          expect(HashIncludingMatcher.new(a: [{ a: [{ a: 1 }] }])).to eq("a" => [{ "a" => [{ "a" => 1, "b" => 2 }] }])
+        end
+
         describe "when matching anythingized keys" do
           let(:anything) { WebMock::Matchers::AnyArgMatcher.new(nil) }
 


### PR DESCRIPTION
This allows more complex structures to be matched
using `hash_including`:

```ruby
hash_including(a: [{b: 1}, {c: 2}]}
hash_including(a: [{b: Fixnum}, {c: Fixnum}]}
```