### PR TITLE
Test against latest Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ before_install:
   - gem update --system
   - gem update bundler
 rvm:
-  - 2.2.10
   - 2.3.8
   - 2.4.5
   - 2.5.3
+  - 2.6.0
   - rbx-2
   - ruby-head
-  - jruby-9.0.5.0
   - jruby-9.1.17.0
+  - jruby-9.2.5.0
   - jruby-head
 matrix:
   allow_failures:


### PR DESCRIPTION
Test against latest Ruby and JRuby versions

Drop tests against EOL ruby versions:
- MRI 2.2.10
- JRuby 9.0.5.0

Add tests against:
- MRI 2.6.0
- JRuby 9.2.5.0