### PR TITLE
Fix failing Async::HTTP specs due to Async API change

### DIFF
--- a/spec/acceptance/async_http_client/async_http_client_spec.rb
+++ b/spec/acceptance/async_http_client/async_http_client_spec.rb
@@ -345,7 +345,7 @@ unless RUBY_PLATFORM =~ /java/
     end
 
     def make_request(method, url, protocol: nil, headers: {}, body: nil)
-      Async do
+      result  = Async do
         endpoint = Async::HTTP::Endpoint.parse(url)
 
         begin
@@ -362,6 +362,8 @@ unless RUBY_PLATFORM =~ /java/
           e
         end
       end.wait
+
+      result.is_a?(Exception) ? raise(result) : result
     end
 
     def response_to_hash(response)

--- a/spec/acceptance/async_http_client/async_http_client_spec_helper.rb
+++ b/spec/acceptance/async_http_client/async_http_client_spec_helper.rb
@@ -16,7 +16,7 @@ module AsyncHttpClientSpecHelper
 
     body = options[:body]
 
-    Async do
+    result = Async do
       begin
         Async::HTTP::Client.open(endpoint) do |client|
           response = client.send(
@@ -34,6 +34,8 @@ module AsyncHttpClientSpecHelper
         e
       end
     end.wait
+
+    result.is_a?(Exception) ? raise(result) : result
   end
 
   def client_timeout_exception_class


### PR DESCRIPTION
The `async` gem recently made a breaking API change that was released in patch version 2.6.4.[^1] Following the change, async tasks that return an  exception object will no longer raise that exception when `wait` is called.

The `Async::HTTP` specs in webmock were written to leverage the old behavior of `wait`. Since async 2.6.4 was released, these specs have been failing in CI.

This commit fixes the failing specs by updating how `wait` is used, such that exceptions are still raised as expected in async 2.6.4. This should restore CI to a working state.

Fixes #1036 

[^1]: https://github.com/socketry/async/pull/270