### PR TITLE
Fix overeager removal of default ports from urls when matching

### DIFF
--- a/lib/webmock/util/uri.rb
+++ b/lib/webmock/util/uri.rb
@@ -41,11 +41,11 @@ module WebMock
           uris = uris_with_trailing_slash_and_without(uris)
         end
 
-        uris = uris_encoded_and_unencoded(uris)
-
         if normalized_uri.port == Addressable::URI.port_mapping[normalized_uri.scheme]
           uris = uris_with_inferred_port_and_without(uris)
         end
+
+        uris = uris_encoded_and_unencoded(uris)
 
         if normalized_uri.scheme == "http" && !only_with_scheme
           uris = uris_with_scheme_and_without(uris)
@@ -80,8 +80,7 @@ module WebMock
 
       def self.uris_with_inferred_port_and_without(uris)
         uris.map { |uri|
-          uri = uri.dup.force_encoding(Encoding::ASCII_8BIT) if uri.respond_to?(:force_encoding)
-          [ uri, uri.gsub(%r{(:80)|(:443)}, "").freeze ]
+          [ uri, uri.omit(:port)]
         }.flatten
       end
 

--- a/spec/unit/util/uri_spec.rb
+++ b/spec/unit/util/uri_spec.rb
@@ -92,6 +92,30 @@ URIS_WITH_SCHEME =
   "http://www.example.com:80/"
 ].sort
 
+URIS_WITH_COLON_IN_PATH =
+[
+  [
+    "https://example.com/a/b:80",
+    "https://example.com:443/a/b:80",
+  ].sort,
+  [
+    "https://example.com:443/a/b:443",
+    "https://example.com/a/b:443",
+  ].sort,
+  [
+    "http://example.com/a/b:443",
+    "example.com/a/b:443",
+    "http://example.com:80/a/b:443",
+    "example.com:80/a/b:443",
+  ].sort,
+  [
+    "http://example.com/a/b:80",
+    "example.com/a/b:80",
+    "http://example.com:80/a/b:80",
+    "example.com:80/a/b:80",
+  ].sort
+]
+
 describe WebMock::Util::URI do
 
   describe "reporting variations of uri" do
@@ -142,6 +166,14 @@ describe WebMock::Util::URI do
       URIS_WITHOUT_PATH_OR_PARAMS.each do |uri|
         variations_of_uri_with_scheme = WebMock::Util::URI.variations_of_uri_as_strings(uri, only_with_scheme: true)
         expect(variations_of_uri_with_scheme.sort).to eq(URIS_WITH_SCHEME)
+      end
+    end
+
+    it "should not replace :80 or :443 in path" do
+      URIS_WITH_COLON_IN_PATH.each do |uris|
+        uris.each do |uri|
+          expect(WebMock::Util::URI.variations_of_uri_as_strings(uri).sort).to eq(uris)
+        end
       end
     end
 


### PR DESCRIPTION
:80 / :443 was removed no matter where it appeared in the url, ie
also in path or authentication sections. Fixed by using URI to remove
the port rather than regexps

See also #827