### PR TITLE
Add `ostruct` gem to Gemfile to prevent an error in development with Ruby 3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org/'
 
 gemspec
 
+gem 'ostruct'
 gem 'rake'
 
 platforms :jruby do


### PR DESCRIPTION
This PR adds `ostruct` gem to Gemfile to fix the following Ruby 3.5 CI build error:

```console
An error occurred while loading ./spec/acceptance/typhoeus/typhoeus_hydra_spec.rb. - Did you mean?
                    rspec ./spec/acceptance/typhoeus/typhoeus_hydra_spec_helper.rb

Failure/Error: require 'ostruct'

LoadError:
  cannot load such file -- ostruct
# ./spec/acceptance/typhoeus/typhoeus_hydra_spec_helper.rb:1:in '<top (required)>'
# ./spec/acceptance/typhoeus/typhoeus_hydra_spec.rb:5:in '<top (required)>'
```

https://github.com/bblimke/webmock/actions/runs/13171078861/job/36761473227?pr=1097

Avoiding the use of `OpenStruct` is certainly an option, but since this module is only used in tests, the simplest solution has been chosen.