### PR TITLE
Replace Async::IO::Socket usage with stdlib Socket…

### DIFF
--- a/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
+++ b/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
@@ -152,11 +152,15 @@ if defined?(Async::HTTP)
 
         private
 
+        def socket_class
+          @_socket_class ||= Gem::Dependency.new("async-io").matching_specs.any? ? Async::IO::Socket : Socket
+        end
+
         def create_connected_sockets
           pair = begin
-            Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM)
+            socket_class.pair(Socket::AF_UNIX, Socket::SOCK_STREAM)
           rescue Errno::EAFNOSUPPORT
-            Socket.pair(Socket::AF_INET, Socket::SOCK_STREAM)
+            socket_class.pair(Socket::AF_INET, Socket::SOCK_STREAM)
           end
           pair.tap do |sockets|
             sockets.each do |socket|

--- a/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
+++ b/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
@@ -154,9 +154,9 @@ if defined?(Async::HTTP)
 
         def create_connected_sockets
           pair = begin
-            Async::IO::Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM)
+            Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM)
           rescue Errno::EAFNOSUPPORT
-            Async::IO::Socket.pair(Socket::AF_INET, Socket::SOCK_STREAM)
+            Socket.pair(Socket::AF_INET, Socket::SOCK_STREAM)
           end
           pair.tap do |sockets|
             sockets.each do |socket|

--- a/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
+++ b/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
@@ -153,7 +153,7 @@ if defined?(Async::HTTP)
         private
 
         def socket_class
-          @_socket_class ||= Gem::Dependency.new("async-io").matching_specs.any? ? Async::IO::Socket : Socket
+          defined?(Async::IO::Socket) ? Async::IO::Socket : Socket
         end
 
         def create_connected_sockets

--- a/lib/webmock/version.rb
+++ b/lib/webmock/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebMock
-  VERSION = '3.23.0' unless defined?(::WebMock::VERSION)
+  VERSION = '3.23.1' unless defined?(::WebMock::VERSION)
 end

--- a/spec/acceptance/async_http_client/async_http_client_spec_helper.rb
+++ b/spec/acceptance/async_http_client/async_http_client_spec_helper.rb
@@ -1,3 +1,5 @@
+require "ostruct"
+
 module AsyncHttpClientSpecHelper
   def http_request(method, url, options = {}, &block)
     endpoint = Async::HTTP::Endpoint.parse(url)

--- a/spec/acceptance/async_http_client/async_http_client_spec_helper.rb
+++ b/spec/acceptance/async_http_client/async_http_client_spec_helper.rb
@@ -1,4 +1,4 @@
-require "ostruct"
+require 'ostruct'
 
 module AsyncHttpClientSpecHelper
   def http_request(method, url, options = {}, &block)


### PR DESCRIPTION
…for `async-http` adapter to remove implicit dependency on `async-io`

`async-io` was removed as a dependency from `async-http` in version 0.65.0: https://github.com/socketry/async-http/releases/tag/v0.65.0

fixes: https://github.com/bblimke/webmock/issues/1055