### PR TITLE
Support write_timeout setter in StubSocket

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -236,7 +236,7 @@ end
 
 class StubSocket #:nodoc:
 
-  attr_accessor :read_timeout, :continue_timeout
+  attr_accessor :read_timeout, :continue_timeout, :write_timeout
 
   def initialize(*args)
   end


### PR DESCRIPTION
ruby 2.6.x, stripe library in spec recorded with vcr/webmock
```
      NoMethodError:
        undefined method `write_timeout=' for #<StubSocket:0x0000556a9cca6f50 @read_timeout=80>

      # /usr/local/bundle/gems/net-http-persistent-3.1.0/lib/net/http/persistent.rb:659:in `connection_for'
      # /usr/local/bundle/gems/net-http-persistent-3.1.0/lib/net/http/persistent.rb:958:in `request'
      # /usr/local/bundle/gems/faraday-0.15.4/lib/faraday/adapter/net_http_persistent.rb:38:in `perform_request'
      # /usr/local/bundle/gems/faraday-0.15.4/lib/faraday/adapter/net_http.rb:43:in `block in call'
      # /usr/local/bundle/gems/faraday-0.15.4/lib/faraday/adapter/net_http.rb:92:in `with_net_http_connection'
      # /usr/local/bundle/gems/faraday-0.15.4/lib/faraday/adapter/net_http.rb:38:in `call'
      # /usr/local/bundle/gems/faraday-0.15.4/lib/faraday/response.rb:8:in `call'
      # /usr/local/bundle/gems/faraday-0.15.4/lib/faraday/request/url_encoded.rb:15:in `call'
      # /usr/local/bundle/gems/faraday-0.15.4/lib/faraday/request/multipart.rb:15:in `call'
      # /usr/local/bundle/gems/faraday-0.15.4/lib/faraday/rack_builder.rb:143:in `build_response'
      # /usr/local/bundle/gems/faraday-0.15.4/lib/faraday/connection.rb:387:in `run_request'
      # /usr/local/bundle/gems/stripe-4.21.3/lib/stripe/stripe_client.rb:185:in `block in execute_request'
      # /usr/local/bundle/gems/stripe-4.21.3/lib/stripe/stripe_client.rb:266:in `execute_request_with_rescues'
      # /usr/local/bundle/gems/stripe-4.21.3/lib/stripe/stripe_client.rb:184:in `execute_request'
      # /usr/local/bundle/gems/stripe-4.21.3/lib/stripe/api_operations/request.rb:19:in `request'
      # /usr/local/bundle/gems/stripe-4.21.3/lib/stripe/api_operations/request.rb:49:in `request'
      # /usr/local/bundle/gems/stripe-4.21.3/lib/stripe/api_resource.rb:96:in `refresh'
      # /usr/local/bundle/gems/stripe-4.21.3/lib/stripe/api_resource.rb:103:in `retrieve'
      # ./app/models/account.rb:481:in `stripe_customer'
```