### PR TITLE
Travis: remove old option sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,3 @@ matrix:
     - rvm: jruby-head
     - rvm: ruby-head
     - rvm: rbx-2
-# Send builds to container-based infrastructure
-# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false


### PR DESCRIPTION
This PR simplifies CI configuration by removing an unused old option.

  - see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration