### PR TITLE
Fix invalid scheme error with Addressable::Template

### DIFF
--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -155,10 +155,10 @@ module WebMock
     def matches?(uri)
       if @query_params.nil?
         # Let Addressable check the whole URI
-        WebMock::Util::URI.variations_of_uri_as_strings(uri).any? { |u| @pattern.match(u) }
+        matches_with_variations?(uri)
       else
         # WebMock checks the query, Addressable checks everything else
-        WebMock::Util::URI.variations_of_uri_as_strings(uri.omit(:query)).any? { |u| @pattern.match(u) } &&
+        matches_with_variations?(uri.omit(:query)) &&
           @query_params == WebMock::Util::QueryMapper.query_to_values(uri.query)
       end
     end
@@ -176,6 +176,17 @@ module WebMock
       str = @pattern.pattern.inspect
       str += " with variables #{@pattern.variables.inspect}" if @pattern.variables
       str
+    end
+
+    private
+
+    def matches_with_variations?(uri)
+      normalized_template = Addressable::Template.new(WebMock::Util::URI.heuristic_parse(@pattern.pattern))
+
+      uri_variations_with_scheme = WebMock::Util::URI.variations_of_uri_as_strings(uri)
+        .map {|u| WebMock::Util::URI.heuristic_parse(u) }
+
+      uri_variations_with_scheme.any? { |u| normalized_template.match(u) }
     end
   end
 

--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -183,7 +183,7 @@ module WebMock
     def matches_with_variations?(uri)
       normalized_template = Addressable::Template.new(WebMock::Util::URI.heuristic_parse(@pattern.pattern))
 
-      WebMock::Util::URI.variations_of_uri_as_strings(uri, with_scheme: true)
+      WebMock::Util::URI.variations_of_uri_as_strings(uri, only_with_scheme: true)
         .any? { |u| normalized_template.match(u) }
     end
   end

--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -183,10 +183,8 @@ module WebMock
     def matches_with_variations?(uri)
       normalized_template = Addressable::Template.new(WebMock::Util::URI.heuristic_parse(@pattern.pattern))
 
-      uri_variations_with_scheme = WebMock::Util::URI.variations_of_uri_as_strings(uri)
-        .map {|u| WebMock::Util::URI.heuristic_parse(u) }
-
-      uri_variations_with_scheme.any? { |u| normalized_template.match(u) }
+      WebMock::Util::URI.variations_of_uri_as_strings(uri, with_scheme: true)
+        .any? { |u| normalized_template.match(u) }
     end
   end
 

--- a/lib/webmock/util/uri.rb
+++ b/lib/webmock/util/uri.rb
@@ -33,7 +33,7 @@ module WebMock
         NORMALIZED_URIS[uri].dup
       end
 
-      def self.variations_of_uri_as_strings(uri_object, with_scheme: false)
+      def self.variations_of_uri_as_strings(uri_object, only_with_scheme: false)
         normalized_uri = normalize_uri(uri_object.dup).freeze
         uris = [ normalized_uri ]
 
@@ -47,7 +47,7 @@ module WebMock
           uris = uris_with_inferred_port_and_without(uris)
         end
 
-        if normalized_uri.scheme == "http" && !with_scheme
+        if normalized_uri.scheme == "http" && !only_with_scheme
           uris = uris_with_scheme_and_without(uris)
         end
 

--- a/lib/webmock/util/uri.rb
+++ b/lib/webmock/util/uri.rb
@@ -33,7 +33,7 @@ module WebMock
         NORMALIZED_URIS[uri].dup
       end
 
-      def self.variations_of_uri_as_strings(uri_object)
+      def self.variations_of_uri_as_strings(uri_object, with_scheme: false)
         normalized_uri = normalize_uri(uri_object.dup).freeze
         uris = [ normalized_uri ]
 
@@ -47,7 +47,7 @@ module WebMock
           uris = uris_with_inferred_port_and_without(uris)
         end
 
-        if normalized_uri.scheme == "http"
+        if normalized_uri.scheme == "http" && !with_scheme
           uris = uris_with_scheme_and_without(uris)
         end
 

--- a/spec/unit/request_pattern_spec.rb
+++ b/spec/unit/request_pattern_spec.rb
@@ -121,6 +121,12 @@ describe WebMock::RequestPattern do
         to match(WebMock::RequestSignature.new(:get, "www.example.com"))
     end
 
+    it "should match if Addressable::Template pattern that has ip address host matches request uri" do
+      signature = WebMock::RequestSignature.new(:get, "127.0.0.1:3000/1234")
+      uri = Addressable::Template.new("127.0.0.1:3000/{id}")
+      expect(WebMock::RequestPattern.new(:get, uri)).to match(signature)
+    end
+
     it "should match for uris with same parameters as pattern" do
       expect(WebMock::RequestPattern.new(:get, "www.example.com?a=1&b=2")).
         to match(WebMock::RequestSignature.new(:get, "www.example.com?a=1&b=2"))


### PR DESCRIPTION
Fix #489 

# problem
`Addressable::Template#match` expects a valid uri with scheme
  https://github.com/sporkmonger/addressable/issues/208#issuecomment-162404607

It works with most cases without uri scheme, but it raises an error with some cases like `127.0.0.1:8080`.

I've found that it causes the error when using webmock with [System Spec](https://relishapp.com/rspec/rspec-rails/docs/system-specs/system-spec) and chrome driver.

# solution
Always pass a uri with scheme to `Addressable::Template#match`. 

The difference from #739 is 
- adding a spec 
- making failing specs pass