### PR TITLE
FEATURE: Allow asserting on requests in tests

### DIFF
--- a/lib/webmock/request_registry.rb
+++ b/lib/webmock/request_registry.rb
@@ -7,25 +7,6 @@ module WebMock
 
     attr_accessor :requested_signatures
 
-    class Request
-      attr_accessor :method, :uri, :headers, :body
-
-      def self.from_webmock_request_signature(request_signature)
-        new(method: request_signature.method, uri: request_signature.uri, headers: request_signature.headers, body: request_signature.body)
-      end
-
-      def initialize(method:, uri:, headers:, body:)
-        @method = method
-        @uri = uri
-        @headers = headers
-        @body = body
-      end
-
-      def parsed_body
-        JSON.parse(body, symbolize_names: true)
-      end
-    end
-
     def initialize
       reset!
     end
@@ -46,8 +27,7 @@ module WebMock
 
     def to_a
       requested_signatures.
-        array.
-        map { |request_signature| Request.from_webmock_request_signature(request_signature) }
+        array
     end
 
     def to_s

--- a/lib/webmock/request_registry.rb
+++ b/lib/webmock/request_registry.rb
@@ -40,8 +40,7 @@ module WebMock
 
     def to_a
       requested_signatures.
-        hash.
-        flat_map { |request_signature, number_of_requests| [request_signature] * number_of_requests }.
+        array.
         map { |request_signature| Request.from_webmock_request_signature(request_signature) }
     end
 

--- a/lib/webmock/request_registry.rb
+++ b/lib/webmock/request_registry.rb
@@ -8,15 +8,16 @@ module WebMock
     attr_accessor :requested_signatures
 
     class Request
-      attr_accessor :method, :uri
+      attr_accessor :method, :uri, :headers
 
       def self.from_webmock_request_signature(request_signature)
-        new(method: request_signature.method, uri: request_signature.uri)
+        new(method: request_signature.method, uri: request_signature.uri, headers: request_signature.headers)
       end
 
-      def initialize(method:, uri:)
+      def initialize(method:, uri:, headers:)
         @method = method
         @uri = uri
+        @headers = headers
       end
     end
 

--- a/lib/webmock/request_registry.rb
+++ b/lib/webmock/request_registry.rb
@@ -8,16 +8,21 @@ module WebMock
     attr_accessor :requested_signatures
 
     class Request
-      attr_accessor :method, :uri, :headers
+      attr_accessor :method, :uri, :headers, :body
 
       def self.from_webmock_request_signature(request_signature)
-        new(method: request_signature.method, uri: request_signature.uri, headers: request_signature.headers)
+        new(method: request_signature.method, uri: request_signature.uri, headers: request_signature.headers, body: request_signature.body)
       end
 
-      def initialize(method:, uri:, headers:)
+      def initialize(method:, uri:, headers:, body:)
         @method = method
         @uri = uri
         @headers = headers
+        @body = body
+      end
+
+      def parsed_body
+        JSON.parse(body, symbolize_names: true)
       end
     end
 

--- a/lib/webmock/request_registry.rb
+++ b/lib/webmock/request_registry.rb
@@ -7,6 +7,19 @@ module WebMock
 
     attr_accessor :requested_signatures
 
+    class Request
+      attr_accessor :method, :uri
+
+      def self.from_webmock_request_signature(request_signature)
+        new(method: request_signature.method, uri: request_signature.uri)
+      end
+
+      def initialize(method:, uri:)
+        @method = method
+        @uri = uri
+      end
+    end
+
     def initialize
       reset!
     end
@@ -19,6 +32,17 @@ module WebMock
       self.requested_signatures.select do |request_signature|
         request_pattern.matches?(request_signature)
       end.inject(0) { |sum, (_, times_executed)| sum + times_executed }
+    end
+
+    def requests_made
+      to_a
+    end
+
+    def to_a
+      requested_signatures.
+        hash.
+        flat_map { |request_signature, number_of_requests| [request_signature] * number_of_requests }.
+        map { |request_signature| Request.from_webmock_request_signature(request_signature) }
     end
 
     def to_s

