### PR TITLE
ADD configurable custom content type mapping for request body matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+###
+
+* Add ability to config custom content type mapping for request body matching
+
 ## 3.4.2
 
   * Fixed `rbuf_fill` in Net::HTTP adapter to be thread-safe

--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ RestClient.post('www.example.com', '<data a="1" b="five" />',
   content_type: 'application/xml')    # ===> Success
 ```
 
-With a custom content type mapping:
+With an additional custom content type mapping:
 
 ```ruby
-WebMock.custom_content_type_mapping("application/vnd.api+json" => :json)
+WebMock.custom_content_type_mapping = { "application/vnd.api+json" => :json }
 
 stub_request(:post, "www.example.com").
   with(body: {data: {a: '1', b: 'five'}})

--- a/README.md
+++ b/README.md
@@ -158,6 +158,18 @@ RestClient.post('www.example.com', '<data a="1" b="five" />',
   content_type: 'application/xml')    # ===> Success
 ```
 
+With a custom content type mapping:
+
+```ruby
+WebMock.custom_content_type_mapping("application/vnd.api+json" => :json)
+
+stub_request(:post, "www.example.com").
+  with(body: {data: {a: '1', b: 'five'}})
+
+RestClient.post('www.example.com', '{"data":{"a":"1","b":"five"}}',
+  content_type: 'application/vnd.api+json')    # ===> Success
+```
+
 ### Matching request body against partial hash.
 
 ```ruby

--- a/lib/webmock/config.rb
+++ b/lib/webmock/config.rb
@@ -14,5 +14,6 @@ module WebMock
     attr_accessor :show_stubbing_instructions
     attr_accessor :query_values_notation
     attr_accessor :show_body_diff
+    attr_accessor :custom_content_type_mapping
   end
 end

--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -268,7 +268,7 @@ module WebMock
 
     private
     def body_as_hash(body, content_type)
-      case BODY_FORMATS[content_type]
+      case body_format(content_type)
       when :json then
         WebMock::Util::JSON.parse(body)
       when :xml then
@@ -276,6 +276,10 @@ module WebMock
       else
         WebMock::Util::QueryMapper.query_to_values(body, notation: Config.instance.query_values_notation)
       end
+    end
+
+    def body_format(content_type)
+      BODY_FORMATS[content_type] || (Config.instance.custom_content_type_mapping || {})[content_type]
     end
 
     def assert_non_multipart_body(content_type)

--- a/lib/webmock/webmock.rb
+++ b/lib/webmock/webmock.rb
@@ -83,7 +83,7 @@ module WebMock
     end
   end
 
-  def self.custom_content_type_mapping(config)
+  def self.custom_content_type_mapping=(config)
     Config.instance.custom_content_type_mapping = config
   end
 

--- a/lib/webmock/webmock.rb
+++ b/lib/webmock/webmock.rb
@@ -83,6 +83,10 @@ module WebMock
     end
   end
 
+  def self.custom_content_type_mapping(config)
+    Config.instance.custom_content_type_mapping = config
+  end
+
   def self.show_body_diff!
     Config.instance.show_body_diff = true
   end

--- a/spec/unit/request_pattern_spec.rb
+++ b/spec/unit/request_pattern_spec.rb
@@ -464,7 +464,7 @@ describe WebMock::RequestPattern do
 
           context "custom json content type" do
             before do
-              WebMock.custom_content_type_mapping("application/vnd.api+json" => :json)
+              WebMock.custom_content_type_mapping = { "application/vnd.api+json" => :json }
             end
             let(:content_type) { 'application/vnd.api+json' }
             it_behaves_like "a json body"


### PR DESCRIPTION
jsonapi (http://jsonapi.org/format/) requests have the custom content type `application/vnd.api+json`, which is not recognized by the current `BODY_FORMATS` as a `json` request. Since others might have similar issues with this, adding `application/vnd.api+json` to the `BODY_FORMATS` would have only solved the problem by it's root. Therefore I've added the possibility to customize the possible content types and to which format they map.