### PR TITLE
Automatically disable WebMock after rspec suite

### DIFF
--- a/lib/webmock/rspec.rb
+++ b/lib/webmock/rspec.rb
@@ -20,12 +20,18 @@ end
 
 require 'webmock/rspec/matchers'
 
-WebMock.enable!
-
 RSPEC_CONFIGURER.configure { |config|
 
   config.include WebMock::API
   config.include WebMock::Matchers
+
+  config.before(:suite) do
+    WebMock.enable!
+  end
+
+  config.after(:suite) do
+    WebMock.disable!
+  end
 
   config.after(:each) do
     WebMock.reset!


### PR DESCRIPTION
When using [ruby-codacy-coverage](https://github.com/codacy/ruby-codacy-coverage) we were forced to whitelist Codacy by hand, even though the code coverage was being sent long after the entire test suite has run (in `at_exit` block in [simplecov](https://github.com/colszowka/simplecov)).

This was a surprising behaviour as the point of requiring `webmock/rspec` is to have a seamless integration that doesn't interfere with other tooling.

This PR changes the default behaviour of `webmock/rspec` so it does not by default interfere with test configuration.