### PR TITLE
Simplify Net::HTTP connection handing

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -77,7 +77,6 @@ module WebMock
           WebMock::RequestRegistry.instance.requested_signatures.put(request_signature)
 
           if webmock_response = WebMock::StubRegistry.instance.response_for_request(request_signature)
-            @socket = Net::HTTP.socket_type.new
             WebMock::CallbackRegistry.invoke_callbacks(
               {lib: :net_http}, request_signature, webmock_response)
             build_net_http_response(webmock_response, &block)

--- a/spec/acceptance/net_http/net_http_spec.rb
+++ b/spec/acceptance/net_http/net_http_spec.rb
@@ -215,14 +215,14 @@ describe "Net:HTTP" do
 
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
     it "uses the StubSocket to provide IP address" do
-      Net::HTTP.start("http://example.com") do |http|
+      Net::HTTP.start("example.com") do |http|
         expect(http.ipaddr).to eq("127.0.0.1")
       end
     end
   end
 
   it "defines common socket methods" do
-    Net::HTTP.start("http://example.com") do |http|
+    Net::HTTP.start("example.com") do |http|
       socket = http.instance_variable_get(:@socket)
       expect(socket.io.ssl_version).to eq("TLSv1.3")
       expect(socket.io.cipher).to eq(["TLS_AES_128_GCM_SHA256", "TLSv1.3", 128, 128])


### PR DESCRIPTION
This PR aims to simplify the way that the stub socket is assigned and swapped in Net::HTTP.