### PR TITLE
Fix matching stubs with HashExcludingMatcher

### DIFF
--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -283,7 +283,7 @@ module WebMock
         matching_body_hashes?(body_as_hash(body, content_type), @pattern, content_type)
       elsif (@pattern).is_a?(Array)
         matching_body_array?(body_as_hash(body, content_type), @pattern, content_type)
-      elsif (@pattern).is_a?(WebMock::Matchers::HashIncludingMatcher)
+      elsif (@pattern).is_a?(WebMock::Matchers::HashArgumentMatcher)
         @pattern == body_as_hash(body, content_type)
       else
         empty_string?(@pattern) && empty_string?(body) ||


### PR DESCRIPTION
Stubs using HashExcludingMatcher were not working because body is not being converted to a hash in order to do the matching