### PR TITLE
Remove development and test files from the gem package

### DIFF
--- a/webmock.gemspec
+++ b/webmock.gemspec
@@ -47,8 +47,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rdoc',            '>  3.5.0'
   s.add_development_dependency 'webrick'
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject do |file|
+      file.start_with?(*%w[. Gemfile Rakefile minitest spec test webmock.gemspec])
+    end
+  end
   s.require_paths = ['lib']
 end


### PR DESCRIPTION
There are several files in the gem package that aren't useful for downstream projects. Removing these files reduces the gem package size from **125K** to **66K**!

<details><summary>gem contents diff</summary>

```diff
< .gemtest
< .github/workflows/CI.yml
< .gitignore
< .rspec-tm
  CHANGELOG.md
< Gemfile
  LICENSE
  README.md
< Rakefile
  lib/webmock.rb
  lib/webmock/api.rb
  lib/webmock/assertion_failure.rb
  lib/webmock/callback_registry.rb
  lib/webmock/config.rb
  lib/webmock/cucumber.rb
  lib/webmock/deprecation.rb
  lib/webmock/errors.rb
  lib/webmock/http_lib_adapters/async_http_client_adapter.rb
  lib/webmock/http_lib_adapters/curb_adapter.rb
  lib/webmock/http_lib_adapters/em_http_request_adapter.rb
  lib/webmock/http_lib_adapters/excon_adapter.rb
  lib/webmock/http_lib_adapters/http_lib_adapter.rb
  lib/webmock/http_lib_adapters/http_lib_adapter_registry.rb
  lib/webmock/http_lib_adapters/http_rb/client.rb
  lib/webmock/http_lib_adapters/http_rb/request.rb
  lib/webmock/http_lib_adapters/http_rb/response.rb
  lib/webmock/http_lib_adapters/http_rb/streamer.rb
  lib/webmock/http_lib_adapters/http_rb/webmock.rb
  lib/webmock/http_lib_adapters/http_rb_adapter.rb
  lib/webmock/http_lib_adapters/httpclient_adapter.rb
  lib/webmock/http_lib_adapters/manticore_adapter.rb
  lib/webmock/http_lib_adapters/net_http.rb
  lib/webmock/http_lib_adapters/net_http_response.rb
  lib/webmock/http_lib_adapters/patron_adapter.rb
  lib/webmock/http_lib_adapters/typhoeus_hydra_adapter.rb
  lib/webmock/matchers/any_arg_matcher.rb
  lib/webmock/matchers/hash_argument_matcher.rb
  lib/webmock/matchers/hash_excluding_matcher.rb
  lib/webmock/matchers/hash_including_matcher.rb
  lib/webmock/minitest.rb
  lib/webmock/rack_response.rb
  lib/webmock/request_body_diff.rb
  lib/webmock/request_execution_verifier.rb
  lib/webmock/request_pattern.rb
  lib/webmock/request_registry.rb
  lib/webmock/request_signature.rb
  lib/webmock/request_signature_snippet.rb
  lib/webmock/request_stub.rb
  lib/webmock/response.rb
  lib/webmock/responses_sequence.rb
  lib/webmock/rspec.rb
  lib/webmock/rspec/matchers.rb
  lib/webmock/rspec/matchers/request_pattern_matcher.rb
  lib/webmock/rspec/matchers/webmock_matcher.rb
  lib/webmock/stub_registry.rb
  lib/webmock/stub_request_snippet.rb
  lib/webmock/test_unit.rb
  lib/webmock/util/hash_counter.rb
  lib/webmock/util/hash_keys_stringifier.rb
  lib/webmock/util/hash_validator.rb
  lib/webmock/util/headers.rb
  lib/webmock/util/json.rb
  lib/webmock/util/query_mapper.rb
  lib/webmock/util/uri.rb
  lib/webmock/util/values_stringifier.rb
  lib/webmock/util/version_checker.rb
  lib/webmock/version.rb
  lib/webmock/webmock.rb
< minitest/test_helper.rb
< minitest/test_webmock.rb
< minitest/webmock_spec.rb
< spec/acceptance/async_http_client/async_http_client_spec.rb
< spec/acceptance/async_http_client/async_http_client_spec_helper.rb
< spec/acceptance/curb/curb_spec.rb
< spec/acceptance/curb/curb_spec_helper.rb
< spec/acceptance/em_http_request/em_http_request_spec.rb
< spec/acceptance/em_http_request/em_http_request_spec_helper.rb
< spec/acceptance/excon/excon_spec.rb
< spec/acceptance/excon/excon_spec_helper.rb
< spec/acceptance/http_rb/http_rb_spec.rb
< spec/acceptance/http_rb/http_rb_spec_helper.rb
< spec/acceptance/httpclient/httpclient_spec.rb
< spec/acceptance/httpclient/httpclient_spec_helper.rb
< spec/acceptance/manticore/manticore_spec.rb
< spec/acceptance/manticore/manticore_spec_helper.rb
< spec/acceptance/net_http/net_http_shared.rb
< spec/acceptance/net_http/net_http_spec.rb
< spec/acceptance/net_http/net_http_spec_helper.rb
< spec/acceptance/net_http/real_net_http_spec.rb
< spec/acceptance/patron/patron_spec.rb
< spec/acceptance/patron/patron_spec_helper.rb
< spec/acceptance/shared/allowing_and_disabling_net_connect.rb
< spec/acceptance/shared/callbacks.rb
< spec/acceptance/shared/complex_cross_concern_behaviors.rb
< spec/acceptance/shared/enabling_and_disabling_webmock.rb
< spec/acceptance/shared/precedence_of_stubs.rb
< spec/acceptance/shared/request_expectations.rb
< spec/acceptance/shared/returning_declared_responses.rb
< spec/acceptance/shared/stubbing_requests.rb
< spec/acceptance/typhoeus/typhoeus_hydra_spec.rb
< spec/acceptance/typhoeus/typhoeus_hydra_spec_helper.rb
< spec/acceptance/webmock_shared.rb
< spec/fixtures/test.txt
< spec/quality_spec.rb
< spec/spec_helper.rb
< spec/support/example_curl_output.txt
< spec/support/failures.rb
< spec/support/my_rack_app.rb
< spec/support/network_connection.rb
< spec/support/webmock_server.rb
< spec/unit/api_spec.rb
< spec/unit/errors_spec.rb
< spec/unit/http_lib_adapters/http_lib_adapter_registry_spec.rb
< spec/unit/http_lib_adapters/http_lib_adapter_spec.rb
< spec/unit/matchers/hash_excluding_matcher_spec.rb
< spec/unit/matchers/hash_including_matcher_spec.rb
< spec/unit/rack_response_spec.rb
< spec/unit/request_body_diff_spec.rb
< spec/unit/request_execution_verifier_spec.rb
< spec/unit/request_pattern_spec.rb
< spec/unit/request_registry_spec.rb
< spec/unit/request_signature_snippet_spec.rb
< spec/unit/request_signature_spec.rb
< spec/unit/request_stub_spec.rb
< spec/unit/response_spec.rb
< spec/unit/stub_registry_spec.rb
< spec/unit/stub_request_snippet_spec.rb
< spec/unit/util/hash_counter_spec.rb
< spec/unit/util/hash_keys_stringifier_spec.rb
< spec/unit/util/headers_spec.rb
< spec/unit/util/json_spec.rb
< spec/unit/util/query_mapper_spec.rb
< spec/unit/util/uri_spec.rb
< spec/unit/util/version_checker_spec.rb
< spec/unit/webmock_spec.rb
< test/http_request.rb
< test/shared_test.rb
< test/test_helper.rb
< test/test_webmock.rb
< webmock.gemspec
```

</details>