### PR TITLE
Fix Syntax Error: `reutrn`

### DIFF
--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -359,7 +359,7 @@ module WebMock
 
       query_parameters.each_with_index do |actual, index|
         expected = pattern[index]
-        reutrn false unless matching_values(actual, expected, content_type)
+        return false unless matching_values(actual, expected, content_type)
       end
 
       true

--- a/spec/unit/request_pattern_spec.rb
+++ b/spec/unit/request_pattern_spec.rb
@@ -553,6 +553,12 @@ describe WebMock::RequestPattern do
                 headers: {content_type: content_type}, body: "[{\"a\":1}]"))
             end
 
+            it "should not match if the request body has a different top level array" do
+              expect(WebMock::RequestPattern.new(:post, 'www.example.com', body: ["a", "b"])).
+                not_to match(WebMock::RequestSignature.new(:post, "www.example.com",
+                headers: {content_type: content_type}, body: "[\"a\", \"c\"]"))
+            end
+
             it "should not match when body is not json" do
               expect(WebMock::RequestPattern.new(:post, 'www.example.com', body: body_hash)).
                 not_to match(WebMock::RequestSignature.new(:post, "www.example.com",


### PR DESCRIPTION
We have a syntax error, `reutrn`, when matching on an array body.