### PR TITLE
Fix EM HTTP request adapter's timeout class

### DIFF
--- a/lib/webmock/http_lib_adapters/em_http_request_adapter.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request_adapter.rb
@@ -107,7 +107,7 @@ if defined?(EventMachine::HttpClient)
           @uri ||= nil
           EM.next_tick {
             setup(make_raw_response(stubbed_webmock_response), @uri,
-                  stubbed_webmock_response.should_timeout ? "WebMock timeout error" : nil)
+                  stubbed_webmock_response.should_timeout ? Errno::ETIMEDOUT : nil)
           }
           self
         elsif WebMock.net_connect_allowed?(request_signature.uri)

--- a/spec/acceptance/em_http_request/em_http_request_spec_helper.rb
+++ b/spec/acceptance/em_http_request/em_http_request_spec_helper.rb
@@ -50,7 +50,7 @@ module EMHttpRequestSpecHelper
   end
 
   def client_timeout_exception_class
-    "WebMock timeout error"
+    'Errno::ETIMEDOUT'
   end
 
   def connection_refused_exception_class


### PR DESCRIPTION
As defined in a test, that's the expected error class:

https://github.com/igrigorik/em-http-request/blob/907f46713e8257e1c1dd348bc5da77adc8d38392/spec/client_spec.rb#L499
