### PR TITLE
Strip transfer-encoding header for requests using async_http_client_a…

### DIFF
--- a/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
+++ b/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
@@ -203,8 +203,18 @@ if defined?(Async::HTTP)
             @webmock_responses ||= {}
           end
 
+          def strip_header?(key:, value:)
+            # WebMock's internal processing will not handle the body
+            # correctly if the header indicates that it is chunked, unless
+            # we also create all the chunks.
+            # It's far easier just to remove the header.
+            key =~ /transfer-encoding/i && value =~/chunked/i
+          end
+
           def build_response(webmock_response)
             headers = (webmock_response.headers || {}).each_with_object([]) do |(k, value), o|
+              next if strip_header?(key: k, value: value)
+
               Array(value).each do |v|
                 o.push [k, v]
               end

--- a/spec/acceptance/async_http_client/async_http_client_spec.rb
+++ b/spec/acceptance/async_http_client/async_http_client_spec.rb
@@ -130,6 +130,11 @@ unless RUBY_PLATFORM =~ /java/
       )
     end
 
+    it 'works with responses that use chunked transfer encoding' do
+      stub_request(:get, "www.example.com").to_return(body: "abc", headers: { 'Transfer-Encoding' => 'chunked' })
+      expect(http_request(:get, "http://www.example.com").body).to eq("abc")
+    end
+
     it 'works with to_timeout' do
       stub_request(:get, 'http://www.example.com').to_timeout
       expect { make_request(:get, 'http://www.example.com') }.to raise_error Async::TimeoutError


### PR DESCRIPTION
…dapter

When mocking requests using webmock where the request has a `transfer-encoding` header with a value of `chunked`, the request will raise an exception:

```
Protocol::HTTP1::BadRequest:
       Message contains both transfer encoding and content length!
```

This happens because the data is not actually chunked, so the underlying Protocol::HTTP1 library attempts to send a fixed length body in the response, which injects the `content-length` header after the `transfer-encoding` header was already sent.

This PR simply copies what was done to address a similar problem in `WebMock::HttpLibAdapters::EmHttpRequestAdapter` - simply remove the `transfer-encoding` header when present in the mocked response.