### PR TITLE
Temporarily disable jruby-head in the CI matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,8 @@ jobs:
           - '3.0'
           - '2.7'
           - '2.6'
-          - jruby-head
+          # TODO: llhttp-ffi fails to install on jruby-head. Re-enable jruby-head once fixed.
+          # - jruby-head
     continue-on-error: ${{ matrix.ruby == 'head' || matrix.ruby == 'jruby-head' }}
     name: Ruby ${{ matrix.ruby }}
     env:


### PR DESCRIPTION
This PR temporarily disables jruby-head in the CI matrix due to the following CI failure when installing llhttp-ffi:

```console
Installing llhttp-ffi 0.5.1 with native extensions
      org.snakeyaml:snakeyaml-engine:2.10:compile
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
/__w/webmock/webmock/vendor/bundle/jruby/3.4.0/gems/llhttp-ffi-0.5.1/ext
/home/runner/.rubies/jruby-head/bin/jruby -rrubygems
/__w/webmock/webmock/vendor/bundle/jruby/3.4.0/gems/rake-13.3.1/exe/rake
RUBYARCHDIR\=/__w/webmock/webmock/vendor/bundle/jruby/3.4.0/extensions/universal-java/3.4.0/llhttp-ffi-0.5.1
RUBYLIBDIR\=/__w/webmock/webmock/vendor/bundle/jruby/3.4.0/extensions/universal-java/3.4.0/llhttp-ffi-0.5.1
rake aborted!
```

https://github.com/bblimke/webmock/actions/runs/20910050923/job/60071029160