### PR TITLE
Fix FrozenError in Typhoeus streaming response body

### DIFF
--- a/lib/webmock/http_lib_adapters/typhoeus_hydra_adapter.rb
+++ b/lib/webmock/http_lib_adapters/typhoeus_hydra_adapter.rb
@@ -172,7 +172,7 @@ if defined?(Typhoeus)
                 request.execute_headers_callbacks(response)
               end
               if request.respond_to?(:streaming?) && request.streaming?
-                response.options[:response_body] = ""
+                response.options[:response_body] = "".dup
                 request.on_body.each { |callback| callback.call(webmock_response.body, response) }
               end
               request.finish(response)

--- a/spec/acceptance/typhoeus/typhoeus_hydra_spec.rb
+++ b/spec/acceptance/typhoeus/typhoeus_hydra_spec.rb
@@ -125,6 +125,19 @@ unless RUBY_PLATFORM =~ /java/
           expect(test_complete).to eq("")
         end
 
+        it "should initialize the streaming response body with a mutible (non-frozen) string" do
+          skip("This test requires a newer version of Typhoeus") unless @request.respond_to?(:on_body)
+
+          stub_request(:any, "example.com").to_return(body: "body")
+
+          @request.on_body do |body_chunk, response|
+            response.body << body_chunk
+          end
+          hydra.queue @request
+
+          expect{ hydra.run }.not_to raise_error
+        end
+
         it "should call on_headers with 2xx response" do
           body = "on_headers fired"
           stub_request(:any, "example.com").to_return(body: body, headers: {'X-Test' => '1'})


### PR DESCRIPTION
When stubbing a response for the Typhoeus adapter, and the Typhoeus request has an `on_body` callback, a `FrozenError` exception is raised when attempting to concatenate the current chunk of the response to the existing response body (i.e. `response.body << chunk`).

FWIW, my use case for this is to abort a request as early as possible when the response body exceeds a given size, specifically when the response doesn't have a `Content-Length` header.

The example below illustrates the issue:

```ruby
require "bundler/inline"

gemfile do
  source "https://rubygems.org"

  gem "typhoeus", "1.4.1"
  gem "webmock", "3.24.0"
end

WebMock.enable!
WebMock.stub_request(:get, "https://example.com").to_return(status: "200", body: "body")

request = Typhoeus::Request.new("https://example.com")

request.on_body do |chunk, response|
  response.body << chunk
end

request.run
```

This change initializes the Typhoeus response body to a non-frozen, mutable string when using the `on_body` callback.