### PR TITLE
Support typhoeus 1.3.0

### DIFF
--- a/spec/acceptance/typhoeus/typhoeus_hydra_spec.rb
+++ b/spec/acceptance/typhoeus/typhoeus_hydra_spec.rb
@@ -127,7 +127,7 @@ unless RUBY_PLATFORM =~ /java/
           end
           hydra.queue @request
           hydra.run
-          expect(test_headers).to include('X-Test' => '1')
+          expect(test_headers.to_h).to include('X-Test' => '1')
         end
       end
     end


### PR DESCRIPTION
Typhoeus::Response::Header becomes delegated class instead of Hash
subclass from 1.3.0.