### PR TITLE
Make it compatible with the newest http.rb version (3.0.0)

### DIFF
--- a/lib/webmock/http_lib_adapters/http_rb/request.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/request.rb
@@ -1,9 +1,15 @@
 module HTTP
   class Request
     def webmock_signature
+      request_body = if defined?(HTTP::Request::Body)
+                       ''.tap { |string| body.each { |part| string << part } }
+                     else
+                       body
+                     end
+
       ::WebMock::RequestSignature.new(verb, uri.to_s, {
         headers: headers.to_h,
-        body: body
+        body: request_body
       })
     end
   end


### PR DESCRIPTION
http.rb 3.0.0 have introduced HTTP::Request::Body abstraction (https://github.com/httprb/http/pull/412) - let's make webmock compatible with it.