### PR TITLE
Add Accept header to real calls in http://httpstat.us

### DIFF
--- a/spec/acceptance/excon/excon_spec.rb
+++ b/spec/acceptance/excon/excon_spec.rb
@@ -20,7 +20,8 @@ describe "Excon" do
     it "should support excon response_block for real requests", net_connect: true do
       a = []
       WebMock.allow_net_connect!
-      r = Excon.new('http://httpstat.us/200').get(response_block: lambda {|e, remaining, total| a << e}, chunk_size: 1)
+      r = Excon.new('http://httpstat.us/200', headers: { "Accept" => "*" }).
+        get(response_block: lambda {|e, remaining, total| a << e}, chunk_size: 1)
       expect(a).to eq(["2", "0", "0", " ", "O", "K"])
       expect(r.body).to eq("")
     end
@@ -40,7 +41,8 @@ describe "Excon" do
       WebMock.after_request { |_, res|
         response = res
       }
-      r = Excon.new('http://httpstat.us/200').get(response_block: lambda {|e, remaining, total| a << e}, chunk_size: 1)
+      r = Excon.new('http://httpstat.us/200', headers: { "Accept" => "*" }).
+        get(response_block: lambda {|e, remaining, total| a << e}, chunk_size: 1)
       expect(response.body).to eq("200 OK")
       expect(a).to eq(["2", "0", "0", " ", "O", "K"])
       expect(r.body).to eq("")

--- a/spec/acceptance/shared/callbacks.rb
+++ b/spec/acceptance/shared/callbacks.rb
@@ -102,7 +102,7 @@ shared_context "callbacks" do |*adapter_info|
           WebMock.after_request(except: [:other_lib])  do |_, response|
             @response = response
           end
-          http_request(:get, "http://httpstat.us/201")
+          http_request(:get, "http://httpstat.us/201", headers: { "Accept" => "*" })
         end
 
         it "should pass real response to callback with status and message" do


### PR DESCRIPTION
They have changed their site to return an empty response if Accept is not specified.
Fixes the tests that depend on those responses.

Related to https://github.com/Readify/httpstatus/pull/49