### PR TITLE
Add write_timeout keyword arg to WebMockNetBufferedIO

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -256,8 +256,9 @@ end
 module Net  #:nodoc: all
 
   class WebMockNetBufferedIO < BufferedIO
-    def initialize(io, read_timeout: 60, continue_timeout: nil, debug_output: nil)
+    def initialize(io, read_timeout: 60, write_timeout: 60, continue_timeout: nil, debug_output: nil)
       @read_timeout = read_timeout
+      @write_timeout = write_timeout
       @rbuf = ''.dup
       @debug_output = debug_output
 


### PR DESCRIPTION
Ruby-head has introduced the following commit:
https://github.com/ruby/ruby/commit/bd7c46a7aa8b4f44ef683e22f469033b96d3dd5f#diff-8c2ab8e0fb4f052e1d95ab6334e192c1

It introduces a `write_timeout` keyward arg to BufferedIO, and this keyward arg gets set by Net::HTTP. This is causing failures when trying to run webmock on ruby-head since WebMockNetBufferedIO does not know about this keyword.

You can see a sample stacktrace here:
https://travis-ci.org/arkadiyt/ssrf_filter/jobs/398511410
```
Failure/Error: http.request(request)
     
     ArgumentError:
       unknown keyword: write_timeout
     # /home/travis/.rvm/gems/ruby-head/gems/webmock-3.4.2/lib/webmock/http_lib_adapters/net_http.rb:259:in `initialize'
     # /home/travis/.rvm/gems/ruby-head/gems/webmock-3.4.2/lib/webmock/http_lib_adapters/net_http.rb:136:in `start_with_connect_without_finish'
     # /home/travis/.rvm/gems/ruby-head/gems/webmock-3.4.2/lib/webmock/http_lib_adapters/net_http.rb:104:in `request'
``` 

This PR fixes the issue by adding the keyword arg. Running against this version locally on ruby-head all my tests pass again.

Thanks,