### PR TITLE
Adjust `perform` override and call HTTP features wrapping request/res…

### DIFF
--- a/lib/webmock/http_lib_adapters/http_rb/client.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/client.rb
@@ -6,9 +6,7 @@ module HTTP
       return __perform__(request, options) unless webmock_enabled?
 
       response = WebMockPerform.new(request) { __perform__(request, options) }.exec
-      
       options.features.each { |_name, feature| response = feature.wrap_response(response) }
-      
       response
     end
 

--- a/lib/webmock/http_lib_adapters/http_rb/client.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/client.rb
@@ -4,7 +4,11 @@ module HTTP
 
     def perform(request, options)
       return __perform__(request, options) unless webmock_enabled?
-      WebMockPerform.new(request) { __perform__(request, options) }.exec
+       
+      response = options.features.inject(response) do |response, (_name, feature)|
+        feature.wrap_response(response)
+      end
+      response
     end
 
     def webmock_enabled?

--- a/lib/webmock/http_lib_adapters/http_rb/client.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/client.rb
@@ -5,6 +5,7 @@ module HTTP
     def perform(request, options)
       return __perform__(request, options) unless webmock_enabled?
        
+      response = WebMockPerform.new(request) { __perform__(request, options) }.exec
       response = options.features.inject(response) do |response, (_name, feature)|
         feature.wrap_response(response)
       end

--- a/lib/webmock/http_lib_adapters/http_rb/client.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/client.rb
@@ -6,9 +6,9 @@ module HTTP
       return __perform__(request, options) unless webmock_enabled?
 
       response = WebMockPerform.new(request) { __perform__(request, options) }.exec
-      response = options.features.inject(response) do |response, (_name, feature)|
-        feature.wrap_response(response)
-      end
+      
+      options.features.each { |_name, feature| response = feature.wrap_response(response) }
+      
       response
     end
 

--- a/lib/webmock/http_lib_adapters/http_rb/client.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/client.rb
@@ -4,7 +4,7 @@ module HTTP
 
     def perform(request, options)
       return __perform__(request, options) unless webmock_enabled?
-       
+
       response = WebMockPerform.new(request) { __perform__(request, options) }.exec
       response = options.features.inject(response) do |response, (_name, feature)|
         feature.wrap_response(response)


### PR DESCRIPTION
…ponse pairs.

The change helps reduce differences between mocking and not mocking to successfully test e.g. instrumentation which the `http` gem exposes through said features.

What it looks like in the `http` gem:

```rb
module HTTP
  # ...
  class Client
  # ...
    def perform
      # ...
      res = build_response(req, options)

      res = options.features.inject(res) do |response, (_name, feature)|
        feature.wrap_response(response)
      end
      # ...
    end
```

What it looks like in this gem:

```rb
module HTTP
  class Client
    alias_method :__perform__, :perform

    def perform(request, options)
      return __perform__(request, options) unless webmock_enabled?
      WebMockPerform.new(request) { __perform__(request, options) }.exec
    end

    def webmock_enabled?
      ::WebMock::HttpLibAdapters::HttpRbAdapter.enabled?
    end
  end
end
```

The code does not call the features middleware, which makes it hard to test e.g. instrumentations, as these are exposed as a feature middleware in the `http` gem.