### PR TITLE
Compatible with async-http 0.54+

### DIFF
--- a/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
+++ b/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
@@ -40,8 +40,8 @@ if defined?(Async::HTTP)
         )
           webmock_endpoint = WebMockEndpoint.new(scheme, authority, protocol)
 
-          @network_client = WebMockClient.new(endpoint, protocol, scheme, authority, **options)
-          @webmock_client = WebMockClient.new(webmock_endpoint, protocol, scheme, authority, **options)
+          @network_client = WebMockClient.new(endpoint, **options)
+          @webmock_client = WebMockClient.new(webmock_endpoint, **options)
 
           @scheme = scheme
           @authority = authority


### PR DESCRIPTION
`async-http` switch to keyword arguments: https://github.com/socketry/async-http/commit/3e967d4ff729bb4f02587d3e5784fd5cf4e37c26

because its signature

`def initialize(endpoint, protocol = endpoint.protocol, scheme = endpoint.scheme, authority = endpoint.authority, retries: DEFAULT_RETRIES, connection_limit: DEFAULT_CONNECTION_LIMIT)` 

`def initialize(endpoint, protocol: endpoint.protocol, scheme: endpoint.scheme, authority: endpoint.authority, retries: DEFAULT_RETRIES, connection_limit: DEFAULT_CONNECTION_LIMIT)`

This should be the easist way to keeping compatibility