### PR TITLE
Make CI green again

### DIFF
--- a/lib/webmock/http_lib_adapters/http_rb/response.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/response.rb
@@ -24,7 +24,10 @@ module HTTP
         elsif HTTP::VERSION < "3.0.0"
           Body.new(Streamer.new(webmock_response.body), webmock_response.body.encoding)
         else
-          Body.new(Streamer.new(webmock_response.body), encoding: webmock_response.body.encoding)
+          Body.new(
+            Streamer.new(webmock_response.body, encoding: webmock_response.body.encoding),
+            encoding: webmock_response.body.encoding
+          )
         end
 
         return new(status, "1.1", headers, body, uri) if HTTP::VERSION < "1.0.0"

--- a/lib/webmock/http_lib_adapters/http_rb/streamer.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/streamer.rb
@@ -1,8 +1,9 @@
 module HTTP
   class Response
     class Streamer
-      def initialize(str)
+      def initialize(str, encoding: Encoding::BINARY)
         @io = StringIO.new str
+        @encoding = encoding
       end
 
       def readpartial(size = nil, outbuf = nil)
@@ -14,7 +15,8 @@ module HTTP
           end
         end
 
-        @io.read size, outbuf
+        chunk = @io.read size, outbuf
+        chunk.force_encoding(@encoding) if chunk
       end
 
       def close

--- a/spec/acceptance/async_http_client/async_http_client_spec.rb
+++ b/spec/acceptance/async_http_client/async_http_client_spec.rb
@@ -248,7 +248,7 @@ unless RUBY_PLATFORM =~ /java/
     end
 
     context 'multiple requests' do
-      let(:endpoint) { Async::HTTP::Endpoint.parse('http://www.example.com') }
+      let!(:endpoint) { Async::HTTP::Endpoint.parse('http://www.example.com') }
       let(:requests_count) { 3 }
 
       shared_examples :common do
@@ -300,13 +300,13 @@ unless RUBY_PLATFORM =~ /java/
         end
 
         context 'HTTP1 protocol' do
-          let(:protocol) { Async::HTTP::Protocol::HTTP1 }
+          let!(:protocol) { Async::HTTP::Protocol::HTTP1 }
 
           include_examples :common
         end
 
         context 'HTTP2 protocol' do
-          let(:protocol) { Async::HTTP::Protocol::HTTP2 }
+          let!(:protocol) { Async::HTTP::Protocol::HTTP2 }
 
           include_examples :common
         end
@@ -331,13 +331,13 @@ unless RUBY_PLATFORM =~ /java/
         end
 
         context 'HTTP1 protocol' do
-          let(:protocol) { Async::HTTP::Protocol::HTTP1 }
+          let!(:protocol) { Async::HTTP::Protocol::HTTP1 }
 
           include_examples :common
         end
 
         context 'HTTP2 protocol' do
-          let(:protocol) { Async::HTTP::Protocol::HTTP2 }
+          let!(:protocol) { Async::HTTP::Protocol::HTTP2 }
 
           include_examples :common
         end

--- a/spec/acceptance/excon/excon_spec.rb
+++ b/spec/acceptance/excon/excon_spec.rb
@@ -20,7 +20,7 @@ describe "Excon" do
     it "should support excon response_block for real requests", net_connect: true do
       a = []
       WebMock.allow_net_connect!
-      r = Excon.new('http://httpstat.us/200', headers: { "Accept" => "*" }).
+      r = Excon.new('https://httpstat.us/200', headers: { "Accept" => "*" }).
         get(response_block: lambda {|e, remaining, total| a << e}, chunk_size: 1)
       expect(a).to eq(["2", "0", "0", " ", "O", "K"])
       expect(r.body).to eq("")
@@ -41,7 +41,7 @@ describe "Excon" do
       WebMock.after_request { |_, res|
         response = res
       }