--- a/lib/webmock/request_signature.rb
+++ b/lib/webmock/request_signature.rb
@@ -44,6 +44,10 @@ module WebMock
       !!(headers&.fetch('Content-Type', nil)&.start_with?('application/json'))
     end
 
+    def parsed_body
+      JSON.parse(body, symbolize_names: true)
+    end
+
     private
 
     def assign_options(options)

--- a/lib/webmock/util/hash_counter.rb
+++ b/lib/webmock/util/hash_counter.rb
@@ -13,19 +13,24 @@ module WebMock
         @max = 0
         @lock = ::Mutex.new
         self.array = []
+        @request_object_ids = {}
       end
 
       def put(key, num=1)
         @lock.synchronize do
-          if hash.key?(key)
-            existing_key = hash.keys.find { |k| k.hash == key.hash }
-            array << existing_key
-          else
-            array << key
-          end
+          store_to_array(key:, num:)
           hash[key] += num
           @order[key] = @max += 1
         end
+      end
+
+      def store_to_array(key:, num:)
+        request_object_id = @request_object_ids[key.hash]
+        request_object_id = key.object_id if request_object_id.nil?
+        num.times do
+          array << ObjectSpace._id2ref(request_object_id)
+        end
+        @request_object_ids[key.hash] = key.object_id
       end
 
       def get(key)

--- a/lib/webmock/util/hash_counter.rb
+++ b/lib/webmock/util/hash_counter.rb
@@ -17,9 +17,14 @@ module WebMock
 
       def put(key, num=1)
         @lock.synchronize do
+          if hash.key?(key)
+            existing_key = hash.keys.find { |k| k.hash == key.hash }
+            array << existing_key
+          else
+            array << key
+          end
           hash[key] += num
           @order[key] = @max += 1
-          array << key
         end
       end
 

--- a/lib/webmock/util/hash_counter.rb
+++ b/lib/webmock/util/hash_counter.rb
@@ -25,14 +25,14 @@ module WebMock
       end
 
       def store_to_array(key:, num:)
-        request_object_id = @request_object_ids[key.hash]
+        request_object_id = @request_object_ids[key]
         request_object_id = key.object_id if request_object_id.nil?
         num.times do
           array << ObjectSpace._id2ref(request_object_id)
         rescue RangeError
           # Points to an invalid or recycled object so ignore
         end
-        @request_object_ids[key.hash] = key.object_id
+        @request_object_ids[key] = key.object_id
       end
 
       def get(key)

--- a/lib/webmock/util/hash_counter.rb
+++ b/lib/webmock/util/hash_counter.rb
@@ -29,6 +29,8 @@ module WebMock
         request_object_id = key.object_id if request_object_id.nil?
         num.times do
           array << ObjectSpace._id2ref(request_object_id)
+        rescue RangeError
+          # Points to an invalid or recycled object so ignore
         end
         @request_object_ids[key.hash] = key.object_id
       end

--- a/lib/webmock/util/hash_counter.rb
+++ b/lib/webmock/util/hash_counter.rb
@@ -5,19 +5,21 @@ require 'thread'
 module WebMock
   module Util
     class HashCounter
-      attr_accessor :hash
+      attr_accessor :hash, :array
 
       def initialize
         self.hash = Hash.new(0)
         @order = {}
         @max = 0
         @lock = ::Mutex.new
+        self.array = []
       end
 
       def put(key, num=1)
         @lock.synchronize do
           hash[key] += num
           @order[key] = @max += 1
+          array << key
         end
       end
 

--- a/spec/unit/request_registry_spec.rb
+++ b/spec/unit/request_registry_spec.rb
@@ -94,13 +94,14 @@ describe WebMock::RequestRegistry do
 
   describe "requests_made" do
     it "returns the requests made" do
