### PR TITLE
Add net_http_connect_on_start example with explicit domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,7 +595,11 @@ which can be passed to `WebMock.allow_net_connect!` and `WebMock.disable_net_con
 WebMock.allow_net_connect!(net_http_connect_on_start: true)
 ```
 
-This forces WebMock Net::HTTP adapter to always connect on `Net::HTTP.start`.
+This forces WebMock Net::HTTP adapter to always connect on `Net::HTTP.start`. At the time of connection being made there is no information about the request or URL yet, therefore WebMock is not able to decide whether to stub a request or not and all connections are allowed. To enable connections only to a specific domain (e.g. your test server) use:
+
+```ruby
+WebMock.allow_net_connect!(net_http_connect_on_start: "www.example.com")
+```
 
 ## Setting Expectations
 


### PR DESCRIPTION
While debugging the `net_http_connect_on_start` [gotcha with Capybara](https://github.com/teamcapybara/capybara#gotchas) I found it's sometimes necessary to restrict the scope of `net_http_connect_on_start` to prevent network connections to external services while allowing (and fixing) connections to the local test server.

This PR pulls information from [this comment](https://github.com/bblimke/webmock/issues/914#issuecomment-810134233) into the readme and adds an example to show `net_http_connect_on_start` accepts domains as well as boolean values, which resolved the issue for me.