### PR TITLE
Prevent double-wrapping http.rb features on non-stubbed requests

### DIFF
--- a/lib/webmock/http_lib_adapters/http_rb/client.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/client.rb
@@ -5,9 +5,7 @@ module HTTP
     def perform(request, options)
       return __perform__(request, options) unless webmock_enabled?
 
-      response = WebMockPerform.new(request) { __perform__(request, options) }.exec
-      options.features.each { |_name, feature| response = feature.wrap_response(response) }
-      response
+      WebMockPerform.new(request, options) { __perform__(request, options) }.exec
     end
 
     def webmock_enabled?

--- a/lib/webmock/http_lib_adapters/http_rb/webmock.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/webmock.rb
@@ -1,7 +1,8 @@
 module HTTP
   class WebMockPerform
-    def initialize(request, &perform)
+    def initialize(request, options, &perform)
       @request = request
+      @options = options
       @perform = perform
       @request_signature = nil
     end
@@ -38,7 +39,10 @@ module HTTP
       webmock_response.raise_error_if_any
 
       invoke_callbacks(webmock_response, real_request: false)
-      ::HTTP::Response.from_webmock @request, webmock_response, request_signature
+      response = ::HTTP::Response.from_webmock @request, webmock_response, request_signature
+
+      @options.features.each { |_name, feature| response = feature.wrap_response(response) }
+      response
     end
 
     def raise_timeout_error


### PR DESCRIPTION
Fixes the bug mentioned in https://github.com/bblimke/webmock/pull/896#issuecomment-758270719