### PR TITLE
Bump Addressable from 2.3.6 to 2.8.0

### DIFF
--- a/webmock.gemspec
+++ b/webmock.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency 'addressable', '>= 2.3.6'
+  s.add_dependency 'addressable', '>= 2.8.0'
   s.add_dependency 'crack', '>= 0.3.2'
   s.add_dependency 'hashdiff', ['>= 0.4.0', '< 2.0.0']
 


### PR DESCRIPTION
This version fixes a ReDoS vulnerability in `Addressable::Template#match`

For more information about the issue:
- https://app.snyk.io/vuln/SNYK-RUBY-ADDRESSABLE-1316242

From addressable [CHANGELOG](https://github.com/sporkmonger/addressable/blob/main/CHANGELOG.md), it seems to not have breaking changes, and just ran the test-suite passed in my local without failures ✅ 