### PR TITLE
Fix a sporadic spec error

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -229,7 +229,8 @@ class PatchedStringIO < StringIO #:nodoc:
   alias_method :orig_read_nonblock, :read_nonblock
 
   def read_nonblock(size, *args)
-    orig_read_nonblock(size)
+    args.reject! {|arg| !arg.is_a?(Hash)}
+    orig_read_nonblock(size, *args)
   end
 
 end

--- a/spec/support/webmock_server.rb
+++ b/spec/support/webmock_server.rb
@@ -36,6 +36,7 @@ class WebMockServer
         end
       end
       server.start do |socket|
+        socket.read(1)
         socket.puts <<-EOT.gsub(/^\s+\|/, '')
           |HTTP/1.1 200 OK\r
           |Date: Fri, 31 Dec 1999 23:59:59 GMT\r


### PR DESCRIPTION
I observed builds randomly failing, mostly on linux with EPIPE errors.

I *think* this is webrick closing the connection before the client has sent the request. This change makes webrick wait for the first byte of the request before sending a response.

There was another failure that was because we weren’t passing through the exception:false flag to rbuf_fill causing it to raise exceptions the net http code wasn’t expecting.