### PR TITLE
[ready] perform should reset webmock_method after making request

### DIFF
--- a/lib/webmock/http_lib_adapters/curb_adapter.rb
+++ b/lib/webmock/http_lib_adapters/curb_adapter.rb
@@ -54,6 +54,7 @@ if defined?(Curl)
 
   module Curl
     class WebMockCurlEasy < Curl::Easy
+      attr_reader :webmock_method
 
       def curb_or_webmock
         request_signature = build_request_signature

--- a/lib/webmock/http_lib_adapters/curb_adapter.rb
+++ b/lib/webmock/http_lib_adapters/curb_adapter.rb
@@ -272,6 +272,7 @@ if defined?(Curl)
       def perform
         @webmock_method ||= :get
         curb_or_webmock { super }
+      ensure
         reset_webmock_method
       end
 

--- a/lib/webmock/http_lib_adapters/curb_adapter.rb
+++ b/lib/webmock/http_lib_adapters/curb_adapter.rb
@@ -271,6 +271,7 @@ if defined?(Curl)
       def perform
         @webmock_method ||= :get
         curb_or_webmock { super }
+        reset_webmock_method
       end
 
       def put_data= data
@@ -331,6 +332,10 @@ if defined?(Curl)
             super
           end
         METHOD
+      end
+
+      def reset_webmock_method
+        @webmock_method = :get
       end
 
       def reset

--- a/lib/webmock/http_lib_adapters/curb_adapter.rb
+++ b/lib/webmock/http_lib_adapters/curb_adapter.rb
@@ -54,8 +54,6 @@ if defined?(Curl)
 
   module Curl
     class WebMockCurlEasy < Curl::Easy
-      attr_reader :webmock_method
-
       def curb_or_webmock
         request_signature = build_request_signature
         WebMock::RequestRegistry.instance.requested_signatures.put(request_signature)

--- a/spec/acceptance/curb/curb_spec.rb
+++ b/spec/acceptance/curb/curb_spec.rb
@@ -411,6 +411,16 @@ unless RUBY_PLATFORM =~ /java/
       it_should_behave_like "Curb"
       include CurbSpecHelper::NamedHttp
 
+      it "should reset @webmock_method after each call" do
+        stub_request(:post, "www.example.com").with(body: "01234")
+        c = Curl::Easy.new
+        c.url = "http://www.example.com"
+        c.post_body = "01234"
+        c.http_post
+        expect(c.response_code).to eq(200)
+        expect(c.webmock_method).to eq(:get)
+      end
+
       it "should work with blank arguments for post" do
         stub_request(:post, "www.example.com").with(body: "01234")
         c = Curl::Easy.new

--- a/spec/acceptance/curb/curb_spec.rb
+++ b/spec/acceptance/curb/curb_spec.rb
@@ -417,8 +417,9 @@ unless RUBY_PLATFORM =~ /java/
         c.url = "http://www.example.com"
         c.post_body = "01234"
         c.http_post
-        expect(c.response_code).to eq(200)
-        expect(c.webmock_method).to eq(:get)
+        expect {
+          c.perform
+        }.to raise_error(WebMock::NetConnectNotAllowedError, %r(Real HTTP connections are disabled. Unregistered request: GET http://www.example.com))
       end
 
       it "should work with blank arguments for post" do


### PR DESCRIPTION
I feel like each request should not care about what is the previously called HTTP verb.
For example:
```
c = Curl::Easy.new("http://www.google.co.uk")
c.http_post
c.perform
```
In this case, c.perform http_verb would be set automatically to POST, which is an surprise. If it's default to GET, it feels more intuitive. Since we're already familiar with the notion of stateless request, which is independent from each other.