### PR TITLE
Fix async http adapter warning

### DIFF
--- a/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
+++ b/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
@@ -151,7 +151,7 @@ if defined?(Async::HTTP)
         def create_connected_sockets
           Async::IO::Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM).tap do |sockets|
             sockets.each do |socket|
-              socket.instance_variable_set :@alpn_protocol, @alpn_protocol
+              socket.instance_variable_set :@alpn_protocol, nil
               socket.instance_eval do
                 def alpn_protocol
                   nil # means HTTP11 will be used for HTTPS


### PR DESCRIPTION
Problem: when using async http adapter rspec outputs the following warning
`lib/webmock/http_lib_adapters/async_http_client_adapter.rb:154: warning: instance variable @alpn_protocol not initialized`
Reason for that is: `@alpn_protocol` is never defined.

Solution: don't use `@alpn_protocol`