### PR TITLE
[fix] CurbAdapter alias `code` from `response_code`

### DIFF
--- a/lib/webmock/http_lib_adapters/curb_adapter.rb
+++ b/lib/webmock/http_lib_adapters/curb_adapter.rb
@@ -313,6 +313,7 @@ if defined?(Curl)
       def response_code
         @response_code ||= super
       end
+      alias code response_code
 
       def header_str
         @header_str ||= super

--- a/spec/acceptance/curb/curb_spec.rb
+++ b/spec/acceptance/curb/curb_spec.rb
@@ -373,6 +373,15 @@ unless RUBY_PLATFORM =~ /java/
         expect(c.body).to eq("abc")
       end
 
+      it "should alias code to response_code" do
+        stub_request(:get, "www.example.com").to_return(status: 456)
+
+        c = Curl::Easy.new
+        c.url = "http://www.example.com"
+        c.http(:GET)
+        expect(c.code).to eq(456)
+      end
+
       it "supports array headers passed to Curl::Easy" do
         stub_request(:get, "www.example.com").with(headers: {'X-One' => '1'}).to_return(body: "abc")
 


### PR DESCRIPTION
  * similar to body_str -> body and others there

one of the central APIs of Curb::Easy is `#code`, README (of curb project) mentions in first example there I tried to use it with webmock and failed miserable until I found out it misses over here.