### PR TITLE
Demonstrate using Addressable::Template for URI host part worked in v3.4.1

### DIFF
--- a/spec/unit/request_pattern_spec.rb
+++ b/spec/unit/request_pattern_spec.rb
@@ -121,6 +121,12 @@ describe WebMock::RequestPattern do
         to match(WebMock::RequestSignature.new(:get, "www.example.com"))
     end
 
+    it "should match if Addressable::Template pattern host matches request uri" do
+      signature = WebMock::RequestSignature.new(:get, "www.example.com")
+      uri = Addressable::Template.new("{subdomain}.example.com")
+      expect(WebMock::RequestPattern.new(:get, uri)).to match(signature)
+    end
+
     it "should match for uris with same parameters as pattern" do
       expect(WebMock::RequestPattern.new(:get, "www.example.com?a=1&b=2")).
         to match(WebMock::RequestSignature.new(:get, "www.example.com?a=1&b=2"))


### PR DESCRIPTION
This PR is a demonstration for https://github.com/bblimke/webmock/pull/797 to show that `Addressable::Template.new("{subdomain}.example.com")` templates used to work in v3.4.1 but no longer don't since v3.4.2.

**This PR is not intended to be merged.**

The parent commit of this PR is commit ca54cf8bfd64e1563012b630951377c922141385, i.e. the commit tagged as `v3.4.1`.