### PR TITLE
Fix a build error for Ruby 3.5 CI matrix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,13 @@ source 'https://rubygems.org/'
 
 gemspec
 
+# FIXME: This is a workaround to resolve the following error in Ruby 3.5:
+#
+# /home/runner/work/webmock/webmock/vendor/bundle/ruby/3.5.0+0/gems/ethon-0.16.0/lib/ethon.rb:2:
+# warning: logger was loaded from the standard library, but is not part of the default gems starting from Ruby 3.5.0.
+#
+# It can likely be removed once `ethon`, which is a dependency of `typhoeus`, manages its `logger` dependency.
+gem 'logger'
 gem 'ostruct'
 gem 'rake'
 


### PR DESCRIPTION
This is a workaround to resolve the following error in Ruby 3.5:

```console
/home/runner/work/webmock/webmock/vendor/bundle/ruby/3.5.0+0/gems/ethon-0.16.0/lib/ethon.rb:2:
warning: logger was loaded from the standard library, but is not part of the default gems starting from Ruby 3.5.0.

It can likely be removed once `ethon`, which is a dependency of `typhoeus`, manages its `logger` dependency.
```

https://github.com/bblimke/webmock/actions/runs/13170758361/job/36760571749