### PR TITLE
Make version checker optional with env variable WEBMOCK_CHECK_VERSION

### DIFF
--- a/lib/webmock/util/version_checker.rb
+++ b/lib/webmock/util/version_checker.rb
@@ -43,6 +43,7 @@ module WebMock
     end
 
     def check_version!
+      return unless ENV['WEBMOCK_CHECK_VERSION'] == "1"
       warn_about_too_low if too_low?
       warn_about_too_high if too_high?
       warn_about_unsupported_version if unsupported_version?


### PR DESCRIPTION
Since version numbers seem to be not up to date and not actively maintained, I suggest making the version checker optional with this commit.