### PR TITLE
Set Typhoeus timing fields when constructing Response objects

### DIFF
--- a/lib/webmock/http_lib_adapters/typhoeus_hydra_adapter.rb
+++ b/lib/webmock/http_lib_adapters/typhoeus_hydra_adapter.rb
@@ -96,7 +96,14 @@ if defined?(Typhoeus)
               status_message: "",
               body: "",
               headers: {},
-              return_code: :operation_timedout
+              return_code: :operation_timedout,
+              total_time: 0.0,
+              starttransfer_time: 0.0,
+              appconnect_time: 0.0,
+              pretransfer_time: 0.0,
+              connect_time: 0.0,
+              namelookup_time: 0.0,
+              redirect_time: 0.0
             )
           else
             ::Typhoeus::Response.new(
@@ -104,7 +111,14 @@ if defined?(Typhoeus)
               status_message: webmock_response.status[1],
               body: webmock_response.body,
               headers: webmock_response.headers,
-              effective_url: request_signature.uri
+              effective_url: request_signature.uri,
+              total_time: 0.0,
+              starttransfer_time: 0.0,
+              appconnect_time: 0.0,
+              pretransfer_time: 0.0,
+              connect_time: 0.0,
+              namelookup_time: 0.0,
+              redirect_time: 0.0
             )
           end
           response.mock = :webmock

--- a/spec/acceptance/typhoeus/typhoeus_hydra_spec.rb
+++ b/spec/acceptance/typhoeus/typhoeus_hydra_spec.rb
@@ -29,6 +29,15 @@ unless RUBY_PLATFORM =~ /java/
           expect(response.body).not_to be_nil
           expect(response.headers).not_to be_nil
           expect(response.effective_url).not_to be_nil
+          expect(response.total_time).to eq 0.0
+          expect(response.time).to eq 0.0  # aliased by Typhoeus::Response::Informations
+          expect(response.starttransfer_time).to eq 0.0
+          expect(response.start_transfer_time).to eq 0.0  # aliased by Typhoeus::Response::Informations
+          expect(response.appconnect_time).to eq 0.0
+          expect(response.pretransfer_time).to eq 0.0
+          expect(response.connect_time).to eq 0.0
+          expect(response.namelookup_time).to eq 0.0
+          expect(response.redirect_time).to eq 0.0
         end
       end
 


### PR DESCRIPTION
This sets all of the `*_time` fields from [Typhoeus::Response::Informations](https://www.rubydoc.info/github/typhoeus/typhoeus/Typhoeus/Response/Informations) to 0.0 when constructing the `Typhoeus::Response` objects.

It would be cool to have an API for mocking these; perhaps something like
```ruby
stub_request(:get, "http://www.example.com")
  .to_return(status: 200)
  .to_take(3.seconds)
```

but for now I just wanted to set them to a non-nil value