### PR TITLE
Suppress excon warning generated by extra key

### DIFF
--- a/lib/webmock/http_lib_adapters/excon_adapter.rb
+++ b/lib/webmock/http_lib_adapters/excon_adapter.rb
@@ -159,4 +159,7 @@ if defined?(Excon)
       end
     end
   end
+
+  # Suppresses Excon connection argument validation warning
+  Excon::VALID_CONNECTION_KEYS << :__construction_args
 end

--- a/spec/acceptance/excon/excon_spec_helper.rb
+++ b/spec/acceptance/excon/excon_spec_helper.rb
@@ -28,6 +28,8 @@ module ExconSpecHelper
       res
     end
 
+    Excon.set_raise_on_warnings!(true)
+
     OpenStruct.new \
       body: response.body,
       headers: headers,


### PR DESCRIPTION
WebMock adapter for [excon](https://github.com/excon/excon) generates the following warning when sending a request:
```
[excon][WARNING] Invalid Excon connection keys: :__construction_args
```

This happens because excon [validates if all parameters provided are indeed valid connection parameters](https://github.com/excon/excon/blob/514db813e58453bb7a6bbd65751ba04b8e8a343b/lib/excon/connection.rb#L414-L425), and `:__construction_args`, WebMock's internal storage parameter, is not.

This PR adds `:__construction_args` to excon's [list of valid connection parameters](https://github.com/excon/excon/blob/514db813e58453bb7a6bbd65751ba04b8e8a343b/lib/excon/constants.rb#L68-L105).

This list has existed since excon's minimum version supported by WebMock: [`0.27.5`](https://github.com/excon/excon/blob/v0.27.5/lib/excon/constants.rb#L64-L86).

In the future, any new excon warnings raised during the adapter test will raise an error.