### PR TITLE
Add RequestStub#to_return_json

### DIFF
--- a/lib/webmock/request_stub.rb
+++ b/lib/webmock/request_stub.rb
@@ -24,6 +24,21 @@ module WebMock
     end
     alias_method :and_return, :to_return
 
+    def to_return_json(*response_hashes)
+      raise ArgumentError, '#to_return_json does not support passing a block' if block_given?
+
+      json_response_hashes = [*response_hashes].flatten.map do |resp_h|
+        headers, body = resp_h.values_at(:headers, :body)
+        resp_h.merge(
+          headers: headers.to_h.merge(content_type: 'application/json'),
+          body: body.is_a?(Hash) ? body.to_json : body
+        )
+      end
+
+      to_return(json_response_hashes)
+    end
+    alias_method :and_return_json, :to_return_json
+
     def to_rack(app, options={})
       @responses_sequences << ResponsesSequence.new([RackResponse.new(app)])
     end

--- a/lib/webmock/request_stub.rb
+++ b/lib/webmock/request_stub.rb
@@ -30,7 +30,7 @@ module WebMock
       json_response_hashes = [*response_hashes].flatten.map do |resp_h|
         headers, body = resp_h.values_at(:headers, :body)
         resp_h.merge(
-          headers: headers.to_h.merge(content_type: 'application/json'),
+          headers: {content_type: 'application/json'}.merge(headers.to_h),
           body: body.is_a?(Hash) ? body.to_json : body
         )
       end

--- a/spec/unit/request_stub_spec.rb
+++ b/spec/unit/request_stub_spec.rb
@@ -50,6 +50,36 @@ describe WebMock::RequestStub do
 
   end
 
+  describe "to_return_json" do
+
+    it "should raise if a block is given" do
+      expect {
+        @request_stub.to_return_json(body: "abc", status: 500) { puts "don't call me" }
+      }.to raise_error(ArgumentError, '#to_return_json does not support passing a block')
+    end
+
+    it "should assign responses normally" do
+      @request_stub.to_return_json([{body: "abc"}, {body: "def"}])
+      expect([@request_stub.response.body, @request_stub.response.body]).to eq(["abc", "def"])
+    end
+
+    it "should json-ify a Hash body" do
+      @request_stub.to_return_json(body: {abc: "def"}, status: 500)
+      expect(@request_stub.response.body).to eq({abc: "def"}.to_json)
+      expect(@request_stub.response.status).to eq([500, ""])
+    end
+
+    it "should apply the content_type header" do
+      @request_stub.to_return_json(body: {abc: "def"}, status: 500)
+      expect(@request_stub.response.headers).to eq({"Content-Type"=>"application/json"})
+    end
+
+    it "should preserve existing headers" do
+      @request_stub.to_return_json(headers: {"A" => "a"}, body: "")
+      expect(@request_stub.response.headers).to eq({"A"=>"a", "Content-Type"=>"application/json"})
+    end
+  end
+
   describe "then" do
     it "should return stub without any modifications, acting as syntactic sugar" do
       expect(@request_stub.then).to eq(@request_stub)

--- a/spec/unit/request_stub_spec.rb
+++ b/spec/unit/request_stub_spec.rb
@@ -78,6 +78,11 @@ describe WebMock::RequestStub do
       @request_stub.to_return_json(headers: {"A" => "a"}, body: "")
       expect(@request_stub.response.headers).to eq({"A"=>"a", "Content-Type"=>"application/json"})
     end
+
+    it "should allow callsites to override content_type header" do
+      @request_stub.to_return_json(headers: {content_type: 'application/super-special-json'})
+      expect(@request_stub.response.headers).to eq({"Content-Type"=>"application/super-special-json"})
+    end
   end
 
   describe "then" do


### PR DESCRIPTION
Make stubbing out json responses a little bit more convenient by

1) JSON-ifying Hash bodies
2) applying the Content-Type: application/json header

Some relevant discussion in #449 
