### PR TITLE
Ruby 2.7: Use keyword args double-asterisk in `WebMockNetBufferedIO`

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -268,7 +268,14 @@ module Net  #:nodoc: all
       end
       raise "Unable to create local socket" unless io
 
-      super
+      # Prior to 2.4.0 `BufferedIO` only takes a single argument (`io`) with no
+      # options. Here we pass through our full set of arguments only if we're
+      # on 2.4.0 or later, and use a simplified invocation otherwise.
+      if RUBY_VERSION >= '2.4.0'
+        super
+      else
+        super(io)
+      end
     end
 
     if RUBY_VERSION >= '2.6.0'

--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -257,7 +257,7 @@ end
 module Net  #:nodoc: all
 
   class WebMockNetBufferedIO < BufferedIO
-    def initialize(io, *args)
+    def initialize(io, **args)
       io = case io
       when Socket, OpenSSL::SSL::SSLSocket, IO
         io


### PR DESCRIPTION
Webmock is currently showing a warning on Ruby 2.7 related to the use of
a single asterisk for passing keyword args to `BufferedIO` via the use
of an argument-less `super`.

Here's the warning:

```
/Users/brandur/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/webmock-3.7.6/lib/webmock/http_lib_adapters/net_http.rb:271: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/brandur/.rbenv/versions/2.7.0/lib/ruby/2.7.0/net/protocol.rb:114: warning: The called method `initialize' is defined here
```

And here's the method in question:

``` ruby
  class WebMockNetBufferedIO < BufferedIO
    def initialize(io, **args)
      io = case io
      when Socket, OpenSSL::SSL::SSLSocket, IO
        io
      when StringIO
        PatchedStringIO.new(io.string)
      when String
        PatchedStringIO.new(io)
      end
      raise "Unable to create local socket" unless io

      super
    end
```

Taking a look at the definition of `BufferedIO` [1], it seems to purely
take keyword args after the first `io` argument:

``` ruby
initialize(io, read_timeout: 60, write_timeout: 60, continue_timeout: nil, debug_output: nil) ⇒ BufferedIO
```

So I believe it's safe here just to switch to a double asterisk from a
single and call it a day.

[1] https://www.rubydoc.info/stdlib/net/Net/BufferedIO