### PR TITLE
httpclient_adapter: use uri after filters when building request signature

### DIFF
--- a/lib/webmock/http_lib_adapters/httpclient_adapter.rb
+++ b/lib/webmock/http_lib_adapters/httpclient_adapter.rb
@@ -157,13 +157,13 @@ if defined?(::HTTPClient)
     end
 
     def build_request_signature(req, reuse_existing = false)
-      uri = WebMock::Util::URI.heuristic_parse(req.header.request_uri.to_s)
-      uri.query = WebMock::Util::QueryMapper.values_to_query(req.header.request_query, notation: WebMock::Config.instance.query_values_notation) if req.header.request_query
-      uri.port = req.header.request_uri.port
-
       @request_filter.each do |filter|
         filter.filter_request(req)
       end
+
+      uri = WebMock::Util::URI.heuristic_parse(req.header.request_uri.to_s)
+      uri.query = WebMock::Util::QueryMapper.values_to_query(req.header.request_query, notation: WebMock::Config.instance.query_values_notation) if req.header.request_query
+      uri.port = req.header.request_uri.port
 
       headers = req.header.all.inject({}) do |hdrs, header|
         hdrs[header[0]] ||= []

--- a/spec/acceptance/httpclient/httpclient_spec.rb
+++ b/spec/acceptance/httpclient/httpclient_spec.rb
@@ -102,6 +102,7 @@ describe "HTTPClient" do
     class Filter
       def filter_request(request)
         request.header["Authorization"] = "Bearer 0123456789"
+        request.header.request_uri.query = "webmock=here"
       end
 
       def filter_response(request, response)
@@ -112,7 +113,9 @@ describe "HTTPClient" do
     before do
       @client = HTTPClient.new
       @client.request_filter << Filter.new
-      stub_request(:get, 'www.example.com').with(headers: {'Authorization' => 'Bearer 0123456789'})
+      stub_request(:get, 'www.example.com').with(
+        query: {'webmock' => 'here'},
+        headers: {'Authorization' => 'Bearer 0123456789'})
     end
 
     it "supports request filters" do


### PR DESCRIPTION
If a filter changes the URI (e.g. to enforce a protocol or change the hostname of the request) this is currently unable to be mocked as webmock fetches the URI for the signature of the request before calling the filters!