### PR TITLE
Bump addressable version

### DIFF
--- a/webmock.gemspec
+++ b/webmock.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency 'addressable', '>= 2.3.6'
+  s.add_dependency 'addressable', '~> 2.5'
   s.add_dependency 'crack', '>= 0.3.2'
   s.add_dependency 'hashdiff'
 


### PR DESCRIPTION
Addressable 2.5+ adds support for ruby 2.4 which also is a dependency in other gems.