### PR TITLE
Updates for frozen-string-literal compatibility.

### DIFF
--- a/lib/webmock/http_lib_adapters/curb_adapter.rb
+++ b/lib/webmock/http_lib_adapters/curb_adapter.rb
@@ -153,7 +153,7 @@ if defined?(Curl)
         @body_str = webmock_response.body
         @response_code = webmock_response.status[0]
 
-        @header_str = "HTTP/1.1 #{webmock_response.status[0]} #{webmock_response.status[1]}\r\n"
+        @header_str = "HTTP/1.1 #{webmock_response.status[0]} #{webmock_response.status[1]}\r\n".dup
 
         @on_debug.call(@header_str, 1) if defined?( @on_debug )
 

--- a/lib/webmock/http_lib_adapters/excon_adapter.rb
+++ b/lib/webmock/http_lib_adapters/excon_adapter.rb
@@ -92,7 +92,7 @@ if defined?(Excon)
         end
 
         def self.to_query(hash)
-          string = ""
+          string = "".dup
           for key, values in hash
             if values.nil?
               string << key.to_s << '&'

--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -258,7 +258,7 @@ module Net  #:nodoc: all
   class WebMockNetBufferedIO < BufferedIO
     def initialize(io, read_timeout: 60, continue_timeout: nil, debug_output: nil)
       @read_timeout = read_timeout
-      @rbuf = ''
+      @rbuf = ''.dup
       @debug_output = debug_output
 
       @io = case io

--- a/lib/webmock/http_lib_adapters/patron_adapter.rb
+++ b/lib/webmock/http_lib_adapters/patron_adapter.rb
@@ -106,11 +106,11 @@ if defined?(::Patron)
           header_data   = ([status_line] + header_fields).join("\r\n")
 
           ::Patron::Response.new(
-            "",
+            "".dup,
             webmock_response.status[0],
             0,
             header_data,
-            webmock_response.body,
+            webmock_response.body.dup,
             default_response_charset
           )
         end

--- a/lib/webmock/rack_response.rb
+++ b/lib/webmock/rack_response.rb
@@ -17,7 +17,7 @@ module WebMock
     end
 
     def body_from_rack_response(response)
-      body = ""
+      body = "".dup
       response.each { |line| body << line }
       response.close if response.respond_to?(:close)
       return body

--- a/lib/webmock/request_execution_verifier.rb
+++ b/lib/webmock/request_execution_verifier.rb
@@ -53,9 +53,8 @@ module WebMock
 
     def failure_message_phrase(is_negated=false)
       negation = is_negated ? "was not" : "was"
-      text = "The request #{request_pattern} #{negation} expected to execute #{quantity_phrase(is_negated)}but it executed #{times(times_executed)}"
-      text << self.class.executed_requests_message
-      text
+      "The request #{request_pattern} #{negation} expected to execute #{quantity_phrase(is_negated)}but it executed #{times(times_executed)}" +
+        self.class.executed_requests_message
     end
 
     def quantity_phrase(is_negated=false)

--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -41,7 +41,7 @@ module WebMock
     end
 
     def to_s
-      string = "#{@method_pattern.to_s.upcase}"
+      string = "#{@method_pattern.to_s.upcase}".dup
       string << " #{@uri_pattern.to_s}"
       string << " with body #{@body_pattern.to_s}" if @body_pattern
       string << " with headers #{@headers_pattern.to_s}" if @headers_pattern

--- a/lib/webmock/request_registry.rb
+++ b/lib/webmock/request_registry.rb
@@ -23,7 +23,7 @@ module WebMock
       if requested_signatures.hash.empty?
         "No requests were made."
       else
-        text = ""
+        text = "".dup
         self.requested_signatures.each do |request_signature, times_executed|
           text << "#{request_signature} was made #{times_executed} time#{times_executed == 1 ? '' : 's' }\n"
         end

--- a/lib/webmock/request_signature.rb
+++ b/lib/webmock/request_signature.rb
@@ -12,7 +12,7 @@ module WebMock
     end
 
     def to_s
-      string = "#{self.method.to_s.upcase}"
+      string = "#{self.method.to_s.upcase}".dup
       string << " #{WebMock::Util::URI.strip_default_port_from_uri_string(self.uri.to_s)}"
       string << " with body '#{body.to_s}'" if body && body.to_s != ''
       if headers && !headers.empty?

--- a/lib/webmock/request_signature_snippet.rb
+++ b/lib/webmock/request_signature_snippet.rb
@@ -13,14 +13,14 @@ module WebMock
     def stubbing_instructions
       return unless WebMock.show_stubbing_instructions?
 
