### PR TITLE
Fix leaky file descriptors and reuse socket for persistent connections

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -132,6 +132,10 @@ module WebMock
 
 
         def start_with_connect_without_finish
+          if @socket
+            @socket.close
+            @socket = nil
+          end
           do_start
         end
 

--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -101,9 +101,8 @@ module WebMock
               if WebMock::Config.instance.net_http_connect_on_start
                 super_with_after_request.call
               else
-                start_with_connect_without_finish {
-                  super_with_after_request.call
-                }
+                start_with_connect_without_finish
+                super_with_after_request.call
               end
             else
               start_with_connect {
@@ -132,15 +131,8 @@ module WebMock
         end
 
 
-        def start_with_connect_without_finish  # :yield: http
-          if block_given?
-            begin
-              do_start
-              return yield(self)
-            end
-          end
+        def start_with_connect_without_finish
           do_start
-          self
         end
 
         alias_method :start_with_connect, :start

--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -98,12 +98,8 @@ module WebMock
               after_request.call(response)
             }
             if started?
-              if WebMock::Config.instance.net_http_connect_on_start
-                super_with_after_request.call
-              else
-                start_with_connect_without_finish
-                super_with_after_request.call
-              end
+              ensure_actual_connection
+              super_with_after_request.call
             else
               start_with_connect {
                 super_with_after_request.call
@@ -131,12 +127,8 @@ module WebMock
         end
 
 
-        def start_with_connect_without_finish
-          if @socket
-            @socket.close
-            @socket = nil
-          end
-          do_start
+        def ensure_actual_connection
+          do_start if @socket.is_a?(StubSocket)
         end
 
         alias_method :start_with_connect, :start

--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -119,12 +119,14 @@ module WebMock
           raise IOError, 'HTTP session already opened' if @started
           if block_given?
             begin
+              @socket = Net::HTTP.socket_type.new
               @started = true
               return yield(self)
             ensure
               do_finish
             end
           end
+          @socket = Net::HTTP.socket_type.new
           @started = true
           self
         end
@@ -258,6 +260,7 @@ class StubSocket #:nodoc:
 
   class StubIO
     def setsockopt(*args); end
+    def peer_cert; end
   end
 end
 

--- a/spec/acceptance/net_http/net_http_shared.rb
+++ b/spec/acceptance/net_http/net_http_shared.rb
@@ -26,20 +26,20 @@ shared_examples_for "Net::HTTP" do
 
     it "should connect only once when connected on start", net_connect: true do
       @http = Net::HTTP.new('localhost', port)
-      socket_id_before_request = socket_id_after_request = nil
+      socket_before_request = socket_after_request = nil
       @http.start {|conn|
-        socket_id_before_request = conn.instance_variable_get(:@socket).object_id
+        socket_before_request = conn.instance_variable_get(:@socket)
         conn.request(Net::HTTP::Get.new("/"))
-        socket_id_after_request = conn.instance_variable_get(:@socket).object_id
+        socket_after_request = conn.instance_variable_get(:@socket)
       }
 
-      if !defined?(WebMock::Config) || WebMock::Config.instance.net_http_connect_on_start
-        expect(socket_id_before_request).not_to eq(nil.object_id)
-        expect(socket_id_after_request).not_to eq(nil.object_id)
-        expect(socket_id_after_request).to eq(socket_id_before_request)
+      if WebMock::Config.instance.net_http_connect_on_start
+        expect(socket_before_request).to be_a(Net::BufferedIO)
+        expect(socket_after_request).to be_a(Net::BufferedIO)
+        expect(socket_after_request).to be(socket_before_request)
       else
-        expect(socket_id_before_request).to eq(nil.object_id)
-        expect(socket_id_after_request).not_to eq(nil.object_id)
+        expect(socket_before_request).to be_a(StubSocket)
+        expect(socket_after_request).to be_a(Net::BufferedIO)
       end
     end
 

--- a/spec/acceptance/net_http/net_http_shared.rb
+++ b/spec/acceptance/net_http/net_http_shared.rb
@@ -68,8 +68,11 @@ shared_examples_for "Net::HTTP" do
 
       if WebMock::Config.instance.net_http_connect_on_start
         expect(sockets.length).to eq(1)
+        expect(sockets.to_a[0]).to be_a(Net::BufferedIO)
       else
-        expect(sockets.length).to eq(4)
+        expect(sockets.length).to eq(2)
+        expect(sockets.to_a[0]).to be_a(StubSocket)
+        expect(sockets.to_a[1]).to be_a(Net::BufferedIO)
       end
 
       expect(sockets.all?(&:closed?)).to be(true)


### PR DESCRIPTION
Take the following example:

```ruby
require 'net/http'
require 'webmock'
WebMock.enable!
WebMock.allow_net_connect!

http = Net::HTTP.new('example.org')
http.start
http.get('/')
http.get('/')
http.get('/')
http.finish
```

This example would create 3 sockets and only close one of them. That's because `start_with_connect_without_finish` spawns a new connection for each request, and never closes the previous one.

This PR also makes it so that when using a persistent connection, the `@socket` will be reused across requests. I believe this should totally fix the common "gotcha" that people encounter when combining WebMock with Capybara _without_ needing to enable `net_http_connect_on_start`.

I'd recommend reviewing this PR commit-by-commit. I tried to provide pretty detailed explanations for the changes as I made them.