### PR TITLE
Be able to mock non-ASCII bodies with HTTP.rb

### DIFF
--- a/lib/webmock/http_lib_adapters/http_rb/response.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/response.rb
@@ -14,7 +14,7 @@ module HTTP
       def from_webmock(webmock_response, request_signature = nil)
         status  = Status.new(webmock_response.status.first)
         headers = webmock_response.headers || {}
-        body    = Body.new Streamer.new webmock_response.body
+        body    = Body.new(Streamer.new(webmock_response.body), encoding: webmock_response.body.encoding)
         uri     = normalize_uri(request_signature && request_signature.uri)
 
         return new(status, "1.1", headers, body, uri) if HTTP::VERSION < "1.0.0"

--- a/spec/acceptance/http_rb/http_rb_spec.rb
+++ b/spec/acceptance/http_rb/http_rb_spec.rb
@@ -74,13 +74,13 @@ describe "HTTP.rb" do
   context "streamer" do
     it "can be read to a provided buffer" do
       stub_request(:get, "example.com/foo")
-        .to_return(status: 200, body: "Hello world!")
+        .to_return(status: 200, body: "Hello world! ")
       response = HTTP.get "http://example.com/foo"
 
       buffer = ""
       response.body.readpartial(1024, buffer)
 
-      expect(buffer).to eq "Hello world!"
+      expect(buffer).to eq "Hello world! "
     end
 
     it "can be closed" do


### PR DESCRIPTION
HTTP::Response::Body uses Encoding::BINARY as the default: https://github.com/httprb/http/blob/v4.3.0/lib/http/response/body.rb#L19

The failure without the patch looks like this:

```ruby
$ bundle e rspec -r ./spec/spec_helper.rb -e 'HTTP.rb streamer can be read to a provided buffer'
Run options: include {:full_description=>/HTTP\.rb\ streamer\ can\ be\ read\ to\ a\ provided\ buffer/}

HTTP.rb
  streamer
    can be read to a provided buffer (FAILED - 1)

Failures:

  1) HTTP.rb streamer can be read to a provided buffer
     Failure/Error: expect(buffer).to eq "Hello world! "

       expected: "Hello world! "
            got: "Hello world! \xEF\xA3\xBF"

       (compared using ==)
     # ./spec/acceptance/http_rb/http_rb_spec.rb:83:in `block (3 levels) in <top (required)>'

Finished in 0.17638 seconds (files took 2.02 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/acceptance/http_rb/http_rb_spec.rb:75 # HTTP.rb streamer can be read to a provided buffer
```

Let me know if you want the specs done in some other way, this was just the quickest way of demonstrating the problem.