-      text = "You can stub this request with the following snippet:\n\n"
-      text << WebMock::StubRequestSnippet.new(request_stub).to_s
+      "You can stub this request with the following snippet:\n\n" +
+        WebMock::StubRequestSnippet.new(request_stub).to_s
     end
 
     def request_stubs
       return if WebMock::StubRegistry.instance.request_stubs.empty?
 
-      text = "registered request stubs:\n"
+      text = "registered request stubs:\n".dup
       WebMock::StubRegistry.instance.request_stubs.each do |stub|
         text << "\n#{WebMock::StubRequestSnippet.new(stub).to_s(false)}"
         add_body_diff(stub, text) if WebMock.show_body_diff?
@@ -50,7 +50,7 @@ module WebMock
     end
 
     def pretty_print_to_string(string_to_print)
-      StringIO.open("") do |stream|
+      StringIO.open("".dup) do |stream|
         PP.pp(string_to_print, stream)
         stream.rewind
         stream.read

--- a/lib/webmock/stub_request_snippet.rb
+++ b/lib/webmock/stub_request_snippet.rb
@@ -10,10 +10,10 @@ module WebMock
 
     def to_s(with_response = true)
       request_pattern = @request_stub.request_pattern
-      string = "stub_request(:#{request_pattern.method_pattern.to_s},"
+      string = "stub_request(:#{request_pattern.method_pattern.to_s},".dup
       string << " \"#{request_pattern.uri_pattern.to_s}\")"
 
-      with = ""
+      with = "".dup
 
       if (request_pattern.body_pattern)
         with << "body: #{request_pattern.body_pattern.to_s}"

--- a/lib/webmock/util/headers.rb
+++ b/lib/webmock/util/headers.rb
@@ -22,7 +22,7 @@ module WebMock
 
       def self.sorted_headers_string(headers)
         headers = WebMock::Util::Headers.normalize_headers(headers)
-        str = '{'
+        str = '{'.dup
         str << headers.map do |k,v|
           v = case v
             when Regexp then v.inspect

--- a/lib/webmock/util/query_mapper.rb
+++ b/lib/webmock/util/query_mapper.rb
@@ -204,7 +204,7 @@ module WebMock::Util
           end
         end
 
-        buffer = ''
+        buffer = ''.dup
         new_query_values.each do |parent, value|
           encoded_parent = ::Addressable::URI.encode_component(
               parent.dup, ::Addressable::URI::CharacterClasses::UNRESERVED
@@ -251,14 +251,14 @@ module WebMock::Util
             ]
           end
           value.sort!
-          buffer = ''
+          buffer = ''.dup
           value.each do |key, val|
             new_parent = options[:notation] != :flat_array ? "#{parent}[#{key}]" : parent
             buffer << "#{to_query(new_parent, val, options)}&"
           end
           buffer.chop
         when ::Array
-          buffer = ''
+          buffer = ''.dup
           value.each_with_index do |val, i|
             new_parent = options[:notation] != :flat_array ? "#{parent}[#{i}]" : parent
             buffer << "#{to_query(new_parent, val, options)}&"

--- a/minitest/webmock_spec.rb
+++ b/minitest/webmock_spec.rb
@@ -43,7 +43,7 @@ require File.expand_path(File.dirname(__FILE__) + '/test_helper')
 
     it  "should verify that expect request didn't occur" do
      expected_message = "The request GET http://www.example.com/ was expected to execute 1 time but it executed 0 times"
-     expected_message << "\n\nThe following requests were made:\n\nNo requests were made.\n============================================================"
+     expected_message += "\n\nThe following requests were made:\n\nNo requests were made.\n============================================================"
      assert_fail(expected_message) do
        assert_requested(:get, "http://www.example.com")
      end
@@ -51,7 +51,7 @@ require File.expand_path(File.dirname(__FILE__) + '/test_helper')
 
     it  "should verify that expect stub didn't occur" do
      expected_message = "The request ANY http://www.example.com/ was expected to execute 1 time but it executed 0 times"
-     expected_message << "\n\nThe following requests were made:\n\nNo requests were made.\n============================================================"
+     expected_message += "\n\nThe following requests were made:\n\nNo requests were made.\n============================================================"
      assert_fail(expected_message) do
        assert_requested(@stub_http)
      end

--- a/spec/acceptance/httpclient/httpclient_spec.rb
+++ b/spec/acceptance/httpclient/httpclient_spec.rb
@@ -48,7 +48,7 @@ describe "HTTPClient" do
 
   it "should work with get_content" do
     stub_request(:get, 'www.example.com').to_return(status: 200, body: 'test', headers: {})
