### PR TITLE
Fix  with no arguments when allow is a non-localhost URI string

### DIFF
--- a/lib/webmock/webmock.rb
+++ b/lib/webmock/webmock.rb
@@ -59,6 +59,8 @@ module WebMock
   end
 
   def self.net_connect_allowed?(uri = nil)
+    return Config.instance.allow_net_connect if uri.nil?
+
     if uri.is_a?(String)
       uri = WebMock::Util::URI.normalize_uri(uri)
     end

--- a/spec/unit/util/webmock_spec.rb
+++ b/spec/unit/util/webmock_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+module WebMock
+  describe ".net_connect_allowed?" do
+    context 'enabled globally' do
+      before do
+        WebMock.enable_net_connect!
+      end
+
+      context 'without arguments' do
+        it 'returns WebMock::Config.instance.allow_net_connect' do
+          expect(WebMock.net_connect_allowed?).to be_truthy
+        end
+      end
+    end
+
+    context 'disabled with allowed remote string' do
+      before do
+        WebMock.disable_net_connect!(allow: "http://192.168.64.2:20031")
+      end
+
+      context 'without arguments' do
+        it 'returns WebMock::Config.instance.allow_net_connect' do
+          expect(WebMock.net_connect_allowed?).to be_falsey
+        end
+      end
+    end
+
+    context 'disabled globally' do
+      before do
+        WebMock.disable_net_connect!
+      end
+
+      context 'without arguments' do
+        it 'returns WebMock::Config.instance.allow_net_connect' do
+          expect(WebMock.net_connect_allowed?).to be_falsey
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/bblimke/webmock/issues/814.

From the issue:

```
$ ruby -v
ruby 2.5.5p157 (2019-03-15 revision 67260) [x86_64-darwin18]
$ gem list webmock

*** LOCAL GEMS ***

webmock (3.5.1)
$ irb
irb(main):001:0> require 'webmock'
=> true
irb(main):002:0> WebMock.net_connect_allowed?
=> nil
irb(main):003:0> WebMock.disable_net_connect!(allow: "http://192.168.64.2:20031")
=> nil
irb(main):004:0> WebMock.net_connect_allowed?
Traceback (most recent call last):
        4: from /opt/rubies/2.5.5/bin/irb:11:in `<main>'
        3: from (irb):4
        2: from /Users/redacted/.gem/ruby/2.5.5/gems/webmock-3.5.1/lib/webmock/webmock.rb:63:in `net_connect_allowed?'
        1: from /Users/redacted/.gem/ruby/2.5.5/gems/webmock-3.5.1/lib/webmock/webmock.rb:75:in `net_connect_explicit_allowed?'
NoMethodError (undefined method `host' for nil:NilClass)
irb(main):005:0> ^C
irb(main):005:0>
```