### PR TITLE
Fix async http adapter

### DIFF
--- a/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
+++ b/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
@@ -136,7 +136,7 @@ if defined?(Async::HTTP)
 
         def connect
           server_socket, client_socket = create_connected_sockets
-          Async do
+          Async(transient: true) do
             accept_socket(server_socket)
           end
           client_socket


### PR DESCRIPTION
Problem: the server in Async::HTTP::WebMockEndpoint#accept_socket was
hanging forever after the rspec example finished.
This is normal as Async::HTTP::Server (or any server) is never supposed
to end. It just continues waiting for new requests which, in this case,
never come.

Solution: use a 'transient' async task when starting a server.
Transient tasks do not block an exiting async reactor.
So, in this case a transient server will not hang forever.

Fixes #858 

@ioquatix we talked about making this a draft PR so we can continue talking about a proper webmock <-> async-http solution. Since this fix is minimal I propose going for a merge.
We can continue thinking about a better approach here https://github.com/socketry/async-http/issues/35