### PR TITLE
Option to invoke local stub before global stub

### DIFF
--- a/lib/webmock/webmock.rb
+++ b/lib/webmock/webmock.rb
@@ -140,8 +140,8 @@ module WebMock
     puts WebMock::RequestExecutionVerifier.executed_requests_message
   end
 
-  def self.globally_stub_request(&block)
-    WebMock::StubRegistry.instance.register_global_stub(&block)
+  def self.globally_stub_request(order = :before_local_stubs, &block)
+    WebMock::StubRegistry.instance.register_global_stub(order, &block)
   end
 
   %w(

--- a/spec/acceptance/shared/stubbing_requests.rb
+++ b/spec/acceptance/shared/stubbing_requests.rb
@@ -593,6 +593,23 @@ shared_examples_for "stubbing requests" do |*adapter_info|
           end
         end
       end
+
+      context "when global stub should be invoked last" do
+        before do
+          WebMock.globally_stub_request(:after_local_stubs) do
+            { body: "global stub body" }
+          end
+        end
+
+        it "uses global stub when non-global stub is not defined" do
+          expect(http_request(:get, "http://www.example.com/").body).to eq("global stub body")
+        end
+
+        it "uses non-global stub first" do
+          stub_request(:get, "www.example.com").to_return(body: 'non-global stub body')
+          expect(http_request(:get, "http://www.example.com/").body).to eq("non-global stub body")
+        end
+      end
     end
 
     describe "when stubbing request with a block evaluated on request" do


### PR DESCRIPTION
We have a similar problem as described in #171 in the project currently I'm working on. Since I did not found PR for this issue I created this one. 

By default, nothing is changed in the API but it is possible to give the `after_stubs` option while registering global stub. Then the global stub will be used only when no "local" stub is found.