-      WebMock::RequestRegistry.instance.requested_signatures.put(WebMock::RequestSignature.new(:get, "www.example.com"))
-      WebMock::RequestRegistry.instance.requested_signatures.put(WebMock::RequestSignature.new(:put, "www.example.org"))
-      expect(WebMock::RequestRegistry.instance.requests_made.count).to eq(2)
-      expect(WebMock::RequestRegistry.instance.requests_made[0].method).to eq(:get)
-      expect(WebMock::RequestRegistry.instance.requests_made[0].uri).to eq(Addressable::URI.parse("http://www.example.com/"))
-      expect(WebMock::RequestRegistry.instance.requests_made[1].method).to eq(:put)
-      expect(WebMock::RequestRegistry.instance.requests_made[1].uri).to eq(Addressable::URI.parse("http://www.example.org/"))
+      request_registry = WebMock::RequestRegistry.instance
+      request_registry.requested_signatures.put(WebMock::RequestSignature.new(:get, "www.example.com"))
+      request_registry.requested_signatures.put(WebMock::RequestSignature.new(:put, "www.example.org"))
+      expect(request_registry.requests_made.count).to eq(2)
+      expect(request_registry.requests_made[0].method).to eq(:get)
+      expect(request_registry.requests_made[0].uri).to eq(Addressable::URI.parse("http://www.example.com/"))
+      expect(request_registry.requests_made[1].method).to eq(:put)
+      expect(request_registry.requests_made[1].uri).to eq(Addressable::URI.parse("http://www.example.org/"))
     end
   end
 end

--- a/spec/unit/request_registry_spec.rb
+++ b/spec/unit/request_registry_spec.rb
@@ -120,6 +120,16 @@ describe WebMock::RequestRegistry do
       expect(request_registry.requests_made[1].object_id).to eq(signature.object_id)
     end
 
+    context "when storing the same signature with a count" do
+      it "adds two references to the signature" do
+        request_registry = WebMock::RequestRegistry.instance
+        signature = WebMock::RequestSignature.new(:get, "www.example.com")
+        request_registry.requested_signatures.put(signature, 2)
+        expect(request_registry.requests_made[0].object_id).to eq(signature.object_id)
+        expect(request_registry.requests_made[1].object_id).to eq(signature.object_id)
+      end
+    end
+
     context "with a JSON request" do
       it "returns the parsed JSON body of the request" do
         request_registry = WebMock::RequestRegistry.instance

--- a/spec/unit/request_registry_spec.rb
+++ b/spec/unit/request_registry_spec.rb
@@ -110,6 +110,16 @@ describe WebMock::RequestRegistry do
       expect(request_registry.requests_made.first.headers).to eq({ 'Content-Type' => 'application/json' })
     end
 
+    it "only stores references to existing signatures" do
+      request_registry = WebMock::RequestRegistry.instance
+      signature = WebMock::RequestSignature.new(:get, "www.example.com")
+      duplicate_signature = WebMock::RequestSignature.new(:get, "www.example.com")
+      request_registry.requested_signatures.put(signature)
+      request_registry.requested_signatures.put(duplicate_signature)
+      expect(request_registry.requests_made[0].object_id).to eq(signature.object_id)
+      expect(request_registry.requests_made[1].object_id).to eq(signature.object_id)
+    end
+
     context "with a JSON request" do
       it "returns the parsed JSON body of the request" do
         request_registry = WebMock::RequestRegistry.instance

--- a/spec/unit/request_registry_spec.rb
+++ b/spec/unit/request_registry_spec.rb
@@ -92,4 +92,15 @@ describe WebMock::RequestRegistry do
     end
   end
 
