### PR TITLE
Remove runtime dependency on `base64`

### DIFF
--- a/lib/webmock/util/headers.rb
+++ b/lib/webmock/util/headers.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'base64'
-
 module WebMock
 
   module Util
@@ -59,7 +57,8 @@ module WebMock
       end
 
       def self.basic_auth_header(*credentials)
-        "Basic #{Base64.strict_encode64(credentials.join(':')).chomp}"
+        strict_base64_encoded = [credentials.join(':')].pack("m0")
+        "Basic #{strict_base64_encoded.chomp}"
       end
 
       def self.normalize_name(name)

--- a/spec/acceptance/async_http_client/async_http_client_spec_helper.rb
+++ b/spec/acceptance/async_http_client/async_http_client_spec_helper.rb
@@ -11,7 +11,7 @@ module AsyncHttpClientSpecHelper
       end
     end
     headers.push(
-      ['authorization', 'Basic ' + Base64.strict_encode64(options[:basic_auth].join(':'))]
+      ['authorization', WebMock::Util::Headers.basic_auth_header(options[:basic_auth])]
     ) if options[:basic_auth]
 
     body = options[:body]


### PR DESCRIPTION
Ruby 3.3 shows a warning when using base64 without declaring it in the gemspec. Ruby 3.4 will remove base64 as a default gem.

Since this gem is only using a single method in one place there is no need to pull in the full dependency. It is only a wrapper over `Array#pack`.

Alternative to #1041

Other gems have taken the same/similar approach:
* https://github.com/rubocop/rubocop/pull/12313
* https://github.com/rack/rack/pull/2110
* https://github.com/newrelic/newrelic-ruby-agent/pull/2378
* https://github.com/lostisland/faraday/pull/1541 (pending)