### PR TITLE
Allow passing an output buffer to HTTP::Response::Body#readpartial

### DIFF
--- a/lib/webmock/http_lib_adapters/http_rb/streamer.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/streamer.rb
@@ -5,7 +5,7 @@ module HTTP
         @io = StringIO.new str
       end
 
-      def readpartial(size = nil)
+      def readpartial(size = nil, outbuf = nil)
         unless size
           if defined?(HTTP::Client::BUFFER_SIZE)
             size = HTTP::Client::BUFFER_SIZE
@@ -14,7 +14,7 @@ module HTTP
           end
         end
 
-        @io.read size
+        @io.read size, outbuf
       end
 
       def close

--- a/spec/acceptance/http_rb/http_rb_spec.rb
+++ b/spec/acceptance/http_rb/http_rb_spec.rb
@@ -72,6 +72,17 @@ describe "HTTP.rb" do
   end
 
   context "streamer" do
+    it "can be read to a provided buffer" do
+      stub_request(:get, "example.com/foo")
+        .to_return(status: 200, body: "Hello world!")
+      response = HTTP.get "http://example.com/foo"
+
+      buffer = ""
+      response.body.readpartial(1024, buffer)
+
+      expect(buffer).to eq "Hello world!"
+    end
+
     it "can be closed" do
       stub_request :get, "example.com/foo"
       response = HTTP.get "http://example.com/foo"


### PR DESCRIPTION
Unmocked:

```
> response = HTTP.get "http://example.com/foo"
> response.body.readpartial(1024, "")
"Hello world!"
```

Mocked:

```
> response = HTTP.get "http://example.com/foo"
> response.body.readpartial(1024, "")
ArgumentError: wrong number of arguments (given 2, expected 0..1)
```

`HTTP::Response::Body` delegates `#readpartial` to the underlying connection. For an unmocked request, that’s an `HTTP::Connection`, which accepts the conventional second argument to `#readpartial`. For a mocked request, it’s an `HTTP::Response::Streamer`, which previously *didn’t* accept a second argument.