+  describe "requests_made" do
+    it "should return an array of request signatures" do
+      WebMock::RequestRegistry.instance.requested_signatures.put(WebMock::RequestSignature.new(:get, "www.example.com"))
+      WebMock::RequestRegistry.instance.requested_signatures.put(WebMock::RequestSignature.new(:put, "www.example.org"))
+      expect(WebMock::RequestRegistry.instance.requests_made.count).to eq(2)
+      expect(WebMock::RequestRegistry.instance.requests_made[0].method).to eq(:get)
+      expect(WebMock::RequestRegistry.instance.requests_made[0].uri).to eq(Addressable::URI.parse("http://www.example.com/"))
+      expect(WebMock::RequestRegistry.instance.requests_made[1].method).to eq(:put)
+      expect(WebMock::RequestRegistry.instance.requests_made[1].uri).to eq(Addressable::URI.parse("http://www.example.org/"))
+    end
+  end
 end

--- a/spec/unit/request_registry_spec.rb
+++ b/spec/unit/request_registry_spec.rb
@@ -109,5 +109,35 @@ describe WebMock::RequestRegistry do
       request_registry.requested_signatures.put(WebMock::RequestSignature.new(:get, "www.example.com", headers: { 'Content-Type' => 'application/json' }))
       expect(request_registry.requests_made.first.headers).to eq({ 'Content-Type' => 'application/json' })
     end
+
+    context "with a JSON request" do
+      it "returns the parsed JSON body of the request" do
+        request_registry = WebMock::RequestRegistry.instance
+        request_registry.requested_signatures.put(json_request_with_body(a: 1))
+        expect(request_registry.requests_made.first.body).to eq({ a: 1 }.to_json)
+        expect(request_registry.requests_made.first.parsed_body).to eq(a: 1)
+      end
+
+      context "and invalid JSON in the body" do
+        it "crashes" do
+          request_registry = WebMock::RequestRegistry.instance
+          request_registry.requested_signatures.put(json_request_with_raw_body("{ invalid_json }"))
+          expect(request_registry.requests_made.first.body).to eq("{ invalid_json }")
+          expect do
+            request_registry.requests_made.first.parsed_body
+          end.to raise_error JSON::ParserError
+        end
+      end
+    end
+  end
+
+  private
+
+  def json_request_with_body(body)
+    WebMock::RequestSignature.new(:get, "www.example.com", body: JSON.generate(body))
+  end
+
+  def json_request_with_raw_body(body)
+    WebMock::RequestSignature.new(:get, "www.example.com", body: body)
   end
 end

--- a/spec/unit/request_registry_spec.rb
+++ b/spec/unit/request_registry_spec.rb
@@ -93,7 +93,7 @@ describe WebMock::RequestRegistry do
   end
 
   describe "requests_made" do
-    it "should return an array of request signatures" do
+    it "returns the requests made" do
       WebMock::RequestRegistry.instance.requested_signatures.put(WebMock::RequestSignature.new(:get, "www.example.com"))
       WebMock::RequestRegistry.instance.requested_signatures.put(WebMock::RequestSignature.new(:put, "www.example.org"))
       expect(WebMock::RequestRegistry.instance.requests_made.count).to eq(2)

--- a/spec/unit/request_registry_spec.rb
+++ b/spec/unit/request_registry_spec.rb
@@ -103,5 +103,11 @@ describe WebMock::RequestRegistry do
       expect(request_registry.requests_made[1].method).to eq(:put)
       expect(request_registry.requests_made[1].uri).to eq(Addressable::URI.parse("http://www.example.org/"))
     end
+
+    it "parses the URL of the requests made" do
+      request_registry = WebMock::RequestRegistry.instance
+      request_registry.requested_signatures.put(WebMock::RequestSignature.new(:get, "www.example.com"))
+      expect(request_registry.requests_made.first.uri).to eq(Addressable::URI.parse("http://www.example.com/"))
+    end
   end
 end

--- a/spec/unit/request_registry_spec.rb
+++ b/spec/unit/request_registry_spec.rb
@@ -104,10 +104,10 @@ describe WebMock::RequestRegistry do
       expect(request_registry.requests_made[1].uri).to eq(Addressable::URI.parse("http://www.example.org/"))
     end
 
-    it "parses the URL of the requests made" do
+    it "returns the headers of the request" do
       request_registry = WebMock::RequestRegistry.instance
