### PR TITLE
Patch raise_timeout_error for HTTP.rb adapter to return proper error

### DIFF
--- a/lib/webmock/http_lib_adapters/http_rb/webmock.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/webmock.rb
@@ -43,7 +43,7 @@ module HTTP
 
     def raise_timeout_error
       raise Errno::ETIMEDOUT if HTTP::VERSION < "1.0.0"
-      raise HTTP::ConnectionError, "connection error: #{Errno::ETIMEDOUT.new}"
+      raise HTTP::TimeoutError, "connection error: #{Errno::ETIMEDOUT.new}"
     end
 
     def perform

--- a/spec/acceptance/http_rb/http_rb_spec_helper.rb
+++ b/spec/acceptance/http_rb/http_rb_spec_helper.rb
@@ -20,7 +20,7 @@ module HttpRbSpecHelper
 
   def client_timeout_exception_class
     return Errno::ETIMEDOUT if HTTP::VERSION < "1.0.0"
-    HTTP::ConnectionError
+    HTTP::TimeoutError
   end
 
   def connection_refused_exception_class


### PR DESCRIPTION
HTTP.rb should raise a HTTP::TimeoutError rather than a HTTP::ConnectionError
when raising a timeout error.