-      r = Excon.new('http://httpstat.us/200', headers: { "Accept" => "*" }).
+      r = Excon.new('https://httpstat.us/200', headers: { "Accept" => "*" }).
         get(response_block: lambda {|e, remaining, total| a << e}, chunk_size: 1)
       expect(response.body).to eq("200 OK")
       expect(a).to eq(["2", "0", "0", " ", "O", "K"])

--- a/spec/acceptance/shared/allowing_and_disabling_net_connect.rb
+++ b/spec/acceptance/shared/allowing_and_disabling_net_connect.rb
@@ -91,7 +91,7 @@ shared_context "allowing and disabling net connect" do |*adapter_info|
     describe "is not allowed, with exceptions" do
       describe "allowing by host string" do
         before :each do
-          WebMock.disable_net_connect!(allow: 'httpstat.us')
+          WebMock.disable_net_connect!(allow: 'https://httpstat.us')
         end
 
         context "when the host is not allowed" do
@@ -109,13 +109,13 @@ shared_context "allowing and disabling net connect" do |*adapter_info|
 
         context "when the host is allowed" do
           it "should return stubbed response if request was stubbed" do
-            stub_request(:get, 'httpstat.us/200').to_return(body: "abc")
-            expect(http_request(:get, "http://httpstat.us/200").body).to eq("abc")
+            stub_request(:get, 'https://httpstat.us/200').to_return(body: "abc")
+            expect(http_request(:get, "https://httpstat.us/200").body).to eq("abc")
           end
 
           # WARNING: this makes a real HTTP request!
           it "should make a real request to allowed host", net_connect: true do
-            expect(http_request(:get, "http://httpstat.us/200").status).to eq('200')
+            expect(http_request(:get, "https://httpstat.us/200").status).to eq('200')
           end
         end
       end
@@ -229,13 +229,13 @@ shared_context "allowing and disabling net connect" do |*adapter_info|
 
         context "when the host is allowed" do
           it "should return stubbed response if request was stubbed" do
-            stub_request(:get, 'httpstat.us/200').to_return(body: "abc")
-            expect(http_request(:get, "http://httpstat.us/200").body).to eq("abc")
+            stub_request(:get, 'https://httpstat.us/200').to_return(body: "abc")
+            expect(http_request(:get, "https://httpstat.us/200").body).to eq("abc")
           end
 
           # WARNING: this makes a real HTTP request!
           it "should make a real request to allowed host", net_connect: true do
-            expect(http_request(:get, "http://httpstat.us/200").status).to eq('200')
+            expect(http_request(:get, "https://httpstat.us/200").status).to eq('200')
           end
 
           it "should make a real request if request is allowed by path regexp and url contains default port", net_connect: true do
@@ -266,20 +266,20 @@ shared_context "allowing and disabling net connect" do |*adapter_info|
 
         context "when the host is allowed" do
           it "should return stubbed response if request was stubbed" do
-            stub_request(:get, 'httpstat.us/200').to_return(body: "abc")
-            expect(http_request(:get, "http://httpstat.us/200").body).to eq("abc")
+            stub_request(:get, 'https://httpstat.us/200').to_return(body: "abc")
+            expect(http_request(:get, "https://httpstat.us/200").body).to eq("abc")
           end
 
           # WARNING: this makes a real HTTP request!
           it "should make a real request to allowed host", net_connect: true do
-            expect(http_request(:get, "http://httpstat.us/200").status).to eq('200')
+            expect(http_request(:get, "https://httpstat.us/200").status).to eq('200')
           end
         end
       end
 
       describe "allowing by a list of the above" do
         before :each do
-          WebMock.disable_net_connect!(allow: [lambda{|_| false }, %r{foobar}, 'httpstat.us'])
+          WebMock.disable_net_connect!(allow: [lambda{|_| false }, %r{foobar}, 'https://httpstat.us'])
         end
 
         context "when the host is not allowed" do
@@ -297,13 +297,13 @@ shared_context "allowing and disabling net connect" do |*adapter_info|
 
         context "when the host is allowed" do
           it "should return stubbed response if request was stubbed" do
