### PR TITLE
Reset memoized response fields in Curb adapter

### DIFF
--- a/lib/webmock/http_lib_adapters/curb_adapter.rb
+++ b/lib/webmock/http_lib_adapters/curb_adapter.rb
@@ -340,6 +340,10 @@ if defined?(Curl)
 
       def reset
         instance_variable_set(:@body_str, nil)
+        instance_variable_set(:@content_type, nil)
+        instance_variable_set(:@header_str, nil)
+        instance_variable_set(:@last_effective_url, nil)
+        instance_variable_set(:@response_code, nil)
         super
       end
     end

--- a/spec/acceptance/curb/curb_spec.rb
+++ b/spec/acceptance/curb/curb_spec.rb
@@ -474,18 +474,25 @@ unless RUBY_PLATFORM =~ /java/
       include CurbSpecHelper::ClassPerform
     end
 
-    describe "using .reset" do
+    describe "using #reset" do
       before do
         @curl = Curl::Easy.new
         @curl.url = "http://example.com"
-        body = "on_success fired"
-        stub_request(:any, "example.com").to_return(body: body)
+        stub_request(:any, "example.com").
+          to_return(body: "abc",
+                    headers: { "Content-Type" => "application/json" })
         @curl.http_get
       end
 
-      it "should clear the body_str" do
+      it "should clear all memoized response fields" do
         @curl.reset
-        expect(@curl.body_str).to eq(nil)
+        expect(@curl).to have_attributes(
+          body_str: nil,
+          content_type: nil,
+          header_str: nil,
+          last_effective_url: nil,
+          response_code: 0,
+        )
       end
     end
   end


### PR DESCRIPTION
Exactly the same issue as in https://github.com/bblimke/webmock/issues/703 bites again!

I was running into a problem with VCR recording the same headers for a series of different Curl requests. Turns out it was due to partial `reset` method implementation, which only cleans up `body_str`, although `Curl::WebMockCurlEasy` memoizes a lot more things, including `header_str` for my case.