### PR TITLE
Add `base64` to runtime dependency

### DIFF
--- a/webmock.gemspec
+++ b/webmock.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.5'
 
   s.add_dependency 'addressable', '>= 2.8.0'
+  s.add_dependency 'base64'
   s.add_dependency 'crack', '>= 0.3.2'
   s.add_dependency 'hashdiff', ['>= 0.4.0', '< 2.0.0']
 


### PR DESCRIPTION
This PR adds `base64` to runtime dependency to suppress the following Ruby 3.3's warning:

```console
$ ruby -v
ruby 3.3.0dev (2023-10-23T08:04:27Z master e6fcf07a6f) [x86_64-darwin22]

$ path/to/rubocop
$ bundle exec rspec
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/webmock-3.19.1/lib/webmock/util/headers.rb:3:
warning: base64 which will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.
```

I found this warning in the RuboCop repository:
https://app.circleci.com/pipelines/github/rubocop/rubocop/10108/workflows/20097132-bbe3-4fa4-ad7e-de7c30c86e69/jobs/291956?invite=true#step-104-0_163

cf: https://github.com/rails/rails/pull/48907