### PR TITLE
fix: Support Addressable::URI in request patterns

### DIFF
--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -86,6 +86,8 @@ module WebMock
         URICallablePattern.new(uri)
       elsif uri.is_a?(::URI::Generic)
         URIStringPattern.new(uri.to_s)
+      elsif uri.is_a?(Addressable::URI)
+        URIStringPattern.new(uri)
       elsif uri.is_a?(String)
         URIStringPattern.new(uri)
       else

--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -86,12 +86,10 @@ module WebMock
         URICallablePattern.new(uri)
       elsif uri.is_a?(::URI::Generic)
         URIStringPattern.new(uri.to_s)
-      elsif uri.is_a?(Addressable::URI)
-        URIStringPattern.new(uri)
-      elsif uri.is_a?(String)
-        URIStringPattern.new(uri)
+      elsif uri.respond_to?(:to_str)
+        URIStringPattern.new(uri.to_str)
       else
-        raise ArgumentError.new("URI should be a String, Regexp, Addressable::Template or a callable object. Got: #{uri.class}")
+        raise ArgumentError.new("URI should be a String, Regexp, Addressable::Template, a callable object, or respond to #to_str. Got: #{uri.class}")
       end
     end
   end

--- a/spec/unit/request_pattern_spec.rb
+++ b/spec/unit/request_pattern_spec.rb
@@ -376,6 +376,42 @@ describe WebMock::RequestPattern do
         end
       end
 
+      describe "when uri is described as Addressable::URI" do
+        it "should match request query params" do
+          expect(WebMock::RequestPattern.new(:get, Addressable::URI.parse("www.example.com"), query: {"a" => ["b", "c"]})).
+            to match(WebMock::RequestSignature.new(:get, "www.example.com?a[]=b&a[]=c"))
+        end
+
+        it "should not match request query params if params don't match" do
+          expect(WebMock::RequestPattern.new(:get, Addressable::URI.parse("www.example.com"), query: {"x" => ["b", "c"]})).
+            not_to match(WebMock::RequestSignature.new(:get, "www.example.com?a[]=b&a[]=c"))
+        end
+
+        it "should match when query params are declared as HashIncluding matcher matching params" do
+          expect(WebMock::RequestPattern.new(:get, Addressable::URI.parse("www.example.com"),
+          query: WebMock::Matchers::HashIncludingMatcher.new({"a" => ["b", "c"]}))).
+            to match(WebMock::RequestSignature.new(:get, "www.example.com?a[]=b&a[]=c&b=1"))
+        end
+
+        it "should not match when query params are declared as HashIncluding matcher not matching params" do
+          expect(WebMock::RequestPattern.new(:get, Addressable::URI.parse("www.example.com"),
+          query: WebMock::Matchers::HashIncludingMatcher.new({"x" => ["b", "c"]}))).
+            not_to match(WebMock::RequestSignature.new(:get, "www.example.com?a[]=b&a[]=c&b=1"))
+        end
+
+        it "should match when query params are declared as RSpec HashIncluding matcher matching params" do
+          expect(WebMock::RequestPattern.new(:get, Addressable::URI.parse("www.example.com"),
+          query: RSpec::Mocks::ArgumentMatchers::HashIncludingMatcher.new({"a" => ["b", "c"]}))).
+            to match(WebMock::RequestSignature.new(:get, "www.example.com?a[]=b&a[]=c&b=1"))
+        end
+
+        it "should not match when query params are declared as RSpec HashIncluding matcher not matching params" do
+          expect(WebMock::RequestPattern.new(:get, Addressable::URI.parse("www.example.com"),
+          query: RSpec::Mocks::ArgumentMatchers::HashIncludingMatcher.new({"a" => ["b", "d"]}))).
+            not_to match(WebMock::RequestSignature.new(:get, "www.example.com?a[]=b&a[]=c&b=1"))
+        end
+      end
+
       describe "when uri is described as string" do
         it "should match when query params are the same as declared in hash" do
           expect(WebMock::RequestPattern.new(:get, "www.example.com", query: {"a" => ["b", "c"]})).


### PR DESCRIPTION
As of 3.24.0 release it became impossible to pass Addressable::URI as pattern, while Addressable::Template is still supported. This patch brings back previous behaviour of Addressable::URI.

Regression: f651c254a3a8d75ec3b2bef73bae35979c9ae5fc