### PR TITLE
Remove unused `pos` variable to fix Ruby warning

### DIFF
--- a/lib/webmock/util/json.rb
+++ b/lib/webmock/util/json.rb
@@ -24,13 +24,12 @@ module WebMock
 
       # Ensure that ":" and "," are always followed by a space
       def self.convert_json_to_yaml(json) #:nodoc:
-        scanner, quoting, marks, pos, times = StringScanner.new(json), false, [], nil, []
+        scanner, quoting, marks, times = StringScanner.new(json), false, [], []
         while scanner.scan_until(/(\\['"]|['":,\\]|\\.)/)
           case char = scanner[1]
           when '"', "'"
             if !quoting
               quoting = char
-              pos = scanner.pos
             elsif quoting == char
               quoting = false
             end


### PR DESCRIPTION
This fixes the following warning that is printed when using Ruby 2.5.0:

```
lib/webmock/util/json.rb:27: warning: assigned but unused variable - pos
```
  