### PR TITLE
Return effective_url as string (without port details)

### DIFF
--- a/lib/webmock/http_lib_adapters/typhoeus_hydra_adapter.rb
+++ b/lib/webmock/http_lib_adapters/typhoeus_hydra_adapter.rb
@@ -102,7 +102,7 @@ if defined?(Typhoeus)
               status_message: webmock_response.status[1],
               body: webmock_response.body,
               headers: webmock_response.headers,
-              effective_url: request_signature.uri
+              effective_url: request_signature.uri.omit(:port).to_s
             )
           end
           response.mock = :webmock

--- a/spec/acceptance/typhoeus/typhoeus_hydra_spec.rb
+++ b/spec/acceptance/typhoeus/typhoeus_hydra_spec.rb
@@ -32,6 +32,14 @@ unless RUBY_PLATFORM =~ /java/
         end
       end
 
+      describe 'effective_url' do
+        it "returns effective_url as string without port" do
+          stub_request(:get, "http://www.example.com").to_return(headers: {'X-Test' => '1'})
+          response = Typhoeus.get("http://www.example.com")
+          expect(response.effective_url).to eq 'http://www.example.com/'
+        end
+      end
+
       describe "when params are used" do
         it "should take into account params for POST request" do
           stub_request(:post, "www.example.com/?hello=world").with(query: {hello: 'world'})


### PR DESCRIPTION
This is an attempted fix for this issue https://github.com/bblimke/webmock/issues/552