### PR TITLE
Revert inversion of pattern check in URIPattern constructor

### DIFF
--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -109,11 +109,13 @@ module WebMock
     include RSpecMatcherDetector
 
     def initialize(pattern)
-      @pattern = case pattern
-      when String
-        WebMock::Util::URI.normalize_uri(pattern)
-      else
+      @pattern = if pattern.is_a?(Addressable::URI) \
+                    || pattern.is_a?(Addressable::Template)
         pattern
+      elsif pattern.respond_to?(:call)
+        pattern
+      else
+        WebMock::Util::URI.normalize_uri(pattern)
       end
       @query_params = nil
     end


### PR DESCRIPTION
Fixes #903.

This reinstates `WebMock::Util::URI.normalize_uri` as the default fallback behavior of the constructor, specifically whitelisting callable objects, in addition to the classes that were previously whitelisted, to pass through unchanged.

Also corrected descriptions of some existing specs that didn't match tested behavior.