### PR TITLE
fix async adapter on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+  * fixed async-http adapter on Windows
+
 # 3.14.0
 
   * Bump Addressable from 2.3.6 to 2.8.0

--- a/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
+++ b/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
@@ -151,7 +151,12 @@ if defined?(Async::HTTP)
         private
 
         def create_connected_sockets
-          Async::IO::Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM).tap do |sockets|
+          pair = begin
+            Async::IO::Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM)
+          rescue Errno::EAFNOSUPPORT
+            Async::IO::Socket.pair(Socket::AF_INET, Socket::SOCK_STREAM)
+          end
+          pair.tap do |sockets|
             sockets.each do |socket|
               socket.instance_variable_set :@alpn_protocol, nil
               socket.instance_eval do


### PR DESCRIPTION
even if Socket::AF_UNIX is defined on Windows, it cannot be used, so let's use Socket::AF_INET as a fallback