### PR TITLE
Fix InvalidURIError with `ip` uri

### DIFF
--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -203,7 +203,15 @@ module WebMock
         rescue Addressable::URI::InvalidURIError
           Addressable::Template.new(@pattern.pattern)
         end
-      WebMock::Util::URI.variations_of_uri_as_strings(uri).any? { |u| template.match(u) }
+      uris = WebMock::Util::URI.variations_of_uri_as_strings(uri)
+      uris.select! { |uri| valid_uri?(uri) }
+      uris.any? { |u| template.match(u) }
+    end
+
+    def valid_uri?(uri)
+      !!Addressable::URI.parse(uri)
+    rescue Addressable::URI::InvalidURIError => e
+      false
     end
   end
 

--- a/spec/unit/request_pattern_spec.rb
+++ b/spec/unit/request_pattern_spec.rb
@@ -142,6 +142,12 @@ describe WebMock::RequestPattern do
       expect(WebMock::RequestPattern.new(:get, uri)).to match(signature)
     end
 
+    it "should match if Addressable::Template pattern that has ip address host without port matches request uri" do
+      signature = WebMock::RequestSignature.new(:get, "127.0.0.1/1234")
+      uri = Addressable::Template.new("127.0.0.1/{id}")
+      expect(WebMock::RequestPattern.new(:get, uri)).to match(signature)
+    end
+
     it "should match if Addressable::Template pattern host matches request uri" do
       signature = WebMock::RequestSignature.new(:get, "www.example.com")
       uri = Addressable::Template.new("{subdomain}.example.com")


### PR DESCRIPTION
## problem

It works with most cases without uri scheme, but it raises an error with some cases like 127.0.0.1.

I've found that it causes the error when `Capybara.server_host` is `0.0.0.0`.

## solution

The difference from https://github.com/bblimke/webmock/pull/758 is 

## issue

fixes: https://github.com/bblimke/webmock/issues/889

- delete invalid uri