### PR TITLE
Fix version check when major version is less than the max version

### DIFF
--- a/lib/webmock/util/version_checker.rb
+++ b/lib/webmock/util/version_checker.rb
@@ -86,6 +86,7 @@ module WebMock
         when @major < @min_major then :too_low
         when @max_major && @major > @max_major then :too_high
         when @major > @min_major then :ok
+        when @max_major && @major < @max_major then :ok
         when @minor < @min_minor then :too_low
         when @max_minor && @minor > @max_minor then :too_high
         when @minor > @min_minor then :ok

--- a/spec/unit/util/version_checker_spec.rb
+++ b/spec/unit/util/version_checker_spec.rb
@@ -61,5 +61,11 @@ module WebMock
       expect(Kernel).to receive(:warn).with(%r{You are using foo 2.0.0. WebMock does not support this version. WebMock supports versions >= 1.0.0, < 3.1, except versions 2.0.0.})
       checker.check_version!
     end
+
+    it "does not raise an error or print a warning when the max_minor_version is 1.0 and the version is 0.9" do
+      checker = VersionChecker.new('foo', '0.9.0', '0.8.0', '1.0')
+      expect(Kernel).not_to receive(:warn)#.with(%r{You are using foo 0.9.0. WebMock does not support this version. WebMock supports versions >= 0.8.0, < 1.0.})
+      checker.check_version!
+    end
   end
 end


### PR DESCRIPTION
This should fix the error below

> You are using Curb 0.9.11. WebMock is known to work with Curb >= 0.7.16, < 1.1, except versions 0.8.7. It may not work with this version.
