### PR TITLE
Suspend JRuby CI matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,9 @@ jobs:
           - '3.0'
           - '2.7'
           - '2.6'
-          - jruby-head
+          # FIXME: When the JRuby issue https://github.com/jruby/jruby/issues/8606 is resolved,
+          # please re-run it with the following:
+          # - jruby-head
     continue-on-error: ${{ matrix.ruby == 'head' || matrix.ruby == 'jruby-head' }}
     name: Ruby ${{ matrix.ruby }}
     env:


### PR DESCRIPTION
This PR suspends JRuby CI matrix:

The issue has been reported at jruby/jruby#8606.
https://github.com/bblimke/webmock/actions/runs/13170199216/job/36759013080

The JRuby CI matrix has been failing for a long time, so pining to a version like JRuby 9.4.10.0 will not avoid the error. Since the issue is likely complex and not easy to resolve, it would be better to test with a version released after the resolution of jruby/jruby#8606.
