### PR TITLE
Travis: use latest patch releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ before_install:
   - gem update --system
   - gem update bundler
 rvm:
-  - 2.2.8
-  - 2.3.5
-  - 2.4.2
-  - 2.5.0
+  - 2.2.9
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
   - rbx-2
   - ruby-head
   - jruby-9.0.5.0
-  - jruby-9.1.13.0
+  - jruby-9.2.0.0
   - jruby-head
 matrix:
   allow_failures:


### PR DESCRIPTION
This PR only updates the versions of Rubies in CI.

See https://github.com/rbenv/ruby-build/tree/master/share/ruby-build for versions used.
