### PR TITLE
Handle and empty array as a query param

### DIFF
--- a/lib/webmock/util/query_mapper.rb
+++ b/lib/webmock/util/query_mapper.rb
@@ -161,7 +161,7 @@ module WebMock::Util
         else
           if array_value
             current_node[last_key] ||= []
-            current_node[last_key] << value
+            current_node[last_key] << value unless value.nil?
           else
             current_node[last_key] = value
           end
@@ -186,7 +186,9 @@ module WebMock::Util
           new_query_values = new_query_values.to_hash
           new_query_values = new_query_values.inject([]) do |object, (key, value)|
             key = key.to_s if key.is_a?(::Symbol) || key.nil?
-            if value.is_a?(Array)
+            if value.is_a?(Array) && value.empty?
+              object << [key.to_s + '[]']
+            elsif value.is_a?(Array)
               value.each { |v| object << [key.to_s + '[]', v] }
             elsif value.is_a?(Hash)
               value.each { |k, v| object << ["#{key.to_s}[#{k}]", v]}

--- a/spec/acceptance/shared/request_expectations.rb
+++ b/spec/acceptance/shared/request_expectations.rb
@@ -172,6 +172,13 @@ shared_context "request expectations" do |*adapter_info|
             expect(a_request(:get, "www.example.com").with(query: hash_excluding(a: ['b', 'c']))).to have_been_made
           }.not_to raise_error
         end
+
+        it 'should satisfy expectation if the request was executed with an empty array in the query params' do
+          expect {
+            http_request(:get, "http://www.example.com/?a[]")
+            expect(a_request(:get, "www.example.com").with(query: hash_including(a: []))).to have_been_made
+          }.not_to raise_error
+        end
       end
 
       context "when using flat array notation" do

--- a/spec/acceptance/shared/stubbing_requests.rb
+++ b/spec/acceptance/shared/stubbing_requests.rb
@@ -68,6 +68,11 @@ shared_examples_for "stubbing requests" do |*adapter_info|
         stub_request(:get, 'www.example.com').with(query: hash_excluding(a: ['b', 'c'])).to_return(body: 'abc')
         expect(http_request(:get, 'http://www.example.com/?a[]=c&a[]=d&b=1').body).to eq('abc')
       end
+
+      it "should return stubbed response when stub expects an empty array" do
+        stub_request(:get, 'www.example.com').with(query: { a: [] }).to_return(body: 'abc')
+        expect(http_request(:get, 'http://www.example.com/?a[]').body).to eq('abc')
+      end
     end
 
     describe "based on method" do

--- a/spec/unit/util/query_mapper_spec.rb
+++ b/spec/unit/util/query_mapper_spec.rb
@@ -147,4 +147,11 @@ describe WebMock::Util::QueryMapper do
     expect(subject.values_to_query values).to eq query
     expect(subject.query_to_values query).to eq values
   end
+
+  it 'converts an empty array to ?' do
+    query = "one%5B%5D"
+    values = {"one" => []}
+    expect(subject.values_to_query values).to eq query
+    expect(subject.query_to_values query).to eq values
+  end
 end


### PR DESCRIPTION
## The issue

With the following setup:
```ruby

  let(:include_param) { [] }
  let(:request_id)    { SecureRandom.uuid }
  let(:result_body)   { { events: [{ type: event_type }] } }
  let(:uri)           { "https://api.covermymeds.com/requests/#{request_id}/events" }
  let!(:get_request_stub) do
    stub_request(:get, uri)
    .with(
      query: { v: 'root_v1', include: include_param },
      headers: { "Authorization" => "Bearer ..." })
    .to_return(
      body:   result_body.to_json,
      status: 200,
    )
  end

  context '#get_request' do
    subject { client.get_request ... }
  end

```

This test passes with Faraday <= 0.15.1

But a recent [change to Faraday](https://github.com/lostisland/faraday/pull/801) in how empty arrays are handled as query params causes the above test to fail:

```
Unregistered request: GET https://api.covermymeds.com/requests/254aae9e-686d-43cb-ab2d-35913ffe6540/events?include%5B%5D&v=root_v1
```

To fix this issue, I have purposed the following PR so that an empty array is included in the query params like:
```
    query_params = {"one" => []}
    WebMock::Util::QueryMapper.values_to_query(query_params)
    # => "one%5B%5D"
```
