### PR TITLE
Revert "Fix included modules on Ruby 3.4"

### DIFF
--- a/lib/webmock/http_lib_adapters/httpclient_adapter.rb
+++ b/lib/webmock/http_lib_adapters/httpclient_adapter.rb
@@ -230,18 +230,18 @@ if defined?(::HTTPClient)
   end
 
   class WebMockHTTPClient < HTTPClient
-    include WebMockHTTPClients
-
     alias_method :do_get_block_without_webmock, :do_get_block
     alias_method :do_get_stream_without_webmock, :do_get_stream
+
+    include WebMockHTTPClients
   end
 
   if defined? ::JSONClient
     class WebMockJSONClient < JSONClient
-      include WebMockHTTPClients
-
       alias_method :do_get_block_without_webmock, :do_get_block
       alias_method :do_get_stream_without_webmock, :do_get_stream
+
+      include WebMockHTTPClients
     end
   end
 


### PR DESCRIPTION
This reverts commit c228536883c67514a62af03ddfd437d1e0a5d5d8 in #1091.

Since the CI is failing, the changes must ensure that the CI passes.