### PR TITLE
Add httpx as supported http client

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Supported HTTP libraries
   * RightHttpConnection
 * Patron
 * Typhoeus (currently only Typhoeus::Hydra)
+* [httpx](https://honeyryderchuck.gitlab.io/httpx/wiki/Webmock-Adapter) 
 
 Supported Ruby Interpreters
 ---------------------------


### PR DESCRIPTION
Adding httpx as one of the http clients supporting webmock, with a link for the setup, given that the adapter is self-owned.