### PR TITLE
Support http.rb 5.x

### DIFF
--- a/lib/webmock/http_lib_adapters/http_rb/response.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/response.rb
@@ -11,7 +11,7 @@ module HTTP
     end
 
     class << self
-      def from_webmock(webmock_response, request_signature = nil)
+      def from_webmock(request, webmock_response, request_signature = nil)
         status  = Status.new(webmock_response.status.first)
         headers = webmock_response.headers || {}
         uri     = normalize_uri(request_signature && request_signature.uri)
@@ -29,12 +29,23 @@ module HTTP
 
         return new(status, "1.1", headers, body, uri) if HTTP::VERSION < "1.0.0"
 
+        # 5.0.0 had a breaking change to require request instead of uri.
+        if HTTP::VERSION < '5.0.0'
+          return new({
+            status: status,
+            version: "1.1",
+            headers: headers,
+            body: body,
+            uri: uri
+          })
+        end
+
         new({
           status: status,
           version: "1.1",
           headers: headers,
           body: body,
-          uri: uri
+          request: request,
         })
       end
 

--- a/lib/webmock/http_lib_adapters/http_rb/webmock.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/webmock.rb
@@ -38,7 +38,7 @@ module HTTP
       webmock_response.raise_error_if_any
 
       invoke_callbacks(webmock_response, real_request: false)
-      ::HTTP::Response.from_webmock webmock_response, request_signature
+      ::HTTP::Response.from_webmock @request, webmock_response, request_signature
     end
 
     def raise_timeout_error


### PR DESCRIPTION
5.0.0 had a breaking change.

Fixes #940

I'm not completely sure this is the right fix, but my tests work now with both 4.4.1 and 5.0.0 of `http`.