### PR TITLE
CI: Use new Ruby, separate out JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,19 @@ rvm:
   - 2.7.0
   - rbx-2
   - ruby-head
-  - jruby-9.1.17.0
-  - jruby-9.2.7.0
-  - jruby-head
-jdk: openjdk8
 matrix:
+  include:
+    - rvm: jruby-9.1.17.0
+      jdk: openjdk8
+    - rvm: jruby-9.2.11.1
+      jdk: openjdk11
+    - rvm: jruby-head
+      jdk: openjdk11
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
     - rvm: rbx-2
+env:
+  global:
+    JRUBY_OPTS: "--debug"
+


### PR DESCRIPTION
This PR updates the CI matrix to use latest releases. **Update**: too early for rvm! Seems these named versions from the https://www.ruby-lang.org/en/news/ from today are not yet available.

- Use different JDKs for 9.1 and 9.2+

