### PR TITLE
Avoid replacing Net::BufferedIO

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -10,24 +10,19 @@ module WebMock
       adapter_for :net_http
 
       OriginalNetHTTP = Net::HTTP unless const_defined?(:OriginalNetHTTP)
-      OriginalNetBufferedIO = Net::BufferedIO unless const_defined?(:OriginalNetBufferedIO)
 
       def self.enable!
-        Net.send(:remove_const, :BufferedIO)
         Net.send(:remove_const, :HTTP)
         Net.send(:remove_const, :HTTPSession)
         Net.send(:const_set, :HTTP, @webMockNetHTTP)
         Net.send(:const_set, :HTTPSession, @webMockNetHTTP)
-        Net.send(:const_set, :BufferedIO, Net::WebMockNetBufferedIO)
       end
 
       def self.disable!
-        Net.send(:remove_const, :BufferedIO)
         Net.send(:remove_const, :HTTP)
         Net.send(:remove_const, :HTTPSession)
         Net.send(:const_set, :HTTP, OriginalNetHTTP)
         Net.send(:const_set, :HTTPSession, OriginalNetHTTP)
-        Net.send(:const_set, :BufferedIO, OriginalNetBufferedIO)
 
         #copy all constants from @webMockNetHTTP to original Net::HTTP
         #in case any constants were added to @webMockNetHTTP instead of Net::HTTP
@@ -218,19 +213,6 @@ module WebMock
   end
 end
 
-# patch for StringIO behavior in Ruby 2.2.3
-# https://github.com/bblimke/webmock/issues/558
-class PatchedStringIO < StringIO #:nodoc:
-
-  alias_method :orig_read_nonblock, :read_nonblock
-
-  def read_nonblock(size, *args, **kwargs)
-    args.reject! {|arg| !arg.is_a?(Hash)}
-    orig_read_nonblock(size, *args, **kwargs)
-  end
-
-end
-
 class StubSocket #:nodoc:
 
   attr_accessor :read_timeout, :continue_timeout, :write_timeout
@@ -263,54 +245,6 @@ class StubSocket #:nodoc:
     def cipher; ["TLS_AES_128_GCM_SHA256", "TLSv1.3", 128, 128] end
   end
 end
-
-module Net  #:nodoc: all
-
-  class WebMockNetBufferedIO < BufferedIO
-    def initialize(io, *args, **kwargs)
-      io = case io
-      when Socket, OpenSSL::SSL::SSLSocket, IO
-        io
-      when StringIO
-        PatchedStringIO.new(io.string)
-      when String
-        PatchedStringIO.new(io)
-      end
-      raise "Unable to create local socket" unless io
-
-      # Prior to 2.4.0 `BufferedIO` only takes a single argument (`io`) with no
-      # options. Here we pass through our full set of arguments only if we're
-      # on 2.4.0 or later, and use a simplified invocation otherwise.
-      if RUBY_VERSION >= '2.4.0'
-        super
-      else
-        super(io)
-      end
-    end
-
-    if RUBY_VERSION >= '2.6.0'
-      # https://github.com/ruby/ruby/blob/7d02441f0d6e5c9d0a73a024519eba4f69e36dce/lib/net/protocol.rb#L208
-      # Modified version of method from ruby, so that nil is always passed into orig_read_nonblock to avoid timeout
-      def rbuf_fill
-        case rv = @io.read_nonblock(BUFSIZE, nil, exception: false)
-        when String
-          return if rv.nil?
-          @rbuf << rv
-          rv.clear
-          return
-        when :wait_readable
-          @io.to_io.wait_readable(@read_timeout) or raise Net::ReadTimeout
-        when :wait_writable
-          @io.to_io.wait_writable(@read_timeout) or raise Net::ReadTimeout
-        when nil
-          raise EOFError, 'end of file reached'
-        end while true
-      end
-    end
-  end
-
-end
-
 
 module WebMock
   module NetHTTPUtility

--- a/spec/unit/response_spec.rb
+++ b/spec/unit/response_spec.rb
@@ -142,6 +142,34 @@ describe WebMock::Response do
   end
 
   describe "from raw response" do
+    describe "when input is a StringIO" do
+      before(:each) do
+        @io = StringIO.new(File.read(CURL_EXAMPLE_OUTPUT_PATH))
+        @response = WebMock::Response.new(@io)
+      end
+
+      it "should read status" do
+        expect(@response.status).to eq([202, "OK"])
+      end
+
+      it "should read headers" do
+        expect(@response.headers).to eq(
+          "Date"=>"Sat, 23 Jan 2010 01:01:05 GMT",
+          "Content-Type"=>"text/html; charset=UTF-8",
+          "Content-Length"=>"419",
+          "Connection"=>"Keep-Alive",
+          "Accept"=>"image/jpeg, image/png"
+        )
+      end
+
+      it "should read body" do
+        expect(@response.body.size).to eq(419)
+      end
+
+      it "should close IO" do
+        expect(@io).to be_closed
+      end
+    end
 
     describe "when input is IO" do
       before(:each) do


### PR DESCRIPTION
Ruby's Net::BufferedIO doesn't hit the network; therefore, this library should not be patching it.

I believe that `WebMockNetBufferedIO` and `PatchedIO` were introduced so that a String could be used as a raw response. However; it's actually much simpler just to convert the string to a StringIO before attempting to parse the raw HTTP response.