### PR TITLE
Fix failing tests on Ruby 3.4 because of hash inspect changes

### DIFF
--- a/spec/unit/matchers/hash_excluding_matcher_spec.rb
+++ b/spec/unit/matchers/hash_excluding_matcher_spec.rb
@@ -12,7 +12,7 @@ module WebMock
       end
 
       it 'describes itself properly' do
-        expect(HashExcludingMatcher.new(a: 1).inspect).to eq 'hash_excluding({"a"=>1})'
+        expect(HashExcludingMatcher.new(a: 1).inspect).to eq "hash_excluding(#{{"a" => 1}.inspect})"
       end
 
       describe 'success' do

--- a/spec/unit/matchers/hash_including_matcher_spec.rb
+++ b/spec/unit/matchers/hash_including_matcher_spec.rb
@@ -14,7 +14,7 @@ module WebMock
       end
 
       it "describes itself properly" do
-        expect(HashIncludingMatcher.new(a: 1).inspect).to eq "hash_including({\"a\"=>1})"
+        expect(HashIncludingMatcher.new(a: 1).inspect).to eq "hash_including(#{{"a"=>1}.inspect})"
       end
 
       describe "success" do

--- a/spec/unit/request_pattern_spec.rb
+++ b/spec/unit/request_pattern_spec.rb
@@ -18,22 +18,25 @@ describe WebMock::RequestPattern do
     end
 
     it "should report string describing itself with query params" do
-      expect(WebMock::RequestPattern.new(:get, /.*example.*/, query: {'a' => ['b', 'c']}).to_s).to eq(
-        "GET /.*example.*/ with query params {\"a\"=>[\"b\", \"c\"]}"
+      query = {'a' => ['b', 'c']}
+      expect(WebMock::RequestPattern.new(:get, /.*example.*/, query: query).to_s).to eq(
+        "GET /.*example.*/ with query params #{query.inspect}"
       )
     end
 
     it "should report string describing itself with query params as hash including matcher" do
+      query = {'a' => ['b', 'c']}
       expect(WebMock::RequestPattern.new(:get, /.*example.*/,
-      query: WebMock::Matchers::HashIncludingMatcher.new({'a' => ['b', 'c']})).to_s).to eq(
-        "GET /.*example.*/ with query params hash_including({\"a\"=>[\"b\", \"c\"]})"
+      query: WebMock::Matchers::HashIncludingMatcher.new(query)).to_s).to eq(
+        "GET /.*example.*/ with query params hash_including(#{query.inspect})"
       )
     end
 
     it "should report string describing itself with body as hash including matcher" do
+      query = {'a' => ['b', 'c']}
       expect(WebMock::RequestPattern.new(:get, /.*example.*/,
-      body: WebMock::Matchers::HashIncludingMatcher.new({'a' => ['b', 'c']})).to_s).to eq(
-        "GET /.*example.*/ with body hash_including({\"a\"=>[\"b\", \"c\"]})"
+      body: WebMock::Matchers::HashIncludingMatcher.new(query)).to_s).to eq(
+        "GET /.*example.*/ with body hash_including(#{query.inspect})"
       )
     end
   end

--- a/spec/unit/request_signature_snippet_spec.rb
+++ b/spec/unit/request_signature_snippet_spec.rb
@@ -47,8 +47,9 @@ RSpec.describe WebMock::RequestSignatureSnippet do
   end
 
   describe "#request_stubs" do
+    let(:body) { {"a" => "b"} }
     before :each do
-      WebMock.stub_request(:get, "https://www.example.com").with(body: {"a" => "b"})
+      WebMock.stub_request(:get, "https://www.example.com").with(body: body)
     end
 
     context "when showing the body diff is turned off" do
@@ -60,7 +61,7 @@ RSpec.describe WebMock::RequestSignatureSnippet do
         result = subject.request_stubs
         result.sub!("registered request stubs:\n\n", "")
         expect(result).to eq(
-          "stub_request(:get, \"https://www.example.com/\").\n  with(\n    body: {\"a\"=>\"b\"})"
+          "stub_request(:get, \"https://www.example.com/\").\n  with(\n    body: #{body.inspect})"
         )
       end
 
@@ -74,7 +75,7 @@ RSpec.describe WebMock::RequestSignatureSnippet do
         result = subject.request_stubs
         result.sub!("registered request stubs:\n\n", "")
         expect(result).to eq(
-          "stub_request(:get, \"https://www.example.com/\").\n  with(\n    body: {\"a\"=>\"b\"})\n\nBody diff:\n [[\"-\", \"key\", \"different value\"], [\"+\", \"a\", \"b\"]]\n"
+          "stub_request(:get, \"https://www.example.com/\").\n  with(\n    body: #{body.inspect})\n\nBody diff:\n [[\"-\", \"key\", \"different value\"], [\"+\", \"a\", \"b\"]]\n"
         )
       end
     end

--- a/spec/unit/stub_request_snippet_spec.rb
+++ b/spec/unit/stub_request_snippet_spec.rb
@@ -69,7 +69,7 @@ describe WebMock::StubRequestSnippet do
         expected = <<-STUB
 stub_request(:post, "http://www.example.com/").
   with(
-    body: {"user"=>{"first_name"=>"Bartosz"}},
+    body: #{{"user"=>{"first_name"=>"Bartosz"}}.inspect},
     headers: {
 \t  'Content-Type'=>'application/x-www-form-urlencoded'
     }).


### PR DESCRIPTION
Ruby has changed the output of `Hash.inspect`, causing some test failures.

Instead of hardcoding it, just call inspect itself to pass tests on old and new rubies

Ref:
* https://github.com/ruby/ruby/pull/10924
* https://bugs.ruby-lang.org/issues/20433

Note that I still have some failing tests like this:
```
1) Excon with WebMock when after_request callback is declared should invoke callbacks only for real requests if requested
     Failure/Error: response = Excon.new(uri, excon_options.merge(nonblock: false)).request(options, &block)
     
     Excon::Error::Socket:
       undefined method 'casecmp' for nil (NoMethodError)
     Shared Example Group: "callbacks" called from ./spec/acceptance/webmock_shared.rb:43
     Shared Example Group: "with WebMock" called from ./spec/acceptance/excon/excon_spec.rb:7
     # ./spec/acceptance/excon/excon_spec_helper.rb:22:in 'ExconSpecHelper#http_request'
     # ./spec/acceptance/shared/callbacks.rb:136:in 'block (3 levels) in <top (required)>'
     # ./spec/acceptance/webmock_shared.rb:26:in 'block (3 levels) in <top (required)>'
     # ./lib/webmock/rspec.rb:39:in 'block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # NoMethodError:
     #   undefined method 'casecmp' for nil
     #   ./spec/acceptance/excon/excon_spec_helper.rb:22:in 'ExconSpecHelper#http_request'

Finished in 0.67789 seconds (files took 0.81427 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/acceptance/excon/excon_spec.rb[1:1:10:9] # Excon with WebMock when after_request callback is declared should invoke callbacks only for real requests if requested
```

I have not looked into those yet. I did notice that excon very recently released 1.0.0, maybe it's related to that.