### PR TITLE
Allow content type headers to specify a charset

### DIFF
--- a/lib/webmock/request_signature.rb
+++ b/lib/webmock/request_signature.rb
@@ -35,11 +35,11 @@ module WebMock
     alias == eql?
 
     def url_encoded?
-      !!(headers && headers['Content-Type'] == 'application/x-www-form-urlencoded')
+      !!(headers&.fetch('Content-Type', nil)&.start_with?('application/x-www-form-urlencoded'))
     end
 
     def json_headers?
-      !!(headers && headers['Content-Type'] == 'application/json')
+      !!(headers&.fetch('Content-Type', nil)&.start_with?('application/json'))
     end
 
     private

--- a/spec/unit/request_signature_spec.rb
+++ b/spec/unit/request_signature_spec.rb
@@ -125,8 +125,18 @@ describe WebMock::RequestSignature do
       expect(subject.url_encoded?).to be true
     end
 
+    it "returns true if the headers are urlencoded with a specified charset" do
+      subject.headers = { "Content-Type" => "application/x-www-form-urlencoded; charset=UTF-8" }
+      expect(subject.url_encoded?).to be true
+    end
+
     it "returns false if the headers are NOT urlencoded" do
       subject.headers = { "Content-Type" => "application/made-up-format" }
+      expect(subject.url_encoded?).to be false
+    end
+
+    it "returns false when no content type header is present" do
+      subject.headers = { "Some-Header" => "some-value" }
       expect(subject.url_encoded?).to be false
     end
 
@@ -142,8 +152,18 @@ describe WebMock::RequestSignature do
       expect(subject.json_headers?).to be true
     end
 
+    it "returns true if the headers are json with a specified charset" do
+      subject.headers = { "Content-Type" => "application/json; charset=UTF-8" }
+      expect(subject.json_headers?).to be true
+    end
+
     it "returns false if the headers are NOT json" do
       subject.headers = { "Content-Type" => "application/made-up-format" }
+      expect(subject.json_headers?).to be false
+    end
+
+    it "returns false when no content type header is present" do
+      subject.headers = { "Some-Header" => "some-value" }
       expect(subject.json_headers?).to be false
     end
 


### PR DESCRIPTION
When using the HTTP gem with a command like `HTTP.post(url, json: { a: 1 })`, the `Content-Type`-header is set to `application/json; charset=UTF-8`. This currently prevents me from using the `RequestBodyDiff`-method, as a check for `json_headers?` is made, which returns false if the content type isn't exactly `application/json`.

Specifying the charset in the content type [should be allowed](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type#syntax). This PR therefore suggests just to check whether the content type starts with `application/json` instead of requiring an exact match.

The same is done for the `url_encoded?` helper method, checking for the `application/x-www-form-urlencoded` content type.