### PR TITLE
Frozen string literal

### DIFF
--- a/lib/webmock.rb
+++ b/lib/webmock.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'singleton'
 
 require 'addressable/uri'

--- a/lib/webmock/api.rb
+++ b/lib/webmock/api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   module API
     extend self

--- a/lib/webmock/assertion_failure.rb
+++ b/lib/webmock/assertion_failure.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   class AssertionFailure
     @error_class = RuntimeError

--- a/lib/webmock/callback_registry.rb
+++ b/lib/webmock/callback_registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   class CallbackRegistry
     @@callbacks = []

--- a/lib/webmock/config.rb
+++ b/lib/webmock/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   class Config
     include Singleton

--- a/lib/webmock/cucumber.rb
+++ b/lib/webmock/cucumber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'webmock'
 require 'webmock/rspec/matchers'
 

--- a/lib/webmock/deprecation.rb
+++ b/lib/webmock/deprecation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   class Deprecation
     class << self

--- a/lib/webmock/errors.rb
+++ b/lib/webmock/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
 
   class NetConnectNotAllowedError < Exception

--- a/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
+++ b/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'async'
   require 'async/http'

--- a/lib/webmock/http_lib_adapters/curb_adapter.rb
+++ b/lib/webmock/http_lib_adapters/curb_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'curb'
 rescue LoadError

--- a/lib/webmock/http_lib_adapters/em_http_request_adapter.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'em-http-request'
 rescue LoadError

--- a/lib/webmock/http_lib_adapters/excon_adapter.rb
+++ b/lib/webmock/http_lib_adapters/excon_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'excon'
 rescue LoadError

--- a/lib/webmock/http_lib_adapters/http_lib_adapter.rb
+++ b/lib/webmock/http_lib_adapters/http_lib_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   class HttpLibAdapter
     def self.adapter_for(lib)

--- a/lib/webmock/http_lib_adapters/http_lib_adapter_registry.rb
+++ b/lib/webmock/http_lib_adapters/http_lib_adapter_registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   class HttpLibAdapterRegistry
     include Singleton

--- a/lib/webmock/http_lib_adapters/http_rb/client.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HTTP
   class Client
     alias_method :__perform__, :perform

--- a/lib/webmock/http_lib_adapters/http_rb/request.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/request.rb
@@ -4,7 +4,7 @@ module HTTP
   class Request
     def webmock_signature
       request_body = if defined?(HTTP::Request::Body)
-                       ''.tap { |string| body.each { |part| string << part } }
+                       String.new.tap { |string| body.each { |part| string << part } }
                      else
                        body
                      end

--- a/lib/webmock/http_lib_adapters/http_rb/request.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HTTP
   class Request
     def webmock_signature

--- a/lib/webmock/http_lib_adapters/http_rb/response.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HTTP
   class Response
     def to_webmock

--- a/lib/webmock/http_lib_adapters/http_rb/streamer.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/streamer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HTTP
   class Response
     class Streamer

--- a/lib/webmock/http_lib_adapters/http_rb/webmock.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/webmock.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HTTP
   class WebMockPerform
     def initialize(request, options, &perform)

--- a/lib/webmock/http_lib_adapters/http_rb_adapter.rb
+++ b/lib/webmock/http_lib_adapters/http_rb_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "http"
 rescue LoadError

--- a/lib/webmock/http_lib_adapters/httpclient_adapter.rb
+++ b/lib/webmock/http_lib_adapters/httpclient_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'httpclient'
   require 'jsonclient' # defined in 'httpclient' gem as well

--- a/lib/webmock/http_lib_adapters/manticore_adapter.rb
+++ b/lib/webmock/http_lib_adapters/manticore_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'manticore'
 rescue LoadError

--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'net/http'
 require 'net/https'
 require 'stringio'

