### PR TITLE
Fix redundant `Util::` namespacing

### DIFF
--- a/lib/webmock/util/hash_counter.rb
+++ b/lib/webmock/util/hash_counter.rb
@@ -2,7 +2,7 @@ require 'thread'
 
 module WebMock
   module Util
-    class Util::HashCounter
+    class HashCounter
       attr_accessor :hash
       def initialize
         self.hash = {}


### PR DESCRIPTION
On line 5 the reference to `Util` resolves to the class that was just opened on line 4, so `Util::` is redundant.

FYI @bblimke