### PR TITLE
stubbing io on stubbed socket

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -251,6 +251,13 @@ class StubSocket #:nodoc:
   def readuntil(*args)
   end
 
+  def io
+    @io ||= StubIO.new
+  end
+
+  class StubIO
+    def setsockopt(*args); end
+  end
 end
 
 module Net  #:nodoc: all


### PR DESCRIPTION
Hi there!

I'm writing an app that calls some methods from the bundler gem programmatically. I don't want to spam the rubygems API, so I'm trying to use VCR and webmock to record my test requests. 

Now bundler (2.0.2) does some funky low-level stuff with Net::Http sockets that currently cause the following exception when used in conjunction with Webmock and VCR:

```
 NoMethodError:
       undefined method `io' for #<StubSocket:0x00007fde11d49508 @read_timeout=10>
```

Specifically, this is the result of a call to [Bundler::Definition#resolve_remotely](https://github.com/bundler/bundler/blob/master/lib/bundler/definition.rb#L154), and the immediate call triggering the exception is [this](https://github.com/bundler/bundler/blob/master/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb#L708).

This little patch fixes the issue by simply stubbing out the required object and method. I realize this is quite obscure and might not be worth merging. Let me know if it is please and I can try to come up with some code to reproduce this, at the least, and perhaps add a couple of tests to the PR.

Thanks!