-    str = ''
+    str = ''.dup
     HTTPClient.get_content('www.example.com') do |content|
       str << content
     end

--- a/spec/acceptance/net_http/net_http_shared.rb
+++ b/spec/acceptance/net_http/net_http_shared.rb
@@ -12,7 +12,7 @@ shared_examples_for "Net::HTTP" do
     end
 
     it "should handle requests with block passed to read_body", net_connect: true do
-      body = ""
+      body = "".dup
       req = Net::HTTP::Get.new("/")
       Net::HTTP.start("localhost", port) do |http|
         http.request(req) do |res|

--- a/spec/acceptance/net_http/net_http_spec.rb
+++ b/spec/acceptance/net_http/net_http_spec.rb
@@ -293,7 +293,7 @@ describe "Net:HTTP" do
     end
 
     it "should support the after_request callback on an request with block and read_body" do
-      response_body = ''
+      response_body = ''.dup
       http_request(:get, "http://localhost:#{port}/") do |response|
         response.read_body { |fragment| response_body << fragment }
       end

--- a/spec/acceptance/patron/patron_spec_helper.rb
+++ b/spec/acceptance/patron/patron_spec_helper.rb
@@ -16,7 +16,7 @@ module PatronSpecHelper
     sess.timeout = 30
     sess.max_redirects = 0
     uri = "#{uri.path}#{uri.query ? '?' : ''}#{uri.query}"
-    uri.gsub!(' ','%20')
+    uri = uri.gsub(' ','%20')
     response = sess.request(method, uri, options[:headers] || {}, {
       data: options[:body]
     })

--- a/spec/acceptance/typhoeus/typhoeus_hydra_spec_helper.rb
+++ b/spec/acceptance/typhoeus/typhoeus_hydra_spec_helper.rb
@@ -6,7 +6,7 @@ module TyphoeusHydraSpecHelper
 
 
   def http_request(method, uri, options = {}, &block)
