### PR TITLE
Add WEBrick dependency

### DIFF
--- a/webmock.gemspec
+++ b/webmock.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest',        '>= 5.0.0'
   s.add_development_dependency 'test-unit',       '>= 3.0.0'
   s.add_development_dependency 'rdoc',            '>  3.5.0'
+  s.add_development_dependency 'webrick'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
This is required for Ruby 3.0, where the WEBrick was completely removed resulting in test failures such as:

~~~
$ bundle exec rake
/home/travis/.rvm/rubies/ruby-head/bin/ruby -I/home/travis/.rvm/gems/ruby-head/gems/rspec-core-3.10.1/lib:/home/travis/.rvm/gems/ruby-head/gems/rspec-support-3.10.1/lib /home/travis/.rvm/gems/ruby-head/gems/rspec-core-3.10.1/exe/rspec --pattern spec/\*\*/\*_spec.rb -c -f progress -r ./spec/spec_helper.rb
An error occurred while loading ./spec/spec_helper.rb. - Did you mean?
                    rspec ./spec/unit/response_spec.rb
Failure/Error: require 'webrick'
LoadError:
  cannot load such file -- webrick
# ./spec/support/webmock_server.rb:1:in `require'
# ./spec/support/webmock_server.rb:1:in `<top (required)>'
# ./spec/spec_helper.rb:20:in `require'
# ./spec/spec_helper.rb:20:in `<top (required)>'
No examples found.
~~~

Fixes #924