### PR TITLE
Start connection in `Net::HTTP` adapter for mocked requests

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -77,6 +77,8 @@ module WebMock
           WebMock::RequestRegistry.instance.requested_signatures.put(request_signature)
 
           if webmock_response = WebMock::StubRegistry.instance.response_for_request(request_signature)
+            return start_without_connect { request(request, body, &block) } unless started?
+
             @socket = Net::HTTP.socket_type.new
             WebMock::CallbackRegistry.invoke_callbacks(
               {lib: :net_http}, request_signature, webmock_response)

--- a/spec/acceptance/net_http/net_http_spec.rb
+++ b/spec/acceptance/net_http/net_http_spec.rb
@@ -213,6 +213,24 @@ describe "Net:HTTP" do
     end
   end
 
+  it "should start mocked Net::HTTP" do
+    uri = URI.parse('http://www.example.com/')
+    stub_http_request(:get, uri).to_return(body: "the body")
+
+    http = Net::HTTP.new(uri.host)
+    req = Net::HTTP::Get.new('/')
+    expected_started = [false, true]
+
+    expect(http).to receive(:request).twice.and_wrap_original do |m, *args, &block|
+      expect(expected_started.shift).to equal(m.receiver.started?)
+      m.call(*args, &block)
+    end
+
+    response = http.request(req)
+
+    expect(response.body).to eq("the body")
+  end
+
   describe "connecting on Net::HTTP.start" do
     before(:each) do
       @http = Net::HTTP.new('www.google.com', 443)


### PR DESCRIPTION
Instrumentation like Sentry only instruments requests when
`Net::HTTP.started?` because `#request` is called twice if connection
is not started yet. This change allows this instrumentation to work
with mocked requests.

See https://github.com/ruby/net-http/blob/master/lib/net/http.rb#L1529-L1534