### PR TITLE
Remove `--pride` option from Minitest Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,6 @@ end
 
 Rake::TestTask.new(:minitest) do |test|
   test.test_files = FileList["minitest/**/*.rb"].exclude("test/test_helper.rb")
-  test.options = "--pride"
   test.verbose = false
   test.warning = false
 end


### PR DESCRIPTION
The `--pride` option passed via `Rake::TestTask#options` is not recognized by the Minitest CLI runner. This causes "invalid option: --pride" error on Ruby 3.2+ where Minitest 6 processes command-line arguments differently.