### PR TITLE
HTTPClient doesn't yield block on empty body

### DIFF
--- a/lib/webmock/http_lib_adapters/httpclient_adapter.rb
+++ b/lib/webmock/http_lib_adapters/httpclient_adapter.rb
@@ -75,8 +75,10 @@ if defined?(::HTTPClient)
         elsif block
           body = ''
           do_get_block_without_webmock(req, proxy, conn) do |http_res, chunk|
-            body += chunk
-            block.call(http_res, chunk)
+            if chunk && chunk.bytesize > 0
+              body += chunk
+              block.call(http_res, chunk)
+            end
           end
         else
           do_get_block_without_webmock(req, proxy, conn)
@@ -117,7 +119,7 @@ if defined?(::HTTPClient)
       raise HTTPClient::TimeoutError if webmock_response.should_timeout
       webmock_response.raise_error_if_any
 
-      block.call(response, body) if block
+      block.call(response, body) if block && body && body.bytesize > 0
 
       response
     end

--- a/spec/acceptance/httpclient/httpclient_spec.rb
+++ b/spec/acceptance/httpclient/httpclient_spec.rb
@@ -31,6 +31,13 @@ describe "HTTPClient" do
     expect(response_body).to eq("abc")
   end
 
+  it "should not yield block on empty response if block provided" do
+    stub_request(:get, "www.example.com").to_return(body: "")
+    response_body = ""
+    http_request(:get, "http://www.example.com/"){ raise }
+    expect(response_body).to eq("")
+  end
+
   it "should match requests if headers are the same  but in different order" do
     stub_request(:get, "www.example.com").with(headers: {"a" => ["b", "c"]} )
     expect(http_request(


### PR DESCRIPTION
By following code to reproduce, it doesn't call block.

Server:
```
#!/usr/bin/env ruby
require 'socket'
TCPServer.open("", 0) do |serv|
  addr = serv.addr
  puts "port: #{addr[1]}"
  while true
    Thread.start(serv.accept) do |s|
      print(s, " is accepted\n")
      p s.readpartial 900
      s.write "HTTP/1.1 200 OK\nContent-Type: text/html\n\n"
      s.close
    end
  end
end
```

Client:
```
require'httpclient'
HTTPClient.new.get("http://localhost:53503"){|r,c|p [r,c]}
```