### PR TITLE
Avoid escaping Excon query string values

### DIFF
--- a/lib/webmock/http_lib_adapters/excon_adapter.rb
+++ b/lib/webmock/http_lib_adapters/excon_adapter.rb
@@ -9,6 +9,8 @@ end
 if defined?(Excon)
   WebMock::VersionChecker.new('Excon', Excon::VERSION, '0.27.5').check_version!
 
+  EXCON_1_1_1_OR_LATER = Gem::Version.new(Excon::VERSION) >= Gem::Version.new('1.1.1')
+
   module WebMock
     module HttpLibAdapters
 
@@ -100,7 +102,7 @@ if defined?(Excon)
               string << key.to_s << '&'
             else
               for value in [*values]
-                string << key.to_s << '=' << CGI.escape(value.to_s) << '&'
+                string << key.to_s << '=' << (EXCON_1_1_1_OR_LATER ? value.to_s : CGI.escape(value.to_s)) << '&'
               end
             end
           end


### PR DESCRIPTION
Excon released a change in [version 1.1.1](https://rubygems.org/gems/excon/versions/1.1.1) where query string values are no longer being unescaped. (See excon/excon#869 for context.)

This means that the `CGI.escape` in the adapter may double-escape values.

For example, a request to `https://example.com/search?q=bob%40example.com` will require a stub for `https://example.com/search?q=bob%2540example.com`.

## Reproduction

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'excon', '= 1.1.1'
  gem 'webmock'
end

WebMock.enable!

WebMock.stub_request(:get, 'https://example.com/search?q=bob@example.com')
  .to_return(status: 200)

Excon.get("https://example.com/search?q=#{URI.encode_uri_component('bob@example.com')}")
```

Executing this code will raise the following exception:

```
~/.gem/ruby/3.3.5/gems/webmock-3.24.0/lib/webmock/http_lib_adapters/excon_adapter.rb:70:in `handle_request': Real HTTP connections are disabled. Unregistered request: GET https://example.com/search?q=bob%2540example.com with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'deflate, gzip', 'Host'=>'example.com', 'User-Agent'=>'excon/1.1.1'} (WebMock::NetConnectNotAllowedError)

You can stub this request with the following snippet:

stub_request(:get, "https://example.com/search?q=bob%2540example.com").
  with(
    headers: {
          'Accept'=>'*/*',
          'Accept-Encoding'=>'deflate, gzip',
          'Host'=>'example.com',
          'User-Agent'=>'excon/1.1.1'
    }).
  to_return(status: 200, body: "", headers: {})

registered request stubs:

stub_request(:get, "https://example.com/search?q=bob@example.com")
```

Downgrading the Excon version constraint from `= 1.1.1` to `= 1.1.0` or pointing `gem 'webmock'` at a path containing this pull request's change will let it pass.