### PR TITLE
Typhoeus returns OK for a return code

### DIFF
--- a/lib/webmock/http_lib_adapters/typhoeus_hydra_adapter.rb
+++ b/lib/webmock/http_lib_adapters/typhoeus_hydra_adapter.rb
@@ -102,6 +102,7 @@ if defined?(Typhoeus)
               status_message: webmock_response.status[1],
               body: webmock_response.body,
               headers: webmock_response.headers,
+              return_code: :ok,
               effective_url: request_signature.uri
             )
           end


### PR DESCRIPTION
Whenever Typhoeus successfully completes a request, the return code is `:ok`. This pull request adds this return code to the adapter. 