### PR TITLE
Fix: Clarify exception message

### DIFF
--- a/lib/webmock/response.rb
+++ b/lib/webmock/response.rb
@@ -91,10 +91,10 @@ module WebMock
 
     def ==(other)
       self.body == other.body &&
-      self.headers === other.headers &&
-      self.status == other.status &&
-      self.exception == other.exception &&
-      self.should_timeout == other.should_timeout
+        self.headers === other.headers &&
+        self.status == other.status &&
+        self.exception == other.exception &&
+        self.should_timeout == other.should_timeout
     end
 
     private
@@ -111,7 +111,13 @@ module WebMock
       valid_types = [Proc, IO, Pathname, String, Array]
       return if @body.nil?
       return if valid_types.any? { |c| @body.is_a?(c) }
-      raise InvalidBody, "must be one of: #{valid_types}. '#{@body.class}' given"
+
+      if @body.class.is_a?(Hash)
+        raise InvalidBody, "must be one of: #{valid_types}, but you've used a #{@body.class}' instead." \
+          "\n What shall we encode it to? try calling .to_json .to_xml instead on the hash instead, or otherwise convert it to a string."
+      else
+        raise InvalidBody, "must be one of: #{valid_types}. '#{@body.class}' given"
+      end
     end
 
     def read_raw_response(raw_response)

--- a/spec/unit/response_spec.rb
+++ b/spec/unit/response_spec.rb
@@ -130,11 +130,15 @@ describe WebMock::Response do
     # Users of webmock commonly make the mistake of stubbing the response
     # body to return a hash, to prevent this:
     #
-    it "should error if not given one of the allowed types" do
+    it "should error if given a non-allowed type: a hash" do
       expect { WebMock::Response.new(body: Hash.new) }.to \
         raise_error(WebMock::Response::InvalidBody)
     end
 
+    it "should error if given a non-allowed type: something that is not a hash" do
+      expect { WebMock::Response.new(body: 123) }.to \
+        raise_error(WebMock::Response::InvalidBody)
+    end
   end
 
   describe "from raw response" do
@@ -152,12 +156,12 @@ describe WebMock::Response do
 
       it "should read headers" do
         expect(@response.headers).to eq({
-          "Date"=>"Sat, 23 Jan 2010 01:01:05 GMT",
-          "Content-Type"=>"text/html; charset=UTF-8",
-          "Content-Length"=>"419",
-          "Connection"=>"Keep-Alive",
-          "Accept"=>"image/jpeg, image/png"
-          })
+                                          "Date"=>"Sat, 23 Jan 2010 01:01:05 GMT",
+                                          "Content-Type"=>"text/html; charset=UTF-8",
+                                          "Content-Length"=>"419",
+                                          "Connection"=>"Keep-Alive",
+                                          "Accept"=>"image/jpeg, image/png"
+        })
       end
 
       it "should read body" do
@@ -182,12 +186,12 @@ describe WebMock::Response do
 
       it "should read headers" do
         expect(@response.headers).to eq({
-          "Date"=>"Sat, 23 Jan 2010 01:01:05 GMT",
-          "Content-Type"=>"text/html; charset=UTF-8",
-          "Content-Length"=>"419",
-          "Connection"=>"Keep-Alive",
-          "Accept"=>"image/jpeg, image/png"
-          })
+                                          "Date"=>"Sat, 23 Jan 2010 01:01:05 GMT",
+                                          "Content-Type"=>"text/html; charset=UTF-8",
+                                          "Content-Length"=>"419",
+                                          "Connection"=>"Keep-Alive",
+                                          "Accept"=>"image/jpeg, image/png"
+        })
       end
 
       it "should read body" do
@@ -234,11 +238,11 @@ describe WebMock::Response do
       it "should evaluate new response with evaluated options" do
         request_signature = WebMock::RequestSignature.new(:post, "www.example.com", body: "abc", headers: {'A' => 'a'})
         response = WebMock::DynamicResponse.new(lambda {|request|
-          {
-            body: request.body,
-            headers: request.headers,
-            status: 302
-          }
+                                                  {
+                                                    body: request.body,
+                                                    headers: request.headers,
+                                                    status: 302
+                                                  }
         })
         evaluated_response = response.evaluate(request_signature)
         expect(evaluated_response.body).to eq("abc")


### PR DESCRIPTION
# Why this PR?

Right now, users might be confused as to why a hash cannot be accepted
as a response body? See Issue #449 on Github as well as #427.

This seems to have caused considerable consternation
to API users - with some spending many frustrated hours searching for a
solution. Perhaps it can be solved with a more helpful exception
message? This PR hopes to remedy this apparent shortcoming. Perhaps
I shall remedy it with an update to the documentation as well.

I submit it with the utmost respect to the maintainers and community.

Thank you for your efforts, and for reviewing.

Ben