### PR TITLE
Fix `Async::HTTP::WebMockClientWrapper` mock interface

### DIFF
--- a/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
+++ b/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
@@ -35,9 +35,9 @@ if defined?(Async::HTTP)
       class WebMockClientWrapper < Client
         def initialize(
           endpoint,
-          protocol = endpoint.protocol,
-          scheme = endpoint.scheme,
-          authority = endpoint.authority,
+          protocol: endpoint.protocol,
+          scheme: endpoint.scheme,
+          authority: endpoint.authority,
           **options
         )
           webmock_endpoint = WebMockEndpoint.new(scheme, authority, protocol)

--- a/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
+++ b/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
@@ -45,6 +45,7 @@ if defined?(Async::HTTP)
           @network_client = WebMockClient.new(endpoint, **options)
           @webmock_client = WebMockClient.new(webmock_endpoint, **options)
 
+          @endpoint = endpoint
           @scheme = scheme
           @authority = authority
         end

--- a/spec/acceptance/async_http_client/async_http_client_spec.rb
+++ b/spec/acceptance/async_http_client/async_http_client_spec.rb
@@ -289,7 +289,7 @@ unless RUBY_PLATFORM =~ /java/
         subject do
           responses = {}
           Async do |task|
-            Async::HTTP::Client.open(endpoint, protocol) do |client|
+            Async::HTTP::Client.open(endpoint, protocol: protocol) do |client|
               requests_count.times do |index|
                 response = client.get "/foo#{index}"
                 responses[index] = response_to_hash(response)
@@ -316,7 +316,7 @@ unless RUBY_PLATFORM =~ /java/
         subject do
           responses = {}
           Async do |task|
-            Async::HTTP::Client.open(endpoint, protocol) do |client|
+            Async::HTTP::Client.open(endpoint, protocol: protocol) do |client|
               tasks = requests_count.times.map do |index|
                 task.async do
                   response = client.get "/foo#{index}"
@@ -349,7 +349,7 @@ unless RUBY_PLATFORM =~ /java/
         endpoint = Async::HTTP::Endpoint.parse(url)
 
         begin
-          Async::HTTP::Client.open(endpoint, protocol || endpoint.protocol) do |client|
+          Async::HTTP::Client.open(endpoint, protocol: protocol || endpoint.protocol) do |client|
             response = client.send(
               method,
               endpoint.path,


### PR DESCRIPTION
* Changed `Async::HTTP::WebMockClientWrapper#initialize` to use keyword arguments to match [Async::HTTP::Client#initialize](https://socketry.github.io/async-http/source/Async/HTTP/Client/index.html)
* Also initialize `Async::HTTP::WebMockClientWrapper#endpoint` (see #1060).