### PR TITLE
Fix "warning: shadowing outer local variable - v"

### DIFF
--- a/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
+++ b/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
@@ -195,8 +195,8 @@ if defined?(Async::HTTP)
           end
 
           def build_response(webmock_response)
-            headers = (webmock_response.headers || {}).each_with_object([]) do |(k, v), o|
-              Array(v).each do |v|
+            headers = (webmock_response.headers || {}).each_with_object([]) do |(k, value), o|
+              Array(value).each do |v|
                 o.push [k, v]
               end
             end


### PR DESCRIPTION
This fixes the following warning.

```
/usr/local/bundle/gems/webmock-3.7.0/lib/webmock/http_lib_adapters/async_http_client_adapter.rb:199: warning: shadowing outer local variable - v
```