### PR TITLE
FIX: Ensure Net::HTTP socket type is StubSocket.

### DIFF
--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -123,6 +123,13 @@ module WebMock
           self
         end
 
+        def socket_type_check
+          if Net::HTTP.socket_type == Net::BufferedIO
+            StubSocket.new
+          else
+            Net::HTTP.socket_type.new
+          end
+        end
 
         def ensure_actual_connection
           if @socket.is_a?(StubSocket)

--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -118,16 +118,16 @@ module WebMock
               do_finish
             end
           end
-          @socket = Net::HTTP.socket_type.new
+          @socket = socket_type_check.new
           @started = true
           self
         end
 
         def socket_type_check
           if Net::HTTP.socket_type == Net::BufferedIO
-            StubSocket.new
+            StubSocket
           else
-            Net::HTTP.socket_type.new
+            Net::HTTP.socket_type
           end
         end
 


### PR DESCRIPTION
When running my tests related to opensearch using the searchkick gem I was getting intermittent errors from the Webmock library as seen below. After some debug logging I noticed that `StubSocket` wasn't always the `Net::HTTP.socket_type` as expected. This change ensures the socket_type is always `StubSocket` as opposed to `Net::BufferedIO`.

https://github.com/ankane/searchkick/issues/1692

```ruby
ArgumentError: wrong number of arguments (given 0, expected 1)
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/net-protocol-0.2.2/lib/net/protocol.rb:116:in `initialize'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/webmock-3.23.1/lib/webmock/http_lib_adapters/net_http.rb:121:in `new'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/webmock-3.23.1/lib/webmock/http_lib_adapters/net_http.rb:121:in `start_without_connect'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/webmock-3.23.1/lib/webmock/http_lib_adapters/net_http.rb:153:in `start'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/net-http-persistent-4.0.2/lib/net/http/persistent.rb:662:in `start'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/net-http-persistent-4.0.2/lib/net/http/persistent.rb:867:in `reset'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/net-http-persistent-4.0.2/lib/net/http/persistent.rb:604:in `connection_for'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/net-http-persistent-4.0.2/lib/net/http/persistent.rb:892:in `request'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/faraday-net_http_persistent-2.0.2/lib/faraday/adapter/net_http_persistent.rb:68:in `perform_request'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/faraday-net_http-2.1.0/lib/faraday/adapter/net_http.rb:66:in `block in call'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/faraday-2.0.1/lib/faraday/adapter.rb:45:in `connection'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/faraday-net_http-2.1.0/lib/faraday/adapter/net_http.rb:65:in `call'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/faraday_middleware-aws-sigv4-1.0.1/lib/faraday_middleware/request/aws_sigv4.rb:18:in `call'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/searchkick-5.3.1/lib/searchkick/middleware.rb:16:in `call'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/faraday-2.0.1/lib/faraday/rack_builder.rb:153:in `build_response'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/faraday-2.0.1/lib/faraday/connection.rb:445:in `run_request'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/opensearch-ruby-3.4.0/lib/opensearch/transport/transport/http/faraday.rb:56:in `block in perform_request'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/opensearch-ruby-3.4.0/lib/opensearch/transport/transport/base.rb:297:in `perform_request'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/opensearch-ruby-3.4.0/lib/opensearch/transport/transport/http/faraday.rb:45:in `perform_request'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/opensearch-ruby-3.4.0/lib/opensearch/transport/client.rb:191:in `perform_request'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/opensearch-ruby-3.4.0/lib/opensearch.rb:48:in `method_missing'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/opensearch-ruby-3.4.0/lib/opensearch/api/namespace/common.rb:46:in `perform_request'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/opensearch-ruby-3.4.0/lib/opensearch/api/actions/indices/get_alias.rb:64:in `get_alias'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/searchkick-5.3.1/lib/searchkick/index.rb:111:in `all_indices'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/searchkick-5.3.1/lib/searchkick/index.rb:125:in `clean_indices'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/searchkick-5.3.1/lib/searchkick/index.rb:361:in `full_reindex'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/searchkick-5.3.1/lib/searchkick/index.rb:254:in `reindex'
    /Users/miketaylor/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/searchkick-5.3.1/lib/searchkick/model.rb:77:in `searchkick_reindex'
    test/integration/graphql/searches_test.rb:18:in `execute'
    test/integration/graphql/searches_test.rb:32:in `block in <class:SearchesTest>'

```