-    uri.gsub!(" ", "%20") #typhoeus doesn't like spaces in the uri
+    uri = uri.gsub(" ", "%20") #typhoeus doesn't like spaces in the uri
     request_options =  {
       method: method,
       body: options[:body],

--- a/spec/unit/request_execution_verifier_spec.rb
+++ b/spec/unit/request_execution_verifier_spec.rb
@@ -53,7 +53,7 @@ describe WebMock::RequestExecutionVerifier do
       @verifier.times_executed = 0
       @verifier.expected_times_executed = 2
       expected_text = "The request www.example.com was expected to execute 2 times but it executed 0 times"
-      expected_text << @executed_requests_info
+      expected_text += @executed_requests_info
       expect(@verifier.failure_message).to eq(expected_text)
     end
 
@@ -61,7 +61,7 @@ describe WebMock::RequestExecutionVerifier do
       @verifier.times_executed = 1
       @verifier.expected_times_executed = 1
       expected_text = "The request www.example.com was expected to execute 1 time but it executed 1 time"
-      expected_text << @executed_requests_info
+      expected_text += @executed_requests_info
       expect(@verifier.failure_message).to eq(expected_text)
     end
 
@@ -70,7 +70,7 @@ describe WebMock::RequestExecutionVerifier do
         @verifier.times_executed = 1
         @verifier.at_least_times_executed = 2
         expected_text = "The request www.example.com was expected to execute at least 2 times but it executed 1 time"
-        expected_text << @executed_requests_info
+        expected_text += @executed_requests_info
         expect(@verifier.failure_message).to eq(expected_text)
       end
 
@@ -78,7 +78,7 @@ describe WebMock::RequestExecutionVerifier do
         @verifier.times_executed = 2
         @verifier.at_least_times_executed = 3
         expected_text = "The request www.example.com was expected to execute at least 3 times but it executed 2 times"
-        expected_text << @executed_requests_info
+        expected_text += @executed_requests_info
         expect(@verifier.failure_message).to eq(expected_text)
       end
     end
@@ -88,7 +88,7 @@ describe WebMock::RequestExecutionVerifier do
         @verifier.times_executed = 3
         @verifier.at_most_times_executed = 2
         expected_text = "The request www.example.com was expected to execute at most 2 times but it executed 3 times"
-        expected_text << @executed_requests_info
+        expected_text += @executed_requests_info
         expect(@verifier.failure_message).to eq(expected_text)
       end
 
@@ -96,7 +96,7 @@ describe WebMock::RequestExecutionVerifier do
         @verifier.times_executed = 2
         @verifier.at_most_times_executed = 1
         expected_text = "The request www.example.com was expected to execute at most 1 time but it executed 2 times"
-        expected_text << @executed_requests_info
+        expected_text += @executed_requests_info
         expect(@verifier.failure_message).to eq(expected_text)
       end
     end
@@ -108,14 +108,14 @@ describe WebMock::RequestExecutionVerifier do
       @verifier.times_executed = 2
       @verifier.expected_times_executed = 2
       expected_text = "The request www.example.com was not expected to execute 2 times but it executed 2 times"
-      expected_text << @executed_requests_info
+      expected_text += @executed_requests_info
       expect(@verifier.failure_message_when_negated).to eq(expected_text)
     end
 
     it "reports failure message when not expected request but it executed" do
       @verifier.times_executed = 1
       expected_text = "The request www.example.com was not expected to execute but it executed 1 time"
-      expected_text << @executed_requests_info
+      expected_text += @executed_requests_info
       expect(@verifier.failure_message_when_negated).to eq(expected_text)
     end
 
@@ -124,7 +124,7 @@ describe WebMock::RequestExecutionVerifier do
         @verifier.times_executed = 3
         @verifier.at_least_times_executed = 2
         expected_text = "The request www.example.com was not expected to execute at least 2 times but it executed 3 times"
-        expected_text << @executed_requests_info
+        expected_text += @executed_requests_info
         expect(@verifier.failure_message_when_negated).to eq(expected_text)
       end
 
@@ -132,7 +132,7 @@ describe WebMock::RequestExecutionVerifier do
         @verifier.times_executed = 2
         @verifier.at_least_times_executed = 2
         expected_text = "The request www.example.com was not expected to execute at least 2 times but it executed 2 times"
-        expected_text << @executed_requests_info
+        expected_text += @executed_requests_info
         expect(@verifier.failure_message_when_negated).to eq(expected_text)
       end
     end
@@ -142,7 +142,7 @@ describe WebMock::RequestExecutionVerifier do
         @verifier.times_executed = 2
         @verifier.at_most_times_executed = 3
         expected_text = "The request www.example.com was not expected to execute at most 3 times but it executed 2 times"
-        expected_text << @executed_requests_info
+        expected_text += @executed_requests_info
         expect(@verifier.failure_message_when_negated).to eq(expected_text)
       end
 
@@ -150,7 +150,7 @@ describe WebMock::RequestExecutionVerifier do
         @verifier.times_executed = 1
         @verifier.at_most_times_executed = 2
         expected_text = "The request www.example.com was not expected to execute at most 2 times but it executed 1 time"
-        expected_text << @executed_requests_info
+        expected_text += @executed_requests_info
         expect(@verifier.failure_message_when_negated).to eq(expected_text)
       end
     end

--- a/test/shared_test.rb
+++ b/test/shared_test.rb
@@ -41,7 +41,7 @@ module SharedTest
 
   def test_verification_that_expected_request_didnt_occur
     expected_message = "The request GET http://www.example.com/ was expected to execute 1 time but it executed 0 times"
-    expected_message << "\n\nThe following requests were made:\n\nNo requests were made.\n============================================================"
+    expected_message += "\n\nThe following requests were made:\n\nNo requests were made.\n============================================================"
     assert_fail(expected_message) do
       assert_requested(:get, "http://www.example.com")
     end
@@ -49,7 +49,7 @@ module SharedTest
 
   def test_verification_that_expected_stub_didnt_occur
     expected_message = "The request ANY http://www.example.com/ was expected to execute 1 time but it executed 0 times"
-    expected_message << "\n\nThe following requests were made:\n\nNo requests were made.\n============================================================"
+    expected_message += "\n\nThe following requests were made:\n\nNo requests were made.\n============================================================"
     assert_fail(expected_message) do
       assert_requested(@stub_http)
     end


### PR DESCRIPTION
These changes cover webmock's use of string literals, ensuring that it's able to be used with the MRI 2.3+ feature of frozen string literals enabled.

The caveats are as follows:

* Rack is not yet compatible, though [I have submitted a PR](https://github.com/rack/rack/pull/1182)
* Addressable is not yet compatible, though [I have submitted a PR](https://github.com/sporkmonger/addressable/pull/260)
* RSpec is compatible, but not yet in a released version.
* HTTPClient, Patron, em-http-request and perhaps other external dependencies are not yet compatible.

To test, I've been using the `pragmater` gem to add the pragma comment to all files in lib, spec, test and minitest, as well as using my fork of rack and addressable, plus the latest from the rspec repos, and then running the test suite. To have the same behaviour in this PR, I'm happy to add those pragma comments and the git repos to the Gemfile if you'd like, but I realise that's a lot (and especially relying on forks is far from ideal), so I figure I'd start with this :)