### PR TITLE
Remove dead code for supporting Ruby < 2.3

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -165,7 +165,7 @@ module WebMock
           response.extend Net::WebMockHTTPResponse
 
           if webmock_response.should_timeout
-            raise timeout_exception, "execution expired"
+            raise Net::OpenTimeout, "execution expired"
           end
 
           webmock_response.raise_error_if_any
@@ -173,16 +173,6 @@ module WebMock
           yield response if block_given?
 
           response
-        end
-
-        def timeout_exception
-          if defined?(Net::OpenTimeout)
-            # Ruby 2.x
-            Net::OpenTimeout
-          else
-            # Fallback, if things change
-            Timeout::Error
-          end
         end
 
         def build_webmock_response(net_http_response)

--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -328,7 +328,6 @@ module WebMock
       method = request.method.downcase.to_sym
 
       headers = Hash[*request.to_hash.map {|k,v| [k, v]}.inject([]) {|r,x| r + x}]
-      validate_headers(headers)
 
       if request.body_stream
         body = request.body_stream.read
@@ -351,25 +350,6 @@ module WebMock
       hostname = "[#{hostname}]" if /\A\[.*\]\z/ !~ hostname && /:/ =~ hostname
 
       "#{protocol}://#{hostname}:#{net_http.port}#{path}"
-    end
-
-    def self.validate_headers(headers)
-      # For Ruby versions < 2.3.0, if you make a request with headers that are symbols
-      # Net::HTTP raises a NoMethodError
-      #
-      # WebMock normalizes headers when creating a RequestSignature,
-      # and will update all headers from symbols to strings.
-      #
-      # This could create a false positive in a test suite with WebMock.
-      #
-      # So before this point, WebMock raises an ArgumentError if any of the headers are symbols
-      # instead of the cryptic NoMethodError "undefined method `split' ...` from Net::HTTP
-      if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0')
-        header_as_symbol = headers.keys.find {|header| header.is_a? Symbol}
-        if header_as_symbol
-          raise ArgumentError.new("Net:HTTP does not accept headers as symbols")
-        end
-      end
     end
 
     def self.check_right_http_connection

--- a/spec/acceptance/patron/patron_spec.rb
+++ b/spec/acceptance/patron/patron_spec.rb
@@ -93,31 +93,29 @@ unless RUBY_PLATFORM =~ /java/
         @sess.copy("/abc", "/def")
       end
 
-      if /^1\.9/ === RUBY_VERSION
-        describe "handling encoding same way as patron" do
-          around(:each) do |example|
-            @encoding = Encoding.default_internal
-            Encoding.default_internal = "UTF-8"
-            example.run
-            Encoding.default_internal = @encoding
-          end
+      describe "handling encoding same way as patron" do
+        around(:each) do |example|
+          @encoding = Encoding.default_internal
+          Encoding.default_internal = "UTF-8"
+          example.run
+          Encoding.default_internal = @encoding
+        end
 
-          it "should not encode body with default encoding" do
-            stub_request(:get, "www.example.com").
-              to_return(body: "Øl")
+        it "should not encode body with default encoding" do
+          stub_request(:get, "www.example.com").
+            to_return(body: "Øl")
 
-            expect(@sess.get("").body.encoding).to eq(Encoding::ASCII_8BIT)
-            expect(@sess.get("").inspectable_body.encoding).to eq(Encoding::UTF_8)
-          end
+          expect(@sess.get("").body.encoding).to eq(Encoding::ASCII_8BIT)
+          expect(@sess.get("").inspectable_body.encoding).to eq(Encoding::UTF_8)
+        end
 
-          it "should not encode body to default internal" do
-            stub_request(:get, "www.example.com").
-              to_return(headers: {'Content-Type' => 'text/html; charset=iso-8859-1'},
-                        body: "Øl".encode("iso-8859-1"))
+        it "should not encode body to default internal" do
+          stub_request(:get, "www.example.com").
+            to_return(headers: {'Content-Type' => 'text/html; charset=iso-8859-1'},
+                      body: "Øl".encode("iso-8859-1"))
 
-            expect(@sess.get("").body.encoding).to eq(Encoding::ASCII_8BIT)
-            expect(@sess.get("").decoded_body.encoding).to eq(Encoding.default_internal)
-          end
+          expect(@sess.get("").body.encoding).to eq(Encoding::ASCII_8BIT)
+          expect(@sess.get("").decoded_body.encoding).to eq(Encoding.default_internal)
         end
       end
     end


### PR DESCRIPTION
As of #989, this library requires Ruby >= 2.3, so the following changes were in order:

* The `validate_headers` function is only executed for Ruby versions prior to 2.3.
* The patron adapter had tests that were only run for Ruby 1.9. These tests should actually have been written for all Ruby versions _greater than_ 1.9.