### PR TITLE
fix: Unexpected default rack.session

### DIFF
--- a/lib/webmock/rack_response.rb
+++ b/lib/webmock/rack_response.rb
@@ -52,22 +52,12 @@ module WebMock
       end
       env['rack.url_scheme'] = uri.scheme
       env['rack.run_once']   = true
-      env['rack.session']    = session
-      env['rack.session.options'] = session_options
 
       headers.each do |k, v|
         env["HTTP_#{k.tr('-','_').upcase}"] = v
       end
 
       env
-    end
-
-    def session
-      @session ||= {}
-    end
-
-    def session_options
-      @session_options ||= {}
     end
   end
 end

--- a/spec/unit/rack_response_spec.rb
+++ b/spec/unit/rack_response_spec.rb
@@ -82,6 +82,17 @@ describe WebMock::RackResponse do
     end
   end
 
+  it "shouldn't set a rack.session" do
+    request = WebMock::RequestSignature.new(:get, 'www.example.com/env')
+    response = @rack_response.evaluate(request)
+
+    expect(response.status.first).to eq(200)
+    body = JSON.parse(response.body)
+
+    expect(body).not_to include("rack.session")
+    expect(body).not_to include("rack.session.options")
+  end
+
   describe 'rack error output' do
     before :each do
       @original_stderr = $stderr


### PR DESCRIPTION
Some rack applications fail when the `rack.session` is already initialized, but with an unexpected value. For example, in a Rails API-only application, unexpected behavior is triggered when a `rack.session` is present.

This PR changes webmock, not to set a `rack.session` at all, similar to how web servers do not set a session. The application or a middleware sets them up if needed.

Fixes #985