### PR TITLE
Update `Hashdiff` Constant

### DIFF
--- a/lib/webmock/request_body_diff.rb
+++ b/lib/webmock/request_body_diff.rb
@@ -12,7 +12,7 @@ module WebMock
     def body_diff
       return {} unless request_signature_diffable? && request_stub_diffable?
 
-      HashDiff.diff(request_signature_body_hash, request_stub_body_hash)
+      Hashdiff.diff(request_signature_body_hash, request_stub_body_hash)
     end
 
     attr_reader :request_signature, :request_stub

--- a/webmock.gemspec
+++ b/webmock.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'addressable', '>= 2.3.6'
   s.add_dependency 'crack', '>= 0.3.2'
-  s.add_dependency 'hashdiff'
+  s.add_dependency 'hashdiff', ['>= 0.4.0', '< 2.0.0']
 
   unless RUBY_PLATFORM =~ /java/
     s.add_development_dependency 'patron',   '>= 0.4.18'


### PR DESCRIPTION
Why This Change Is Necessary
========================================================================

The `hashdiff` gem is changing its constant and thus we need to do the
same.

How These Changes Address the Issue
========================================================================

Update `HashDiff` references to `Hashdiff`.

Side Effects Caused By This Change
========================================================================

This will not remove the `hashdiff` warning error until `hashdiff`'s
`1.0` version is released, at which point a `bundle update` will remove
the warning.

------------------------------------------------------------------------
Actions:
  * References #822