### PR TITLE
Mock HTTP::Connection#finished_request?

### DIFF
--- a/lib/webmock/http_lib_adapters/http_rb/streamer.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/streamer.rb
@@ -25,6 +25,10 @@ module HTTP
         @io.close
       end
 
+      def finished_request?
+        @io.eof?
+      end
+
       def sequence_id
         -1
       end

--- a/spec/acceptance/http_rb/http_rb_spec.rb
+++ b/spec/acceptance/http_rb/http_rb_spec.rb
@@ -89,6 +89,20 @@ describe "HTTP.rb" do
 
       response.connection.close
     end
+
+    it "reports request finish" do
+      stub_request(:get, "example.com/foo")
+        .to_return(body: 'XX')
+      response = HTTP.get "http://example.com/foo"
+
+      expect(response.connection.finished_request?).to be(false)
+
+      response.body.readpartial(1)
+      expect(response.connection.finished_request?).to be(false)
+
+      response.body.readpartial
+      expect(response.connection.finished_request?).to be(true)
+    end
   end
 
   it "should preserve request body encoding when matching requests" do


### PR DESCRIPTION
Mock [`HTTP::Connection#finished_request?`](https://github.com/httprb/http/blob/b74b16cd55381433627205c90bc126f9b81600ff/lib/http/connection.rb#L139C9-L141) in http.rb.
