### PR TITLE
Don't use deprecated Rack::VERSION in Rack 3

### DIFF
--- a/lib/webmock/rack_response.rb
+++ b/lib/webmock/rack_response.rb
@@ -47,7 +47,9 @@ module WebMock
       # Rack-specific variables
       env['rack.input']      = StringIO.new(body)
       env['rack.errors']     = $stderr
-      env['rack.version']    = Rack::VERSION
+      if !Rack.const_defined?(:RELEASE) || Rack::RELEASE < "3"
+        env['rack.version']    = Rack::VERSION
+      end
       env['rack.url_scheme'] = uri.scheme
       env['rack.run_once']   = true
       env['rack.session']    = session

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,8 @@ require 'support/webmock_server'
 require 'support/my_rack_app'
 require 'support/failures'
 
+Warning[:deprecated] = true if Warning.respond_to?(:[]=)
+
 CURL_EXAMPLE_OUTPUT_PATH = File.expand_path('../support/example_curl_output.txt', __FILE__)
 
 RSpec.configure do |config|

--- a/spec/support/my_rack_app.rb
+++ b/spec/support/my_rack_app.rb
@@ -37,6 +37,8 @@ class MyRackApp
       when ['GET', '/error']
         env['rack.errors'].puts('Error!')
         [500, {}, ['']]
+      when ['GET', '/env']
+        [200, {}, [JSON.dump(env)]]
       else
         [404, {}, ['']]
     end

--- a/spec/unit/rack_response_spec.rb
+++ b/spec/unit/rack_response_spec.rb
@@ -69,6 +69,20 @@ describe WebMock::RackResponse do
     expect(response.body).to include('Good to meet you, Олег!')
   end
 
+  it "should send or not a rack.version depending on the Rack version" do
+    request = WebMock::RequestSignature.new(:get, 'www.example.com/env')
+    response = @rack_response.evaluate(request)
+
+    expect(response.status.first).to eq(200)
+    body = JSON.parse(response.body)
+
+    if Gem.loaded_specs["rack"].version > Gem::Version.new("3.0.0")
+      expect(body).not_to include("rack.version")
+    else
+      expect(body).to include("rack.version")
+    end
+  end
+
   describe 'rack error output' do
     before :each do
       @original_stderr = $stderr


### PR DESCRIPTION
When I upgraded Rack, I got a few deprecation warnings regarding the usage of `Rack::VERSION` in `lib/webmock/rack_response.rb`.

This conditionally adds the key to the Rack environment, since not only it's [no longer required](https://github.com/rack/rack/blob/v3.0.1/UPGRADE-GUIDE.md#rackversion-is-no-longer-required) but it's also [deprecated](https://github.com/rack/rack/blob/v3.0.1/lib/rack/version.rb#L17).

I also added a commit to enable deprecation warnings by default, it's [not something that RSpec does](https://github.com/rspec/rspec-core/issues/2867) but it can be useful like in this case. Let me know (or just remove that commit) if you'd rather not have that.