### PR TITLE
split header values on newlines - as created by Rack::Utils

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -158,7 +158,8 @@ module WebMock
 
           response.instance_variable_set(:@body, body)
           webmock_response.headers.to_a.each do |name, values|
-            values = [values] unless values.is_a?(Array)
+            # values = [values] unless values.is_a?(Array)
+            values = values.split("\n") unless values.is_a?(Array)
             values.each do |value|
               response.add_field(name, value)
             end


### PR DESCRIPTION
**WIP**: Seeking guidance.

I ran into a problem in our Rails app.

A recent change added an additional cookie into the mix. Up until now our specs have only ever set a single cookie.

Many specs set this additional cookie and were failing with an error `header field value cannot include CR/LF`.

Investigation showed that the Rails cookies middleware adds cookies using `Rack::Utils.add_cookie_to_header` which appends additional cookies to the header value with a newline between them.

This one-line change fixes that issue - it breaks no existing specs. But I don't think there are any specs that test this condition at all.

I'm more than happy to add a spec but I'm not sure where best to start or how to proceed on that front.