### PR TITLE
Async http adapter: only consider real requests to be real

### DIFF
--- a/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
+++ b/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
@@ -55,6 +55,7 @@ if defined?(Async::HTTP)
           WebMock::RequestRegistry.instance.requested_signatures.put(request_signature)
           webmock_response = WebMock::StubRegistry.instance.response_for_request(request_signature)
           net_connect_allowed = WebMock.net_connect_allowed?(request_signature.uri)
+          real_request = false
 
           if webmock_response
             webmock_response.raise_error_if_any
@@ -63,6 +64,7 @@ if defined?(Async::HTTP)
             response = @webmock_client.call(request)
           elsif net_connect_allowed
             response = @network_client.call(request)
+            real_request = true
           else
             raise WebMock::NetConnectNotAllowedError.new(request_signature) unless webmock_response
           end
@@ -72,7 +74,7 @@ if defined?(Async::HTTP)
             WebMock::CallbackRegistry.invoke_callbacks(
               {
                 lib: :async_http_client,
-                real_request: net_connect_allowed
+                real_request: real_request
               },
               request_signature,
               webmock_response

--- a/spec/acceptance/async_http_client/async_http_client_spec.rb
+++ b/spec/acceptance/async_http_client/async_http_client_spec.rb
@@ -135,6 +135,28 @@ unless RUBY_PLATFORM =~ /java/
       expect { make_request(:get, 'http://www.example.com') }.to raise_error Async::TimeoutError
     end
 
+    it 'does not invoke "after real request" callbacks for stubbed requests' do
+      WebMock.allow_net_connect!
+      stub_request(:get, 'http://www.example.com').to_return(body: 'abc')
+
+      callback_invoked = false
+      WebMock.after_request(real_requests_only: true) { |_| callback_invoked = true }
+
+      make_request(:get, 'http://www.example.com')
+      expect(callback_invoked).to eq(false)
+    end
+
+    it 'does invoke "after request" callbacks for stubbed requests' do
+      WebMock.allow_net_connect!
+      stub_request(:get, 'http://www.example.com').to_return(body: 'abc')
+
+      callback_invoked = false
+      WebMock.after_request(real_requests_only: false) { |_| callback_invoked = true }
+
+      make_request(:get, 'http://www.example.com')
+      expect(callback_invoked).to eq(true)
+    end
+
     context 'scheme and protocol' do
       let(:default_response_headers) { {} }
 


### PR DESCRIPTION
This was causing an issue in VCR, as callbacks were always firing because net connect was enabled. In this case, continuously appending recorded cassettes.

A stubbed request is not a real request, and therefore shouldn’t fire callbacks that are only meant for real requests.

Note this was made in collaboration with the fix identified by @ioquatix in #930