### PR TITLE
Add aliases of enable_net_connect and disallow_net_connect

### DIFF
--- a/lib/webmock/webmock.rb
+++ b/lib/webmock/webmock.rb
@@ -53,6 +53,11 @@ module WebMock
     Config.instance.net_http_connect_on_start = options[:net_http_connect_on_start]
   end
 
+  class << self
+    alias :enable_net_connect!   :allow_net_connect!
+    alias :disallow_net_connect! :disable_net_connect!
+  end
+
   def self.net_connect_allowed?(uri = nil)
     if uri.is_a?(String)
       uri = WebMock::Util::URI.normalize_uri(uri)

--- a/spec/unit/webmock_spec.rb
+++ b/spec/unit/webmock_spec.rb
@@ -10,10 +10,10 @@ describe "WebMock version" do
   end
 
   it "should alias enable_net_connect! to allow_net_connect!" do
-    expect(WebMock.enable_net_connect!).to eq(WebMock.allow_net_connect!)
+    expect(WebMock.method(:enable_net_connect!)).to eq(WebMock.method(:allow_net_connect!))
   end
 
   it "should alias disallow_net_connect! to disable_net_connect!" do
-    expect(WebMock.disallow_net_connect!).to eq(WebMock.disallow_net_connect!)
+    expect(WebMock.method(:disallow_net_connect!)).to eq(WebMock.method(:disallow_net_connect!))
   end
 end

--- a/spec/unit/webmock_spec.rb
+++ b/spec/unit/webmock_spec.rb
@@ -14,6 +14,6 @@ describe "WebMock version" do
   end
 
   it "should alias disallow_net_connect! to disable_net_connect!" do
-    expect(WebMock.method(:disallow_net_connect!)).to eq(WebMock.method(:disallow_net_connect!))
+    expect(WebMock.method(:disallow_net_connect!)).to eq(WebMock.method(:disable_net_connect!))
   end
 end

--- a/spec/unit/webmock_spec.rb
+++ b/spec/unit/webmock_spec.rb
@@ -8,4 +8,12 @@ describe "WebMock version" do
   it "should not require safe_yaml" do
     expect(defined?SafeYAML).to eq(nil)
   end
+
+  it "should alias enable_net_connect! to allow_net_connect!" do
+    expect(WebMock.enable_net_connect!).to eq(WebMock.allow_net_connect!)
+  end
+
+  it "should alias disallow_net_connect! to disable_net_connect!" do
+    expect(WebMock.disallow_net_connect!).to eq(WebMock.disallow_net_connect!)
+  end
 end


### PR DESCRIPTION
https://github.com/bblimke/webmock/issues/774

Currently there's `WebMock.allow_net_connect!` and `WebMock.disable_net_connect!`. 

For readability and memorability we should add `enable_net_connect!` and `disallow_net_connect` because enable suggests it should be disable.