### PR TITLE
Return support for `em_http_request`

### DIFF
--- a/lib/webmock/http_lib_adapters/em_http_request_adapter.rb
+++ b/lib/webmock/http_lib_adapters/em_http_request_adapter.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-return if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
-
 begin
   require 'em-http-request'
 rescue LoadError

--- a/spec/acceptance/em_http_request/em_http_request_spec.rb
+++ b/spec/acceptance/em_http_request/em_http_request_spec.rb
@@ -8,10 +8,6 @@ unless RUBY_PLATFORM =~ /java/
   describe "EM::HttpRequest" do
     include EMHttpRequestSpecHelper
 
-    before(:all) do
-      skip 'em-http-request is not supported on Ruby >= 3.4' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
-    end
-
     include_context "with WebMock", :no_status_message
 
     #functionality only supported for em-http-request 1.x

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'rubygems'
 require 'httpclient'
 unless RUBY_PLATFORM =~ /java/
   require 'curb'
+  require 'em-http'
   require 'patron'
   require 'typhoeus'
 end
@@ -49,4 +50,3 @@ RSpec.configure do |config|
 
   config.include Failures
 end
-


### PR DESCRIPTION
In version 3.24.0 support for `em_http_request` was dropped due to:
> The current version of em-http-request (1.1.7) is incompatible with Ruby 3.4 due to an unresolved issue (https://github.com/igrigorik/em-http-request/pull/365). Support for em-http-request will be re-enabled once the compatibility issue is resolved.

The problem was addressed in https://github.com/igrigorik/em-http-request/issues/354 and now cookiejar supports ruby 3.3+, it was added in [this commit](https://github.com/dwaite/cookiejar/commit/36332870693334ad9fb51dbfebc398b46bb1427a).

Therefore I'm returning back support for `em_http_request` which was disabled in https://github.com/bblimke/webmock/pull/1070