### PR TITLE
Version checker fails under some conditions

### DIFF
--- a/lib/webmock/util/version_checker.rb
+++ b/lib/webmock/util/version_checker.rb
@@ -84,12 +84,13 @@ module WebMock
     def compare_version
       case
         when @major < @min_major then :too_low
+        when @major == @min_major && @minor < @min_minor then :too_low
+        when @major == @min_major && @minor == @min_minor && @patch < @min_patch then :too_low
+
         when @max_major && @major > @max_major then :too_high
-        when @major > @min_major then :ok
-        when @minor < @min_minor then :too_low
-        when @max_minor && @minor > @max_minor then :too_high
-        when @minor > @min_minor then :ok
-        when @patch < @min_patch then :too_low
+        when @max_major && @major == @max_major && @max_minor && @minor > @max_minor then :too_high
+
+        else :ok
       end
     end
 

--- a/spec/unit/util/version_checker_spec.rb
+++ b/spec/unit/util/version_checker_spec.rb
@@ -8,15 +8,33 @@ module WebMock
       checker.check_version!
     end
 
+    it 'prints a warning if the major version is too low - 2' do
+      checker = VersionChecker.new('foo', '0.7.3', '1.0.0', '2.1')
+      expect(Kernel).to receive(:warn).with("\e[31mYou are using foo 0.7.3. WebMock supports version >= 1.0.0, < 2.2.\e[0m")
+      checker.check_version!
+    end
+
     it 'prints a warning if the minor version is too low' do
       checker = VersionChecker.new('foo', '1.0.99', '1.1.3', '1.2')
       expect(Kernel).to receive(:warn).with("\e[31mYou are using foo 1.0.99. WebMock supports version >= 1.1.3, < 1.3.\e[0m")
       checker.check_version!
     end
 
+    it 'prints a warning if the minor version is too low - 2' do
+      checker = VersionChecker.new('foo', '0.7.8', '0.9.7', '1.0.1')
+      expect(Kernel).to receive(:warn).with("\e[31mYou are using foo 0.7.8. WebMock supports version >= 0.9.7, < 1.1.\e[0m")
+      checker.check_version!
+    end
+
     it 'prints a warning if the patch version is too low' do
       checker = VersionChecker.new('foo', '1.0.8', '1.0.10', '1.2')
       expect(Kernel).to receive(:warn).with("\e[31mYou are using foo 1.0.8. WebMock supports version >= 1.0.10, < 1.3.\e[0m")
+      checker.check_version!
+    end
+
+    it 'prints a warning if the patch version is too low - 2' do
+      checker = VersionChecker.new('foo', '0.9.1', '0.9.7', '1.0.1')
+      expect(Kernel).to receive(:warn).with("\e[31mYou are using foo 0.9.1. WebMock supports version >= 0.9.7, < 1.1.\e[0m")
       checker.check_version!
     end
 
@@ -32,8 +50,20 @@ module WebMock
       checker.check_version!
     end
 
+    it 'prints a warning if the major version is too high - 2' do
+      checker = VersionChecker.new('foo', '2.0.0', '0.9.7', '1.1')
+      expect(Kernel).to receive(:warn).with(/may not work with this version/)
+      checker.check_version!
+    end
+
     it 'prints a warning if the minor version is too high' do
       checker = VersionChecker.new('foo', '1.2.0', '1.0.0', '1.1')
+      expect(Kernel).to receive(:warn).with(/may not work with this version/)
+      checker.check_version!
+    end
+
+    it 'prints a warning if the minor version is too high - 2' do
+      checker = VersionChecker.new('foo', '1.2.0', '0.9.7', '1.1')
       expect(Kernel).to receive(:warn).with(/may not work with this version/)
       checker.check_version!
     end
@@ -50,7 +80,37 @@ module WebMock
       checker.check_version!
     end
 
+    it 'does not raise an error or print a warning when the min_patch is 0.6.5, the max_minor is 1.0.1 and the version is 0.7.3' do
+      checker = VersionChecker.new('foo', '0.7.3', '0.6.5', '1.0.1')
+      expect(Kernel).not_to receive(:warn)
+      checker.check_version!
+    end
+
+    it 'does not raise an error or print a warning when the min_patch is 0.6.5, the max_minor is 1.0.1 and the version is 0.7.3' do
+      checker = VersionChecker.new('foo', '0.7.3', '0.6.5', '1.0.1')
+      expect(Kernel).not_to receive(:warn)
+      checker.check_version!
+    end
+
+    it 'does not raise an error or print a warning when the min_patch is 0.6.5, the max_minor is 1.0.1 and the version is 0.6.5' do
+      checker = VersionChecker.new('foo', '0.7.3', '0.6.5', '1.0.1')
+      expect(Kernel).not_to receive(:warn)
+      checker.check_version!
+    end
+
+    it 'does not raise an error or print a warning when the min_patch is 0.6.5, the max_minor is 1.0.1 and the version is 1.0.1' do
+      checker = VersionChecker.new('foo', '0.7.3', '0.6.5', '1.0.1')
+      expect(Kernel).not_to receive(:warn)
+      checker.check_version!
+    end
+
     it 'does not raise an error or print a warning when the min_patch is 0.6.5, the max_minor is not specified and the version is 0.8.3' do
+      checker = VersionChecker.new('foo', '0.8.3', '0.6.5')
+      expect(Kernel).not_to receive(:warn)
+      checker.check_version!
+    end
+
+    it 'does not raise an error or print a warning when the min_patch is 0.6.5, the max_minor is not specified and the version is 0.6.5' do
       checker = VersionChecker.new('foo', '0.8.3', '0.6.5')
       expect(Kernel).not_to receive(:warn)
       checker.check_version!


### PR DESCRIPTION
For ex we are using Curb version 0.9.7 and it prints a warning even though it shouldn't