### PR TITLE
Add :any parameter for query options

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,14 @@ Net::HTTP.get('www.example.com',
   '/thing/5.json?x=1&y=2&z=3&anyParam=4')    # ===> Success
 ```
 
+### Allow query params
+
+```ruby
+stub_request(:get, "www.example.com").with(query: :any)
+
+RestClient.get("http://www.example.com/?q=example")    # ===> Success
+```
+
 ### Matching query params using hash
 
 ```ruby

--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -128,6 +128,8 @@ module WebMock
     def add_query_params(query_params)
       @query_params = if query_params.is_a?(Hash)
         query_params
+      elsif query_params == :any
+        WebMock::Matchers::AnyArgMatcher.new(nil)
       elsif query_params.is_a?(WebMock::Matchers::HashIncludingMatcher) \
               || query_params.is_a?(WebMock::Matchers::HashExcludingMatcher)
         query_params

--- a/spec/acceptance/shared/request_expectations.rb
+++ b/spec/acceptance/shared/request_expectations.rb
@@ -179,6 +179,13 @@ shared_context "request expectations" do |*adapter_info|
             expect(a_request(:get, "www.example.com").with(query: hash_including(a: []))).to have_been_made
           }.not_to raise_error
         end
+
+        it "should satisfy expectation if the request was executed with query params declared as :any" do
+          expect {
+            http_request(:get, "http://www.example.com/?x=3&b=1")
+            expect(a_request(:get, "www.example.com").with(query: :any)).to have_been_made
+          }.not_to raise_error
+        end
       end
 
       context "when using flat array notation" do


### PR DESCRIPTION
Implements and closes #877!

Implementation was very straightforward, the only doubt I had was the first parameter to `AnyArgMatcher`. I'm not sure if the `nil` argument is necessary, since we explicitly ignore it. Feels like it would be better to make initialize allow a default value of nil. 