### PR TITLE
Temporarily disable ruby-head in the CI matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - head
+          # TODO: curb fails on ruby-head. Re-enable ruby-head once fixed.
+          # - head
           - '3.4'
           - '3.3'
           - '3.2'


### PR DESCRIPTION
This PR temporarily disables ruby-head (head) in the CI matrix due to the following CI failure when testing with curb:

```console
/__w/webmock/webmock/vendor/bundle/ruby/4.1.0+0/gems/io-stream-0.11.1/lib/io/stream/buffered.rb:112:
warning: IO::Buffer is experimental and both the Ruby and C interface may change in the future!
/home/runner/.rubies/ruby-head/bin/ruby: symbol lookup error:
/__w/webmock/webmock/vendor/bundle/ruby/4.1.0+0/gems/curb-1.2.2/lib/curb_core.so: undefined symbol: rb_iterate
/home/runner/.rubies/ruby-head/bin/ruby -I/__w/webmock/webmock/vendor/bundle/ruby/4.1.0+0/gems/rspec-core-3.13.6/lib:
/__w/webmock/webmock/vendor/bundle/ruby/4.1.0+0/gems/rspec-support-3.13.6/lib
/__w/webmock/webmock/vendor/bundle/ruby/4.1.0+0/gems/rspec-core-3.13.6/exe/rspec --pattern spec/\*\*/\*_spec.rb
--force-color --format progress --require ./spec/spec_helper.rb failed
```

https://github.com/bblimke/webmock/actions/runs/20910050923/job/60071029196
