### PR TITLE
excon adapter: new defaults to empty hash

### DIFF
--- a/lib/webmock/http_lib_adapters/excon_adapter.rb
+++ b/lib/webmock/http_lib_adapters/excon_adapter.rb
@@ -152,7 +152,7 @@ if defined?(Excon)
   end
 
   Excon::Connection.class_eval do
-    def self.new(args)
+    def self.new(args = {})
       args.delete(:__construction_args)
       super(args).tap do |instance|
         instance.data[:__construction_args] = args


### PR DESCRIPTION
Excon Adapter should default to an empty hash to allow `Excon::Connection.new`.

See:
https://github.com/excon/excon/blob/c92f240e0e90fc01beac4c52bbdbe2ed06b55263/lib/excon/connection.rb#L52