### PR TITLE
Fix output when there is only header

### DIFF
--- a/lib/webmock/stub_request_snippet.rb
+++ b/lib/webmock/stub_request_snippet.rb
@@ -20,9 +20,9 @@ module WebMock
       end
 
       if (request_pattern.headers_pattern)
-        with << ",\n  " unless with.empty?
+        with << "," unless with.empty?
 
-        with << "  headers: #{request_pattern.headers_pattern.pp_to_s}"
+        with << "\n    headers: #{request_pattern.headers_pattern.pp_to_s}"
       end
       string << ".\n  with(#{with})" unless with.empty?
       if with_response

--- a/spec/unit/stub_request_snippet_spec.rb
+++ b/spec/unit/stub_request_snippet_spec.rb
@@ -34,7 +34,7 @@ describe WebMock::StubRequestSnippet do
       it "should print stub request snippet with headers if any" do
         @request_signature.headers = {'B' => 'b', 'A' => 'a'}
         expected = 'stub_request(:get, "http://www.example.com/?a=b&c=d").'+
-        "\n  with(  headers: {\n\t\  'A\'=>\'a\',\n\t  \'B\'=>\'b\'\n    })." +
+        "\n  with(\n    headers: {\n\t\  'A\'=>\'a\',\n\t  \'B\'=>\'b\'\n    })." +
         "\n  to_return(status: 200, body: \"\", headers: {})"
         @request_stub = WebMock::RequestStub.from_request_signature(@request_signature)
         expect(WebMock::StubRequestSnippet.new(@request_stub).to_s).to eq(expected)
@@ -101,7 +101,10 @@ stub_request(:post, "http://www.example.com/").
         @request_stub = WebMock::RequestStub.from_request_signature(@request_signature)
         expected = <<-STUB
 stub_request(:post, "http://www.example.com/").
-  with(headers: {'Accept'=>'application/json'}).
+  with(
+    headers: {
+\t  'Accept'=>'application/json'
+    }).
   to_return(status: 200, body: \"{}\", headers: {})
         STUB
         expect(WebMock::StubRequestSnippet.new(@request_stub).to_s).to eq(expected.strip)


### PR DESCRIPTION
Currently when there is only header the output will seem like
```
stub_request(:post, "http://www.example.com/").
  with(  headers: {
\t  'Accept'=>'application/json'
    }).
  to_return(status: 200, body: \"{}\", headers: {})
```
But it will be more consistent with the case that body is also included,
to be like

```
stub_request(:post, "http://www.example.com/").
  with(  
    headers: {
\t  'Accept'=>'application/json'
    }).
  to_return(status: 200, body: \"{}\", headers: {})
 ```
when
```
stub_request(:post, "http://www.example.com/").
  with(
    body: "abcdef",
    headers: {
\t  'Content-Type'=>'multipart/form-data; boundary=ABC123'
    }).
  to_return(status: 200, body: \"\", headers: {})
```