### PR TITLE
Do not try to gsub on incompatible encoding

### DIFF
--- a/lib/webmock/util/uri.rb
+++ b/lib/webmock/util/uri.rb
@@ -51,7 +51,10 @@ module WebMock
           uris = uris_with_scheme_and_without(uris)
         end
 
-        uris.map {|uri| uri.to_s.gsub(/^\/\//,'') }.uniq
+        uris.map do |uri|
+          uri = uri.dup.force_encoding(Encoding::ASCII_8BIT) if uri.respond_to?(:force_encoding)
+          uri.to_s.gsub(/^\/\//,'')
+        end.uniq
       end
 
       def self.strip_default_port_from_uri_string(uri_string)

--- a/lib/webmock/util/uri.rb
+++ b/lib/webmock/util/uri.rb
@@ -51,10 +51,7 @@ module WebMock
           uris = uris_with_scheme_and_without(uris)
         end
 
-        uris.map do |uri|
-          uri = uri.dup.force_encoding(Encoding::ASCII_8BIT) if uri.respond_to?(:force_encoding)
-          uri.to_s.gsub(/^\/\//,'')
-        end.uniq
+        uris.map {|uri| uri.to_s.gsub(/^\/\//,'') }.uniq
       end
 
       def self.strip_default_port_from_uri_string(uri_string)
@@ -89,13 +86,15 @@ module WebMock
 
       def self.uris_encoded_and_unencoded(uris)
         uris.map do |uri|
-          [ uri.to_s, Addressable::URI.unencode(uri, String).freeze ]
+          [
+            uri.to_s.force_encoding(Encoding::ASCII_8BIT),
+            Addressable::URI.unencode(uri, String).force_encoding(Encoding::ASCII_8BIT).freeze
+          ]
         end.flatten
       end
 
       def self.uris_with_scheme_and_without(uris)
         uris.map { |uri|
-          uri = uri.dup.force_encoding(Encoding::ASCII_8BIT) if uri.respond_to?(:force_encoding)
           [ uri, uri.gsub(%r{^https?://},"").freeze ]
         }.flatten
       end

--- a/lib/webmock/util/uri.rb
+++ b/lib/webmock/util/uri.rb
@@ -101,8 +101,7 @@ module WebMock
       end
 
       def self.uris_with_trailing_slash_and_without(uris)
-        uris = uris.map { |uri|
-          uri = uri.dup.force_encoding(Encoding::ASCII_8BIT) if uri.respond_to?(:force_encoding)
+        uris.map { |uri|
           [ uri, uri.omit(:path).freeze ]
         }.flatten
       end

--- a/spec/unit/util/uri_spec.rb
+++ b/spec/unit/util/uri_spec.rb
@@ -177,6 +177,16 @@ describe WebMock::Util::URI do
       end
     end
 
+    it "should find all variations of uris with https, basic auth, a non-standard port and a path" do
+      uri = "https://~%8A:pass@www.example.com:9000/foo"
+      variations = [
+        "https://~%8A:pass@www.example.com:9000/foo",
+        "https://~\x8A:pass@www.example.com:9000/foo".force_encoding(Encoding::ASCII_8BIT)
+      ]
+
+      expect(WebMock::Util::URI.variations_of_uri_as_strings(uri)).to eq(variations)
+    end
+
   end
 
   describe "normalized uri equality" do


### PR DESCRIPTION
After #832, if the URL contains incompatible encoding characters the gsub to remove the protocol relative from the URL will fail. We should encode the string to binary mode before doing the gsub.

Got the tests from https://github.com/bblimke/webmock/pull/687 since it is the same issue so this doesn't regress anymore.