### PR TITLE
Run CI against Ruby 4.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,7 @@ jobs:
         ruby:
           # TODO: curb fails on ruby-head. Re-enable ruby-head once fixed.
           # - head
+          - '4.0'
           - '3.4'
           - '3.3'
           - '3.2'

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Supported Ruby Interpreters
 * MRI 3.2
 * MRI 3.3
 * MRI 3.4
+* MRI 4.0
 * JRuby
 
 ## Installation


### PR DESCRIPTION
This PR adds Ruby 4.0 to the CI matrix.