### PR TITLE
Add HTTP.rb v6.0.0 compatibility to http_rb adapter

### DIFF
--- a/lib/webmock/http_lib_adapters/http_rb/response.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/response.rb
@@ -28,9 +28,6 @@ module HTTP
         headers = webmock_response.headers || {}
         uri     = normalize_uri(request_signature && request_signature.uri)
 
-        # HTTP.rb 3.0+ uses a keyword argument to pass the encoding, but 1.x
-        # and 2.x use a positional argument, and 0.x don't support supplying
-        # the encoding.
         body = build_http_rb_response_body_from_webmock_response(webmock_response)
 
         return new(status, "1.1", headers, body, uri) if HTTP::VERSION < "1.0.0"
@@ -44,6 +41,17 @@ module HTTP
             body: body,
             uri: uri
           })
+        end
+
+        # 6.0.0 changed Response.new from a positional hash to keyword arguments.
+        if HTTP::VERSION >= '6.0.0'
+          return new(
+            status: status,
+            version: "1.1",
+            headers: headers,
+            body: body,
+            request: request,
+          )
         end
 
         new({

--- a/lib/webmock/http_lib_adapters/http_rb/streamer.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/streamer.rb
@@ -10,15 +10,22 @@ module HTTP
 
       def readpartial(size = nil, outbuf = nil)
         unless size
-          if defined?(HTTP::Client::BUFFER_SIZE)
-            size = HTTP::Client::BUFFER_SIZE
-          elsif defined?(HTTP::Connection::BUFFER_SIZE)
+          if defined?(HTTP::Connection::BUFFER_SIZE)
             size = HTTP::Connection::BUFFER_SIZE
+          elsif defined?(HTTP::Client::BUFFER_SIZE)
+            size = HTTP::Client::BUFFER_SIZE
           end
         end
 
-        chunk = @io.read size, outbuf
-        chunk.force_encoding(@encoding) if chunk
+        chunk = @io.read(size, outbuf)
+
+        # HTTP.rb 6.0+ expects EOFError at end-of-stream instead of nil
+        if chunk.nil?
+          raise EOFError if HTTP::VERSION >= "6.0.0"
+          return nil
+        end
+
+        chunk.force_encoding(@encoding)
       end
 
       def close

--- a/lib/webmock/http_lib_adapters/http_rb/webmock.rb
+++ b/lib/webmock/http_lib_adapters/http_rb/webmock.rb
@@ -43,7 +43,10 @@ module HTTP
       invoke_callbacks(webmock_response, real_request: false)
       response = ::HTTP::Response.from_webmock @request, webmock_response, request_signature
 
-      @options.features.each { |_name, feature| response = feature.wrap_response(response) }
+      # HTTP.rb 6.0+ wraps responses in reverse feature order
+      features = @options.features.values
+      features = features.reverse if HTTP::VERSION >= "6.0.0"
+      features.each { |feature| response = feature.wrap_response(response) }
       response
     end
 

--- a/spec/acceptance/http_rb/http_rb_spec_helper.rb
+++ b/spec/acceptance/http_rb/http_rb_spec_helper.rb
@@ -11,7 +11,7 @@ module HttpRbSpecHelper
     ssl_ctx = OpenSSL::SSL::SSLContext.new
     ssl_ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
-    response = chain.request(method, normalize_uri(uri), options.merge(ssl_context: ssl_ctx))
+    response = chain.request(method, normalize_uri(uri), **options.merge(ssl_context: ssl_ctx))
 
     OpenStruct.new({
       body: response.body.to_s,


### PR DESCRIPTION
HTTP.rb 6.0.0 was just released with [several breaking changes](https://github.com/httprb/http/blob/main/CHANGELOG.md#600---2026-03-16) that affect the WebMock adapter:
* HTTP verb methods require keyword arguments
* `Response.new` takes keyword arguments
* `Stream#readpartial` raises `EOFError` at EOF instead of returning `nil`
* Features are wrapped in reverse order during response building

All these fixes are compatible back to v0.8, the minimum supported version in the gemspec.