### PR TITLE
Enable handling of multipart/form-data content

### DIFF
--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -248,8 +248,6 @@ module WebMock
     end
 
     def matches?(body, content_type = "")
-      assert_non_multipart_body(content_type)
-
       if (@pattern).is_a?(Hash)
         return true if @pattern.empty?
         matching_body_hashes?(body_as_hash(body, content_type), @pattern, content_type)
@@ -275,12 +273,6 @@ module WebMock
         Crack::XML.parse(body)
       else
         WebMock::Util::QueryMapper.query_to_values(body, notation: Config.instance.query_values_notation)
-      end
-    end
-
-    def assert_non_multipart_body(content_type)
-      if content_type =~ %r{^multipart/form-data}
-        raise ArgumentError.new("WebMock does not support matching body for multipart/form-data requests yet :(")
       end
     end
 

--- a/lib/webmock/request_signature.rb
+++ b/lib/webmock/request_signature.rb
@@ -47,6 +47,17 @@ module WebMock
     def assign_options(options)
       self.body = options[:body] if options.has_key?(:body)
       self.headers = options[:headers] if options.has_key?(:headers)
+
+      if headers && body then
+        if content_type = headers['Content-Type'] then
+          content_type, boundary = content_type.split(';')
+          if boundary && boundary =~ /^\s*boundary=([a-z0-9]+)$/i then
+            boundary_string = $1
+            self.body.gsub!(boundary_string, '<<<boundary>>>')
+            self.headers['Content-Type'].gsub!(boundary_string, '<<<boundary>>>')
+          end
+        end
+      end
     end
 
   end


### PR DESCRIPTION
We desperately needed that since our project uses some external websites (that we cannot change) that utilize this kind of forms, and we needed to write tests for those. Since HTTP clients use automatically generated content delimeters, I replace them with constant strings to enable creation of tests that do not change.