### PR TITLE
call .to_s on passed body

### DIFF
--- a/lib/webmock/util/query_mapper.rb
+++ b/lib/webmock/util/query_mapper.rb
@@ -41,7 +41,7 @@ module WebMock::Util
       #   #=> [['one', 'two'], ['one', 'three']]
       def query_to_values(query, options={})
         return nil if query.nil?
-        query = query.dup.force_encoding('utf-8') if query.respond_to?(:force_encoding)
+        query = query.to_s.dup.force_encoding('utf-8') if query.respond_to?(:force_encoding)
 
         options[:notation] ||= :subscript
 


### PR DESCRIPTION
👋 ,

I'm the maintainer of httpx, an http library which maintains an adapter for webmock. Recently, [an issue](https://gitlab.com/os85/httpx/-/issues/317) was reported about multipart requests failing when the webmock adapter is turned on (webmock does not support matching multipart payloads, that was an "allowed" request). I patched it by [delegating `==`, used in the assertion functions, to the raw body](https://gitlab.com/os85/httpx/-/merge_requests/351/diffs), instead of expanding the request signature into a string. 

Once I released it, I [got](https://gitlab.com/os85/httpx/-/issues/319) [two](https://github.com/HoneyryderChuck/httpx/issues/65) new issues, as that patch broke their integrations. I narrowed it down to webmock expecting the body of the request signature to be a string. 

This is probably a reasonable assumption, considering that this code is quite old, but then again most adapters are maintained in repo, so perhaps this expectation has been forced in the adapters instead. Nevertheless, I'd propose that, instead of forcing client request bodies to delegate all methods to the underlying string (if there is one), `webmock` instead converts it to a string, and then applies its logic. 

LMK what you think. I still have to find a reasonable patch on my side to work around this issue for older versions of webmock, so this forward patch is not really a blocker.