### PR TITLE
Limit the number of splits when parsing headers in the Curb adapter

### DIFF
--- a/lib/webmock/http_lib_adapters/curb_adapter.rb
+++ b/lib/webmock/http_lib_adapters/curb_adapter.rb
@@ -128,7 +128,7 @@ if defined?(Curl)
       def headers_as_hash(headers)
         if headers.is_a?(Array)
           headers.inject({}) {|hash, header|
-            name, value = header.split(":").map(&:strip)
+            name, value = header.split(":", 2).map(&:strip)
             hash[name] = value
             hash
           }

--- a/spec/acceptance/curb/curb_spec.rb
+++ b/spec/acceptance/curb/curb_spec.rb
@@ -383,6 +383,17 @@ unless RUBY_PLATFORM =~ /java/
         expect(c.body).to eq("abc")
       end
 
+      it "supports headers containing the ':' character" do
+        stub_request(:get, "www.example.com").with(headers: {'Referer'=>'http://www.example.com'}).to_return(body: "abc")
+
+        c = Curl::Easy.new
+        c.url = "http://www.example.com"
+        c.headers = ["Referer: http://www.example.com"]
+        c.http(:GET)
+        expect(c.body).to eq("abc")
+        expect(c.headers).to eq(["Referer: http://www.example.com"])
+      end
+
       describe 'match request body' do
         it 'for post' do
           stub_request(:post, "www.example.com").with(body: 'foo=nhe').to_return(body: "abc")


### PR DESCRIPTION
When using headers that contain more than one ":" character the resulting stubbed request will only contain a portion of the original header. This change will prevent the header from being split in more than 2 pieces.

Fixes: [#946 ](https://github.com/bblimke/webmock/issues/946)