### PR TITLE
Requires Ruby 2.3+

### DIFF
--- a/webmock.gemspec
+++ b/webmock.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
     'wiki_uri'          => 'https://github.com/bblimke/webmock/wiki'
   }
 
-  s.required_ruby_version = '>= 2.0'
+  s.required_ruby_version = '>= 2.3'
 
   s.add_dependency 'addressable', '>= 2.8.0'
   s.add_dependency 'crack', '>= 0.3.2'


### PR DESCRIPTION
https://github.com/bblimke/webmock/pull/969 uses `&.`, but `&.` has been available since Ruby 2.3
c.f. https://www.ruby-lang.org/en/news/2015/12/25/ruby-2-3-0-released/

webmock v3.15.0+ already doesn't work with Ruby < 2.3, so I fixed `required_ruby_version`