### PR TITLE
Prevent `Net/ReadTimeout` error in Ruby 2.6

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -271,6 +271,20 @@ module Net  #:nodoc: all
       end
       raise "Unable to create local socket" unless @io
     end
+
+    if RUBY_VERSION >= '2.6.0'
+      def rbuf_fill
+        trace = TracePoint.trace(:line) do |tp|
+          if tp.binding.local_variable_defined?(:tmp)
+            tp.binding.local_variable_set(:tmp, nil)
+          end
+        end
+
+        super
+
+        trace.disable
+      end
+    end
   end
 
 end


### PR DESCRIPTION
This PR fixes the following build error in Ruby 2.6.0 (ruby-head).

```console
$ ruby --version
ruby 2.6.0dev (2018-03-07 trunk 62693) [x86_64-linux]
% bundle exec rake
(snip)

  1) Net:HTTP with WebMock when net connect is allowed should make a
  real https request if request is not stubbed
     Failure/Error: response = super(request, nil, &nil)

     Net::ReadTimeout:
       Net::ReadTimeout
     Shared Example Group: "allowing and disabling net connect" called
       from ./spec/acceptance/webmock_shared.rb:25
     Shared Example Group: "with WebMock" called from
       ./spec/acceptance/net_http/net_http_spec.rb:10
     # ./lib/webmock/http_lib_adapters/net_http.rb:97:in `block in
       request'
     # ./lib/webmock/http_lib_adapters/net_http.rb:105:in `block in
       request'
     # ./lib/webmock/http_lib_adapters/net_http.rb:137:in
       `start_with_connect_without_finish'
     # ./lib/webmock/http_lib_adapters/net_http.rb:104:in `request'
     # ./spec/acceptance/net_http/net_http_spec_helper.rb:35:in `block
       in http_request'
     # ./lib/webmock/http_lib_adapters/net_http.rb:123:in
       `start_without_connect'
     # ./lib/webmock/http_lib_adapters/net_http.rb:150:in `start'
     # ./spec/acceptance/net_http/net_http_spec_helper.rb:34:in
       `http_request'
     #
       ./spec/acceptance/shared/allowing_and_disabling_net_connect.rb:14:in
       `block (4 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Net::ReadTimeout:
     #   Net::ReadTimeout
     #   ./lib/webmock/http_lib_adapters/net_http.rb:97:in `block in
       request'

(Errors continue after this)
```

https://travis-ci.org/bblimke/webmock/jobs/350668167#L942-L1202

This is because it was changed to use `IO#read_nonblock` based on the value of `@rbuf` by the following commit.
https://github.com/ruby/ruby/commit/b02fc0f9fedd635eb64f4bb6440ab63923c2af24

This PR forces the 2nd argument `tmp` of `IO#read_nonblock` to `nil` by using `TracePoint`. So this prevents `Net::ReadTimeout` from occurring.