### PR TITLE
em-http-request: do not alter non stubbed requests

### DIFF
--- a/lib/webmock/http_lib_adapters/em_http_request_adapter.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request_adapter.rb
@@ -116,7 +116,7 @@ if defined?(EventMachine::HttpClient)
           }
           self
         elsif WebMock.net_connect_allowed?(request_signature.uri)
-          super
+          super(request_signature.raw_headers, request_signature.body)
         else
           raise WebMock::NetConnectNotAllowedError.new(request_signature)
         end

--- a/lib/webmock/request_signature.rb
+++ b/lib/webmock/request_signature.rb
@@ -3,7 +3,7 @@ module WebMock
   class RequestSignature
 
     attr_accessor :method, :uri, :body
-    attr_reader :headers
+    attr_reader :headers, :raw_headers
 
     def initialize(method, uri, options = {})
       self.method = method.to_sym
@@ -22,6 +22,7 @@ module WebMock
     end
 
     def headers=(headers)
+      @raw_headers = headers
       @headers = WebMock::Util::Headers.normalize_headers(headers)
     end
 

--- a/spec/acceptance/em_http_request/em_http_request_spec.rb
+++ b/spec/acceptance/em_http_request/em_http_request_spec.rb
@@ -149,6 +149,18 @@ unless RUBY_PLATFORM =~ /java/
           before { WebMock.allow_net_connect! }
           include_examples "em-http-request middleware/after_request hook integration"
 
+          it "doesn't modify headers" do
+            EM.run do
+              conn = EventMachine::HttpRequest.new(webmock_server_url)
+              http = conn.post(head: { 'content-length' => '125' }, body: 'test')
+              expect(conn).to receive(:send_data).with(/POST \/ HTTP\/1.1\r\nContent-Length: 125\r\nConnection: close\r\nHost: localhost:\d+\r\nUser-Agent: EventMachine HttpClient\r\nAccept-Encoding: gzip, compressed\r\n\r\n/).and_call_original
+              expect(conn).to receive(:send_data).with('test')
+              http.callback do
+                EM.stop
+              end
+            end
+          end
+
           it "only calls request middleware once" do
             middleware = Class.new do
               def self.called!

--- a/spec/acceptance/em_http_request/em_http_request_spec.rb
+++ b/spec/acceptance/em_http_request/em_http_request_spec.rb
@@ -152,8 +152,8 @@ unless RUBY_PLATFORM =~ /java/
           it "doesn't modify headers" do
             EM.run do
               conn = EventMachine::HttpRequest.new(webmock_server_url)
-              http = conn.post(head: { 'content-length' => '125' }, body: 'test')
-              expect(conn).to receive(:send_data).with(/POST \/ HTTP\/1.1\r\nContent-Length: 125\r\nConnection: close\r\nHost: localhost:\d+\r\nUser-Agent: EventMachine HttpClient\r\nAccept-Encoding: gzip, compressed\r\n\r\n/).and_call_original
+              http = conn.post(head: { 'content-length' => '4' }, body: 'test')
+              expect(conn).to receive(:send_data).with(/POST \/ HTTP\/1.1\r\nContent-Length: 4\r\nConnection: close\r\nHost: localhost:\d+\r\nUser-Agent: EventMachine HttpClient\r\nAccept-Encoding: gzip, compressed\r\n\r\n/).and_call_original
               expect(conn).to receive(:send_data).with('test')
               http.callback do
                 EM.stop

--- a/spec/unit/request_signature_spec.rb
+++ b/spec/unit/request_signature_spec.rb
@@ -24,6 +24,13 @@ describe WebMock::RequestSignature do
       ).to eq({'B' => 'b'})
     end
 
+    it "assigns raw headers" do
+      allow(WebMock::Util::Headers).to receive(:normalize_headers).with({'A' => 'a'}.freeze).and_return('B' => 'b')
+      expect(
+        WebMock::RequestSignature.new(:get, "www.example.com", headers: {'A' => 'a'}).raw_headers
+      ).to eq({'A' => 'a'})
+    end
+
     it "assign the body" do
       expect(WebMock::RequestSignature.new(:get, "www.example.com", body: "abc").body).to eq("abc")
     end


### PR DESCRIPTION
Following this change: https://github.com/bblimke/webmock/pull/936

We are now altering the header that are sent when using webmock and em-http-request in `WebMock.allow_net_connect!` mode

If you check here https://github.com/igrigorik/em-http-request/blob/34919d760b940dfd27159bbebce5c4dac9845eb6/lib/em-http/client.rb#L180 when forwarding the request to em-http-request, the `send_request` method expects some headers to be downcased (otherwise they are doubled)

This is an issue for example for `Content-Length` which would be interpreted as an array in the receiving webserver and not as a number.

The idea of the fix is to keep the raw_headers (not normalized by webmock) and use those raw_headers when forwarding the request