### PR TITLE
HTTP/1.0 requires `Connection: keep-alive`

### DIFF
--- a/spec/acceptance/async_http_client/async_http_client_spec.rb
+++ b/spec/acceptance/async_http_client/async_http_client_spec.rb
@@ -170,7 +170,17 @@ unless RUBY_PLATFORM =~ /java/
         context 'HTTP10 protocol' do
           let(:protocol) { Async::HTTP::Protocol::HTTP10 }
 
-          include_examples :common
+          if RUBY_VERSION > '2.5.0'
+            specify do
+              expect(subject).to eq(
+                status: 200,
+                headers: { 'connection' => ['keep-alive'] },
+                body: 'BODY'
+              )
+            end
+          else
+            include_examples :common
+          end
         end
 
         context 'HTTP11 protocol' do
@@ -198,7 +208,17 @@ unless RUBY_PLATFORM =~ /java/
         context 'HTTP10 protocol' do
           let(:protocol) { Async::HTTP::Protocol::HTTP10 }
 
-          include_examples :common
+          if RUBY_VERSION > '2.5.0'
+            specify do
+              expect(subject).to eq(
+                status: 200,
+                headers: { 'connection' => ['keep-alive'] },
+                body: 'BODY'
+              )
+            end
+          else
+            include_examples :common
+          end
         end
 
         context 'HTTP11 protocol' do


### PR DESCRIPTION
## problem
In webmock rspec, `{:body=>"BODY", :headers=>{}, :status=>200}` is expected result. After async-http v0.52.1, expected result is `{:body=>"BODY", :headers=>{"connection"=>["keep-alive"]}, :status=>200}`.

## solution
async-http v0.52.1 requires Ruby version > 2.5.0. So, Add if statement like this.

```ruby
if RUBY_VERSION > '2.5.0'
  specify do
    expect(subject).to eq(
      status: 200,
      headers: { 'connection' => ['keep-alive'] },
      body: 'BODY'
    )
  end
else
  include_examples :common
end
```