### PR TITLE
Add test for regression caused by #829

### DIFF
--- a/lib/webmock/util/uri.rb
+++ b/lib/webmock/util/uri.rb
@@ -47,7 +47,7 @@ module WebMock
 
         uris = uris_encoded_and_unencoded(uris)
 
-        if normalized_uri.scheme == "http" && !only_with_scheme
+        if normalized_uri.scheme == "http" && normalized_uri.host.start_with?(/[[:alpha:]]/) && !only_with_scheme
           uris = uris_with_scheme_and_without(uris)
         end
 

--- a/lib/webmock/util/uri.rb
+++ b/lib/webmock/util/uri.rb
@@ -47,7 +47,7 @@ module WebMock
 
         uris = uris_encoded_and_unencoded(uris)
 
-        if !only_with_scheme && normalized_uri.scheme == "http" && normalized_uri.host.start_with?(/[[:alpha:]]/)
+        if !only_with_scheme && normalized_uri.scheme == "http" && normalized_uri.host =~ /^[[:alpha:]]/
           uris = uris_with_scheme_and_without(uris)
         end
 

--- a/lib/webmock/util/uri.rb
+++ b/lib/webmock/util/uri.rb
@@ -47,7 +47,7 @@ module WebMock
 
         uris = uris_encoded_and_unencoded(uris)
 
-        if normalized_uri.scheme == "http" && normalized_uri.host.start_with?(/[[:alpha:]]/) && !only_with_scheme
+        if !only_with_scheme && normalized_uri.scheme == "http" && normalized_uri.host.start_with?(/[[:alpha:]]/)
           uris = uris_with_scheme_and_without(uris)
         end
 

--- a/spec/unit/request_pattern_spec.rb
+++ b/spec/unit/request_pattern_spec.rb
@@ -132,6 +132,12 @@ describe WebMock::RequestPattern do
       expect(WebMock::RequestPattern.new(:get, uri)).to match(signature)
     end
 
+    it "should match if uri Addressable::Template pattern matches request uri without a schema and a path " do
+      signature = WebMock::RequestSignature.new(:get, "127.0.0.1:3000")
+      uri = Addressable::Template.new("127.0.0.1:3000")
+      expect(WebMock::RequestPattern.new(:get, uri)).to match(signature)
+    end
+
     it "should match for uris with same parameters as pattern" do
       expect(WebMock::RequestPattern.new(:get, "www.example.com?a=1&b=2")).
         to match(WebMock::RequestSignature.new(:get, "www.example.com?a=1&b=2"))


### PR DESCRIPTION
I found a regression caused by #829 if we try to match an `Addressable::Template` using an ip and without any patch.

This is the failure I get:

```
  1) WebMock::RequestPattern when matching should match if uri Addressable::Template pattern matches request uri without a schema and a path
     Failure/Error: WebMock::Util::URI.variations_of_uri_as_strings(uri).any? { |u| normalized_template.match(u) }

     Addressable::URI::InvalidURIError:
       Invalid scheme format: 127.0.0.1
     # ./lib/webmock/request_pattern.rb:186:in `block in matches_with_variations?'
     # ./lib/webmock/request_pattern.rb:186:in `any?'
     # ./lib/webmock/request_pattern.rb:186:in `matches_with_variations?'
     # ./lib/webmock/request_pattern.rb:158:in `matches?'
     # ./lib/webmock/request_pattern.rb:37:in `matches?'
     # ./spec/unit/request_pattern_spec.rb:68:in `match'
     # ./spec/unit/request_pattern_spec.rb:138:in `block (3 levels) in <top (required)>'
```

Reverting the changes in #829 this test pass.

I'll try to also provide a fix but I'm opening a PR only with the test in case one of the maintainer know the best way to fix this case.