-      request_registry.requested_signatures.put(WebMock::RequestSignature.new(:get, "www.example.com"))
-      expect(request_registry.requests_made.first.uri).to eq(Addressable::URI.parse("http://www.example.com/"))
+      request_registry.requested_signatures.put(WebMock::RequestSignature.new(:get, "www.example.com", headers: { 'Content-Type' => 'application/json' }))
+      expect(request_registry.requests_made.first.headers).to eq({ 'Content-Type' => 'application/json' })
     end
   end
 end


### PR DESCRIPTION
## Context

@jamesshore has created the concept of ["Testing With Nullables"](https://www.jamesshore.com/v2/projects/nullables/a-light-introduction-to-nullables).

>  I’ve figured out another way. A way that doesn’t use end-to-end tests, doesn’t use mocks, doesn’t ignore infrastructure, doesn’t require a rewrite. It’s something you can start doing today, and it gives you the speed, reliability, and maintainability of unit tests with the power of end-to-end tests.

A small snippet:

```javascript
it("reads command-line argument, transform it with ROT-13, and writes result", () => {
  const { output } = run({ args: [ "my input" ] });
  assert.deepEqual(output.data, [ "zl vachg\n" ];
});

function run({ args = [] } = {}) {
 const commandLine = CommandLine.createNull({ args });
 const output = commandLine.trackOutput();

 const app = new App(commandLine);
 app.run();

 return { output };
}
```

I've been experimenting with these techniques in various codebases and love the code that results.

## Why

This style of assertions, whilst not adhering to James' full pattern, is a thin layer on top of what Webmock is already doing - @jamesshore calls it ["Output Tracking"](https://www.jamesshore.com/v2/projects/nullables/testing-without-mocks#output-tracking)

## Example

Let's say we're doing an API request to Cloudflare to get IP blocking rules.

### Before

```
  it "makes a get request to Cloudflare to get the rules" do
    stub_request(:get, "www.cloudflare.com/api/v2/rules").to_return_json(body: [{...}])
    subject.call
    expect(WebMock).to have_requested(:get, "www.cloudflare.com/api/v2/rules").
      with(query: {"ip" => "2.5.4.3"})
  end
```

**Strengths**

* Leans into the Ruby and RSpec metaprogramming conventions
* Reads like English

**Weaknesses**

* Maintaining a `#have_requested` RSpec matcher means more code
* Custom matchers means writing readable failure messages
* RSpec magic means that if the custom matcher fails it can be difficult to debug

### After

```ruby
  it "makes a get request to Cloudflare to get the rules" do
    stub_request(:get, "www.cloudflare.com/api/v2/rules").to_return_json(body: [{...}])
    subject.call
    expect(requests_made.count).to eq(1)
    expect(requests_made.first.method).to eq(:get)
    expect(requests_made.first.uri.host).to eq("www.cloudflare.com")
    expect(requests_made.first.query).to eq(ip: "2.5.4.3")
  end
```

**Strengths**

* Plain old Ruby
* Works with Minitest with no extra code or magic needed
* Allows asserting on order of requests
* Opens up options for extra helper methods
* Reduces coupling to Webmock - we could use another mocking library, implement `#requests_made` and we'd be good

**Weaknesses**

* `#requests_made` needs a mixin to work
* Can be more verbose (this can be mitigated by writing helper methods)

### After - Cleaner

```ruby
  it "makes a get request to Cloudflare to get the rules" do
    stub_request(:get, "www.cloudflare.com/api/v2/rules").to_return_json(body: [{...}])
    subject.call
    expect(cloudflare_requests_made.count).to eq(1)
    expect(cloudflare_requests_made.first.method).to eq(:get)
    expect(cloudflare_requests_made.first.query).to eq(ip: "2.5.4.3")
  end

  # private method for more readability and resilience
  def cloudflare_requests_made
    requests_made.select { |r| r.uri.host == "www.cloudflare.com" }
  end
```

## How

* Adjust the `HashCounter` class to store requests in an array
* Add some extra methods onto the RequestSignature