-            stub_request(:get, 'httpstat.us/200').to_return(body: "abc")
-            expect(http_request(:get, "http://httpstat.us/200").body).to eq("abc")
+            stub_request(:get, 'https://httpstat.us/200').to_return(body: "abc")
+            expect(http_request(:get, "https://httpstat.us/200").body).to eq("abc")
           end
 
           # WARNING: this makes a real HTTP request!
           it "should make a real request to allowed host", net_connect: true do
-            expect(http_request(:get, "http://httpstat.us/200").status).to eq('200')
+            expect(http_request(:get, "https://httpstat.us/200").status).to eq('200')
           end
         end
       end

--- a/spec/acceptance/shared/callbacks.rb
+++ b/spec/acceptance/shared/callbacks.rb
@@ -102,7 +102,7 @@ shared_context "callbacks" do |*adapter_info|
           WebMock.after_request(except: [:other_lib])  do |_, response|
             @response = response
           end
-          http_request(:get, "http://httpstat.us/201", headers: { "Accept" => "*" })
+          http_request(:get, "https://httpstat.us/201", headers: { "Accept" => "*" })
         end
 
         it "should pass real response to callback with status and message" do
@@ -111,7 +111,7 @@ shared_context "callbacks" do |*adapter_info|
         end
 
         it "should pass real response to callback with headers" do
-          expect(@response.headers["X-Powered-By"]).to eq( "ASP.NET")
+          expect(@response.headers["Server"]).to eq( "Kestrel")
           expect(@response.headers["Content-Length"]).to eq("11") unless adapter_info.include?(:no_content_length_header)
         end
 

--- a/spec/acceptance/shared/complex_cross_concern_behaviors.rb
+++ b/spec/acceptance/shared/complex_cross_concern_behaviors.rb
@@ -18,7 +18,7 @@ shared_context "complex cross-concern behaviors" do |*adapter_info|
     expect(played_back_response).to eq(real_response)
   end
 
-  let(:no_content_url) { 'http://httpstat.us/204' }
+  let(:no_content_url) { 'https://httpstat.us/204' }
   [nil, ''].each do |stub_val|
     it "returns the same value (nil or "") for a request stubbed as #{stub_val.inspect} that a real empty response has", net_connect: true do
       unless http_library == :curb

--- a/spec/unit/request_signature_spec.rb
+++ b/spec/unit/request_signature_spec.rb
@@ -18,7 +18,7 @@ describe WebMock::RequestSignature do
     end
 
     it "assigns normalized headers" do
-      expect(WebMock::Util::Headers).to receive(:normalize_headers).with('A' => 'a').and_return('B' => 'b')
+      allow(WebMock::Util::Headers).to receive(:normalize_headers).with({'A' => 'a'}.freeze).and_return('B' => 'b')
       expect(
         WebMock::RequestSignature.new(:get, "www.example.com", headers: {'A' => 'a'}).headers
       ).to eq({'B' => 'b'})

--- a/spec/unit/response_spec.rb
+++ b/spec/unit/response_spec.rb
@@ -31,7 +31,7 @@ describe WebMock::Response do
   end
 
   it "should report normalized headers" do
-    expect(WebMock::Util::Headers).to receive(:normalize_headers).with('A' => 'a').and_return('B' => 'b')
+    allow(WebMock::Util::Headers).to receive(:normalize_headers).with({'A' => 'a'}.freeze).and_return('B' => 'b')
     @response = WebMock::Response.new(headers: {'A' => 'a'})
     expect(@response.headers).to eq({'B' => 'b'})
   end


### PR DESCRIPTION
httpstat.us switched to HTTPS and returning 301 for plain HTTP and now
there is no `X-Powered-By` header, use HTTPS + `Server` header instead.

`http.rb` >= 5.0.2 expects stream result to be in the proper encoding after https://github.com/httprb/http/pull/653, force encoding in `Streamer`.