### PR TITLE
Keep underscores when normalizing headers

### DIFF
--- a/lib/webmock/util/headers.rb
+++ b/lib/webmock/util/headers.rb
@@ -9,7 +9,8 @@ module WebMock
       def self.normalize_headers(headers)
         return nil unless headers
         array = headers.map { |name, value|
-          [name.to_s.split(/_|-/).map { |segment| segment.capitalize }.join("-"),
+          name = name.to_s.tr("_", "-") if name.is_a? Symbol
+          [name.to_s.split(/(_|-)/).map { |segment| segment.capitalize }.join,
            case value
             when Regexp then value
             when Array then (value.size == 1) ? value.first.to_s : value.map {|v| v.to_s}.sort

--- a/spec/unit/request_pattern_spec.rb
+++ b/spec/unit/request_pattern_spec.rb
@@ -684,9 +684,9 @@ describe WebMock::RequestPattern do
         not_to match(WebMock::RequestSignature.new(:get, "www.example.com", headers: {'Content-Type' => 'image/jpeg'}))
     end
 
-    it "should match even is header keys are declared in different form" do
-      expect(WebMock::RequestPattern.new(:get, "www.example.com", headers: {'ContentLength' => '8888', 'Content-type' => 'image/png'})).
-        to match(WebMock::RequestSignature.new(:get, "www.example.com", headers: {:ContentLength => 8888, 'content_type' => 'image/png'}))
+    it "should match even if header keys are declared in different form" do
+      expect(WebMock::RequestPattern.new(:get, "www.example.com", headers: {'ContentLength' => '8888', 'Content-Type' => 'image/png'})).
+        to match(WebMock::RequestSignature.new(:get, "www.example.com", headers: {:ContentLength => 8888, 'content-type' => 'image/png'}))
     end
 
     it "should match is pattern doesn't have specified headers" do

--- a/spec/unit/util/headers_spec.rb
+++ b/spec/unit/util/headers_spec.rb
@@ -25,4 +25,20 @@ describe WebMock::Util::Headers do
 
   end
 
+  describe ".normalize_headers" do
+    it "normalizes capitalization for string header names" do
+      expect(described_class.normalize_headers({ "foo-BAR-bAz" => "qUx" }))
+        .to eq({ "Foo-Bar-Baz" => "qUx" })
+    end
+
+    it "stringifies and dasherizes symbol header names" do
+      expect(described_class.normalize_headers({ foo_bar: "qUx" }))
+        .to eq({ "Foo-Bar" => "qUx" })
+    end
+
+    it "respects choice of underscores for string header names" do
+      expect(described_class.normalize_headers({ "foo-BAR_bAz" => "qUx" }))
+        .to eq({ "Foo-Bar_Baz" => "qUx" })
+    end
+  end
 end


### PR DESCRIPTION
Some servers distinguish underscores from dashes in request headers. To allow users to test that the correct character is used, checking the sent headers should make the same distinction.

With this change, webmock no longer normalizes underscores to dashes for headers defined using strings.

Since symbols are commonly used with underscores to specify headers that use dashes, headers specified with symbol keys are still normalized to dashes.

Fixes #474.
