### PR TITLE
add "[::1]" for localhost determination

### DIFF
--- a/lib/webmock/util/uri.rb
+++ b/lib/webmock/util/uri.rb
@@ -68,7 +68,7 @@ module WebMock
 
       def self.is_uri_localhost?(uri)
         uri.is_a?(Addressable::URI) &&
-        %w(localhost 127.0.0.1 0.0.0.0).include?(uri.host)
+        %w(localhost 127.0.0.1 0.0.0.0 [::1]).include?(uri.host)
       end
 
       private


### PR DESCRIPTION
Currently, `allow_localhost` option of `disable_net_connect!` method does not allow `[::1]` to be communicated, while this is actually an localhost address (of IPv6).

This PR should allow communicating with `http://[::1]/some/path` address.