### PR TITLE
Make the StubSocket slightly more believable

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -128,7 +128,11 @@ module WebMock
 
 
         def ensure_actual_connection
-          do_start if @socket.is_a?(StubSocket)
+          if @socket.is_a?(StubSocket)
+            @socket&.close
+            @socket = nil
+            do_start
+          end
         end
 
         alias_method :start_with_connect, :start
@@ -232,13 +236,16 @@ class StubSocket #:nodoc:
   attr_accessor :read_timeout, :continue_timeout, :write_timeout
 
   def initialize(*args)
+    @closed = false
   end
 
   def closed?
-    @closed ||= true
+    @closed
   end
 
   def close
+    @closed = true
+    nil
   end
 
   def readuntil(*args)

--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -259,6 +259,8 @@ class StubSocket #:nodoc:
     def setsockopt(*args); end
     def peer_cert; end
     def peeraddr; ["AF_INET", 443, "127.0.0.1", "127.0.0.1"] end
+    def ssl_version; "TLSv1.3" end
+    def cipher; ["TLS_AES_128_GCM_SHA256", "TLSv1.3", 128, 128] end
   end
 end
 

--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -258,6 +258,7 @@ class StubSocket #:nodoc:
   class StubIO
     def setsockopt(*args); end
     def peer_cert; end
+    def peeraddr; ["AF_INET", 443, "127.0.0.1", "127.0.0.1"] end
   end
 end
 

--- a/spec/acceptance/net_http/net_http_spec.rb
+++ b/spec/acceptance/net_http/net_http_spec.rb
@@ -213,9 +213,11 @@ describe "Net:HTTP" do
     end
   end
 
-  it "uses the StubSocket to provide IP address" do
-    Net::HTTP.start("http://example.com") do |http|
-      expect(http.ipaddr).to eq("127.0.0.1")
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
+    it "uses the StubSocket to provide IP address" do
+      Net::HTTP.start("http://example.com") do |http|
+        expect(http.ipaddr).to eq("127.0.0.1")
+      end
     end
   end
 

--- a/spec/acceptance/net_http/net_http_spec.rb
+++ b/spec/acceptance/net_http/net_http_spec.rb
@@ -213,6 +213,12 @@ describe "Net:HTTP" do
     end
   end
 
+  it "uses the StubSocket to provide IP address" do
+    Net::HTTP.start("http://example.com") do |http|
+      expect(http.ipaddr).to eq("127.0.0.1")
+    end
+  end
+
   describe "connecting on Net::HTTP.start" do
     before(:each) do
       @http = Net::HTTP.new('www.google.com', 443)

--- a/spec/acceptance/net_http/net_http_spec.rb
+++ b/spec/acceptance/net_http/net_http_spec.rb
@@ -219,6 +219,14 @@ describe "Net:HTTP" do
     end
   end
 
+  it "defines common socket methods" do
+    Net::HTTP.start("http://example.com") do |http|
+      socket = http.instance_variable_get(:@socket)
+      expect(socket.io.ssl_version).to eq("TLSv1.3")
+      expect(socket.io.cipher).to eq(["TLS_AES_128_GCM_SHA256", "TLSv1.3", 128, 128])
+    end
+  end
+
   describe "connecting on Net::HTTP.start" do
     before(:each) do
       @http = Net::HTTP.new('www.google.com', 443)


### PR DESCRIPTION
Fixes https://github.com/bblimke/webmock/pull/976#issuecomment-1203449899

* ActiveMerchant expects `#ssl_version` and `#cipher` to be defined. Though these methods are private, it's best if webmock can *try* to act like the Net::HTTP to avoid gems having to detect if WebMock is enabled.
* I also took the opportunity to make `StubSocket#close` and `StubSocket#closed?` a bit more realistic as well.
* I also noticed that `Net::HTTP#ipaddr` was broken because `StubSocket#peeraddr` wasn't defined.