### PR TITLE
Change `blacklist` to `denylist` in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -607,9 +607,9 @@
   * `WebMock.disable_net_connect` accepts `:allow` option with an object that responds to `#call`, receiving a `URI` object and returning a boolean:
 
 
-        blacklist = ['google.com', 'facebook.com', 'apple.com']
+        denylist = ['google.com', 'facebook.com', 'apple.com']
         allowed_sites = lambda{|uri|
-          blacklist.none?{|site| uri.host.include?(site) }
+          denylist.none?{|site| uri.host.include?(site) }
         }
         WebMock.disable_net_connect!(:allow => allowed_sites)
 

--- a/README.md
+++ b/README.md
@@ -550,9 +550,9 @@ RestClient.get('sample.org', '/bar')          # ===> Failure
 With an object that responds to `#call`, receiving a `URI` object and returning a boolean:
 
 ```ruby
-blacklist = ['google.com', 'facebook.com', 'apple.com']
+denylist = ['google.com', 'facebook.com', 'apple.com']
 allowed_sites = lambda{|uri|
-  blacklist.none?{|site| uri.host.include?(site) }
+  denylist.none?{|site| uri.host.include?(site) }
 }
 WebMock.disable_net_connect!(allow: allowed_sites)
 


### PR DESCRIPTION
This updates documentation to use the more inclusive `denylist` verbiage instead of `blacklist`.