### PR TITLE
Fix: Handle IPv6 hostname correctly (closes #806)

### DIFF
--- a/spec/acceptance/net_http/net_http_spec.rb
+++ b/spec/acceptance/net_http/net_http_spec.rb
@@ -340,4 +340,30 @@ describe "Net:HTTP" do
       http.request(req, '')
     end
   end
+
+  describe "hostname handling" do
+    it "should set brackets around the hostname if it is an IPv6 address" do
+      net_http = Net::HTTP.new('b2dc:5bdf:4f0d::3014:e0ca', 80)
+      path = '/example.jpg'
+      expect(WebMock::NetHTTPUtility.get_uri(net_http, path)).to eq('http://[b2dc:5bdf:4f0d::3014:e0ca]:80/example.jpg')
+    end
+
+    it "should not set brackets around the hostname if it is already wrapped by brackets" do
+      net_http = Net::HTTP.new('[b2dc:5bdf:4f0d::3014:e0ca]', 80)
+      path = '/example.jpg'
+      expect(WebMock::NetHTTPUtility.get_uri(net_http, path)).to eq('http://[b2dc:5bdf:4f0d::3014:e0ca]:80/example.jpg')
+    end
+
+    it "should not set brackets around the hostname if it is an IPv4 address" do
+      net_http = Net::HTTP.new('181.152.137.168', 80)
+      path = '/example.jpg'
+      expect(WebMock::NetHTTPUtility.get_uri(net_http, path)).to eq('http://181.152.137.168:80/example.jpg')
+    end
+
+    it "should not set brackets around the hostname if it is a domain" do
+      net_http = Net::HTTP.new('www.example.com', 80)
+      path = '/example.jpg'
+      expect(WebMock::NetHTTPUtility.get_uri(net_http, path)).to eq('http://www.example.com:80/example.jpg')
+    end
+  end
 end

--- a/spec/acceptance/net_http/net_http_spec.rb
+++ b/spec/acceptance/net_http/net_http_spec.rb
@@ -365,5 +365,21 @@ describe "Net:HTTP" do
       path = '/example.jpg'
       expect(WebMock::NetHTTPUtility.get_uri(net_http, path)).to eq('http://www.example.com:80/example.jpg')
     end
+
+    it 'should work with IPv6 addresses' do
+      WebMock.stub_request(:get, 'http://[b2dc:5bdf:4f0d::3014:e0c1]:80/example.jpg')
+      uri = URI.parse('http://[b2dc:5bdf:4f0d::3014:e0c1]:80/example.jpg')
+      request = Net::HTTP::Get.new(uri)
+
+      expect { Net::HTTP.start(uri.hostname, uri.port) { |http| http.request(request) } }.not_to raise_error
+    end
+
+    it 'should work with IPv4 addresses' do
+      WebMock.stub_request(:get, 'http://181.152.137.168:80/example.jpg')
+      uri = URI.parse('http://181.152.137.168:80/example.jpg')
+      request = Net::HTTP::Get.new(uri)
+
+      expect { Net::HTTP.start(uri.hostname, uri.port) { |http| http.request(request) } }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
Wrapped the hostname in brackets to separate it from the port, when it is an IPv6 address.
It is an attempt to fix the issue #806.

Is the `net_http_spec.rb` the right place for the added specs or should I rather put them into a new file `net_http_utility_spec.rb`?