--- a/lib/webmock/http_lib_adapters/net_http_response.rb
+++ b/lib/webmock/http_lib_adapters/net_http_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This code is entierly copied from VCR (http://github.com/myronmarston/vcr) by courtesy of Myron Marston
 
 # A Net::HTTP response that has already been read raises an IOError when #read_body

--- a/lib/webmock/http_lib_adapters/patron_adapter.rb
+++ b/lib/webmock/http_lib_adapters/patron_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'patron'
 rescue LoadError

--- a/lib/webmock/http_lib_adapters/typhoeus_hydra_adapter.rb
+++ b/lib/webmock/http_lib_adapters/typhoeus_hydra_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'typhoeus'
 rescue LoadError

--- a/lib/webmock/matchers/any_arg_matcher.rb
+++ b/lib/webmock/matchers/any_arg_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   module Matchers
     # this is a based on RSpec::Mocks::ArgumentMatchers::AnyArgMatcher

--- a/lib/webmock/matchers/hash_argument_matcher.rb
+++ b/lib/webmock/matchers/hash_argument_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   module Matchers
     # Base class for Hash matchers

--- a/lib/webmock/matchers/hash_excluding_matcher.rb
+++ b/lib/webmock/matchers/hash_excluding_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   module Matchers
     # this is a based on RSpec::Mocks::ArgumentMatchers::HashExcludingMatcher

--- a/lib/webmock/matchers/hash_including_matcher.rb
+++ b/lib/webmock/matchers/hash_including_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   module Matchers
     # this is a based on RSpec::Mocks::ArgumentMatchers::HashIncludingMatcher

--- a/lib/webmock/minitest.rb
+++ b/lib/webmock/minitest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'minitest/test'
   test_class = Minitest::Test

--- a/lib/webmock/rack_response.rb
+++ b/lib/webmock/rack_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   class RackResponse < Response
     def initialize(app)

--- a/lib/webmock/request_body_diff.rb
+++ b/lib/webmock/request_body_diff.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "hashdiff"
 require "json"
 

--- a/lib/webmock/request_execution_verifier.rb
+++ b/lib/webmock/request_execution_verifier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   class RequestExecutionVerifier
 

--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
 
   module RSpecMatcherDetector

--- a/lib/webmock/request_registry.rb
+++ b/lib/webmock/request_registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
 
   class RequestRegistry

--- a/lib/webmock/request_signature.rb
+++ b/lib/webmock/request_signature.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
 
   class RequestSignature

--- a/lib/webmock/request_signature_snippet.rb
+++ b/lib/webmock/request_signature_snippet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "pp"
 
 module WebMock

--- a/lib/webmock/request_stub.rb
+++ b/lib/webmock/request_stub.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   class RequestStub
 

--- a/lib/webmock/response.rb
+++ b/lib/webmock/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "pathname"
 
 module WebMock

--- a/lib/webmock/responses_sequence.rb
+++ b/lib/webmock/responses_sequence.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
 
   class ResponsesSequence

--- a/lib/webmock/rspec.rb
+++ b/lib/webmock/rspec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'webmock'
 
 # RSpec 1.x and 2.x compatibility

--- a/lib/webmock/rspec/matchers.rb
+++ b/lib/webmock/rspec/matchers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'webmock'
 require 'webmock/rspec/matchers/request_pattern_matcher'
 require 'webmock/rspec/matchers/webmock_matcher'

--- a/lib/webmock/rspec/matchers/request_pattern_matcher.rb
+++ b/lib/webmock/rspec/matchers/request_pattern_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   class RequestPatternMatcher
 

--- a/lib/webmock/rspec/matchers/webmock_matcher.rb
+++ b/lib/webmock/rspec/matchers/webmock_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   class WebMockMatcher
 

--- a/lib/webmock/stub_registry.rb
+++ b/lib/webmock/stub_registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
 
   class StubRegistry

--- a/lib/webmock/stub_request_snippet.rb
+++ b/lib/webmock/stub_request_snippet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   class StubRequestSnippet
     def initialize(request_stub)

--- a/lib/webmock/test_unit.rb
+++ b/lib/webmock/test_unit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test/unit'
 require 'webmock'
 

--- a/lib/webmock/util/hash_counter.rb
+++ b/lib/webmock/util/hash_counter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 module WebMock

--- a/lib/webmock/util/hash_keys_stringifier.rb
+++ b/lib/webmock/util/hash_keys_stringifier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   module Util
     class HashKeysStringifier

--- a/lib/webmock/util/hash_validator.rb
+++ b/lib/webmock/util/hash_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   class HashValidator
     def initialize(hash)

--- a/lib/webmock/util/headers.rb
+++ b/lib/webmock/util/headers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module WebMock

--- a/lib/webmock/util/json.rb
+++ b/lib/webmock/util/json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This is a copy of https://github.com/jnunemaker/crack/blob/master/lib/crack/json.rb
 # with date parsing removed
 # Copyright (c) 2004-2008 David Heinemeier Hansson

--- a/lib/webmock/util/query_mapper.rb
+++ b/lib/webmock/util/query_mapper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock::Util
   class QueryMapper
     class << self

--- a/lib/webmock/util/uri.rb
+++ b/lib/webmock/util/uri.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
 
   module Util

--- a/lib/webmock/util/values_stringifier.rb
+++ b/lib/webmock/util/values_stringifier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class WebMock::Util::ValuesStringifier
   def self.stringify_values(value)
     case value

--- a/lib/webmock/util/version_checker.rb
+++ b/lib/webmock/util/version_checker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This code was created based on https://github.com/myronmarston/vcr/blob/master/lib/vcr/util/version_checker.rb
 # Thanks to @myronmarston
 

--- a/lib/webmock/version.rb
+++ b/lib/webmock/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
   VERSION = '3.18.1' unless defined?(::WebMock::VERSION)
 end

--- a/lib/webmock/webmock.rb
+++ b/lib/webmock/webmock.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WebMock
 
   def self.included(clazz)


### PR DESCRIPTION
I was going over some [memory_profiler](https://github.com/SamSaffron/memory_profiler) reports, and was digging into some of the memory usage attributed. It looks like there are some hot paths in the code base that have string literals, and without `frozen_string_literal: true`, these would end up creating new strings each time.

For this PR, I added a rubocop rule for requiring frozen_string_literal, and then auto-corrected it.