### PR TITLE
EmHttpRequestAdapter - Call detect instead of select..first

### DIFF
--- a/lib/webmock/http_lib_adapters/em_http_request_adapter.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request_adapter.rb
@@ -156,7 +156,7 @@ if defined?(EventMachine::HttpClient)
         raw_cookie = response_header.cookie
         raw_cookie = [raw_cookie] if raw_cookie.is_a? String
 
-        cookie = raw_cookie.select { |c| c.start_with? name }.first
+        cookie = raw_cookie.detect { |c| c.start_with? name }
         cookie and cookie.split('=', 2)[1]
       end
 


### PR DESCRIPTION
Tiny tiny optimization PR

As per https://github.com/fastruby/fast-ruby/blob/main/code/enumerable/select-first-vs-detect.rb
Detect is slightly faster than select{}.first