### PR TITLE
Allow specifying when Net::HTTP should connect on start

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -341,7 +341,7 @@ module WebMock
       WebMock::RequestSignature.new(method, uri, body: request.body, headers: headers)
     end
 
-    def self.get_uri(net_http, path)
+    def self.get_uri(net_http, path = nil)
       protocol = net_http.use_ssl? ? "https" : "http"
 
       hostname = net_http.address

--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -98,7 +98,7 @@ module WebMock
               after_request.call(response)
             }
             if started?
-              if WebMock::Config.instance.net_http_connect_on_start
+              if WebMock.net_http_connect_on_start?(request_signature.uri)
                 super_with_after_request.call
               else
                 start_with_connect_without_finish {
@@ -144,7 +144,9 @@ module WebMock
         alias_method :start_with_connect, :start
 
         def start(&block)
-          if WebMock::Config.instance.net_http_connect_on_start
+          uri = Addressable::URI.parse(WebMock::NetHTTPUtility.get_uri(self))
+
+          if WebMock.net_http_connect_on_start?(uri)
             super(&block)
           else
             start_without_connect(&block)

--- a/lib/webmock/webmock.rb
+++ b/lib/webmock/webmock.rb
@@ -70,6 +70,10 @@ module WebMock
       Config.instance.allow && net_connect_explicit_allowed?(Config.instance.allow, uri) )
   end
 
+  def self.net_http_connect_on_start?(uri)
+    Config.instance.net_http_connect_on_start
+  end
+
   def self.net_connect_explicit_allowed?(allowed, uri=nil)
     case allowed
     when Array

--- a/lib/webmock/webmock.rb
+++ b/lib/webmock/webmock.rb
@@ -71,7 +71,13 @@ module WebMock
   end
 
   def self.net_http_connect_on_start?(uri)
-    Config.instance.net_http_connect_on_start
+    allowed = Config.instance.net_http_connect_on_start || false
+
+    if [true, false].include?(allowed)
+      allowed
+    else
+      net_connect_explicit_allowed?(allowed, uri)
+    end
   end
 
   def self.net_connect_explicit_allowed?(allowed, uri=nil)

--- a/spec/acceptance/net_http/net_http_spec.rb
+++ b/spec/acceptance/net_http/net_http_spec.rb
@@ -365,5 +365,10 @@ describe "Net:HTTP" do
       path = '/example.jpg'
       expect(WebMock::NetHTTPUtility.get_uri(net_http, path)).to eq('http://www.example.com:80/example.jpg')
     end
+
+    it "does not require a path" do
+      net_http = Net::HTTP.new('www.example.com', 80)
+      expect(WebMock::NetHTTPUtility.get_uri(net_http)).to eq('http://www.example.com:80')
+    end
   end
 end

--- a/spec/acceptance/net_http/net_http_spec.rb
+++ b/spec/acceptance/net_http/net_http_spec.rb
@@ -254,6 +254,21 @@ describe "Net:HTTP" do
         }
       end
 
+      it "should connect to the server on start when allowlisted", net_connect: true do
+        WebMock.disable_net_connect!(allow: "www.google.com", net_http_connect_on_start: "www.google.com")
+        @http.start {|conn|
+          cert = OpenSSL::X509::Certificate.new conn.peer_cert
+          expect(cert).to be_a(OpenSSL::X509::Certificate)
+        }
+      end
+
+      it "should not connect to the server on start when not allowlisted", net_connect: true do
+        WebMock.disable_net_connect!(allow: "www.google.com", net_http_connect_on_start: "www.yahoo.com")
+        @http.start {|conn|
+          expect(conn.peer_cert).to be_nil
+        }
+      end
+
       it "should connect to the server if the URI matches an regex", net_connect: true do
         WebMock.disable_net_connect!(allow: /google.com/)
         Net::HTTP.get('www.google.com','/')
@@ -278,6 +293,13 @@ describe "Net:HTTP" do
   describe "when net_http_connect_on_start is false" do
     before(:each) do
       WebMock.allow_net_connect!(net_http_connect_on_start: false)
+    end
+    it_should_behave_like "Net::HTTP"
+  end
+
+  describe "when net_http_connect_on_start is a specific host" do
+    before(:each) do
+      WebMock.allow_net_connect!(net_http_connect_on_start: "localhost")
     end
     it_should_behave_like "Net::HTTP"
   end

--- a/spec/unit/webmock_spec.rb
+++ b/spec/unit/webmock_spec.rb
@@ -57,4 +57,58 @@ describe "WebMock" do
       end
     end
   end
+
+  describe ".net_http_connect_on_start?" do
+    let(:uri) { Addressable::URI.parse("http://example.org:5432") }
+
+    it "will not connect on start when false" do
+      WebMock.disable_net_connect!
+      expect(WebMock.net_http_connect_on_start?(uri)).to be(false)
+    end
+
+    it "will connect on start when true" do
+      WebMock.disable_net_connect!(net_http_connect_on_start: true)
+      expect(WebMock.net_http_connect_on_start?(uri)).to be(true)
+    end
+
+    it "will connect on start when regexp matches" do
+      WebMock.disable_net_connect!(net_http_connect_on_start: /example/)
+      expect(WebMock.net_http_connect_on_start?(uri)).to be(true)
+    end
+
+    it "will not connect on start when regexp does not match" do
+      WebMock.disable_net_connect!(net_http_connect_on_start: /nope/)
+      expect(WebMock.net_http_connect_on_start?(uri)).to be(false)
+    end
+
+    it "will connect on start when host matches" do
+      WebMock.disable_net_connect!(net_http_connect_on_start: "example.org")
+      expect(WebMock.net_http_connect_on_start?(uri)).to be(true)
+    end
+
+    it "will not connect on start when host does not match" do
+      WebMock.disable_net_connect!(net_http_connect_on_start: "localhost")
+      expect(WebMock.net_http_connect_on_start?(uri)).to be(false)
+    end
+
+    it "will connect on start when host + port matches" do
+      WebMock.disable_net_connect!(net_http_connect_on_start: "example.org:5432")
+      expect(WebMock.net_http_connect_on_start?(uri)).to be(true)
+    end
+
+    it "will not connect on start when host + port does not match" do
+      WebMock.disable_net_connect!(net_http_connect_on_start: "example.org:80")
+      expect(WebMock.net_http_connect_on_start?(uri)).to be(false)
+    end
+
+    it "will connect on start when scheme + host + port matches" do
+      WebMock.disable_net_connect!(net_http_connect_on_start: "http://example.org:5432")
+      expect(WebMock.net_http_connect_on_start?(uri)).to be(true)
+    end
+
+    it "will not connect on start when scheme + host + port does not match" do
+      WebMock.disable_net_connect!(net_http_connect_on_start: "https://example.org:5432")
+      expect(WebMock.net_http_connect_on_start?(uri)).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
Currently, `net_http_connect_on_start` is all or nothing. Many people only want to connect Selenium's requests on start so that WebMock and Capybara play nicely together.

Using `net_http_connect_on_start: true` has some undesirable behaviors (see #914 and #955). I think that this PR provides a workaround for those issues. For most people, I think `net_http_connect_on_start: %w(localhost 127.0.0.1)` will be a more ideal configuration.

This PR is backwards compatible.