### PR TITLE
Ignore parse exceptions

### DIFF
--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -309,6 +309,7 @@ module WebMock
       else
         WebMock::Util::QueryMapper.query_to_values(body, notation: Config.instance.query_values_notation)
       end
+    rescue Psych::SyntaxError, REXML::ParseException
     end
 
     def body_format(content_type)

--- a/spec/unit/request_pattern_spec.rb
+++ b/spec/unit/request_pattern_spec.rb
@@ -562,7 +562,7 @@ describe WebMock::RequestPattern do
             it "should not match when body is not json" do
               expect(WebMock::RequestPattern.new(:post, 'www.example.com', body: body_hash)).
                 not_to match(WebMock::RequestSignature.new(:post, "www.example.com",
-                                                               headers: {content_type: content_type}, body: "foo bar"))
+                                                               headers: {content_type: content_type}, body: "[foo bar"))
             end
 
             it "should not match if request body is different" do
@@ -614,7 +614,7 @@ describe WebMock::RequestPattern do
             it "should not match when body is not xml" do
               expect(WebMock::RequestPattern.new(:post, 'www.example.com', body: body_hash)).
                 not_to match(WebMock::RequestSignature.new(:post, "www.example.com",
-                                                               headers: {content_type: content_type}, body: "foo bar"))
+                                                               headers: {content_type: content_type}, body: "<foo bar"))
                 end
 
             it "matches when the content type include a charset" do


### PR DESCRIPTION
Tests are currently failing in `master` due to a change in the latest version of REXML.

REXML previously accepted some invalid XML (e.g. `foo bar`) but raised on other (`<foo bar`). Since [v3.3.3](https://github.com/ruby/rexml/releases/tag/v3.3.3) it also raises on `foo bar` (see https://github.com/ruby/rexml/pull/184).

Likewise, `WebMock::Util::JSON.parse` accepts some invalid JSON (e.g. `foo bar`) but raises on other (e.g. `[foo bar`).

It seems both matchers should just rescue and ignore parse exceptions.