### PR TITLE
Include documentation RegEx hash_including matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ stub_request(:post, "www.example.com").
 
 RestClient.post('www.example.com', "data[a]=1&data[b]=five&x=1",
 :content_type => 'application/x-www-form-urlencoded')    # ===> Success
+
+stub_request(:post, "www.example.com").
+  with(body: hash_including(id: /\d/))
+
+RestClient.post('www.example.com', "id=1",
+:content_type => 'application/x-www-form-urlencoded')    # ===> Success
 ```
 
 ### Matching custom request headers


### PR DESCRIPTION
I just learned about this really cool feature that you can match agains a RegEx in `hash_including` so I added some documentation for it.

```ruby
stub_request(:post, "www.example.com").
  with(body: hash_including(id: /\d/))

RestClient.post('www.example.com', "id=1",
:content_type => 'application/x-www-form-urlencoded')    # ===> Success
```