### PR TITLE
Expose Async::HTTP::Client#pool for async-websocket (and puppeteer-ruby) compatibility

### DIFF
--- a/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
+++ b/lib/webmock/http_lib_adapters/async_http_client_adapter.rb
@@ -92,6 +92,21 @@ if defined?(Async::HTTP)
           @webmock_client.close
         end
 
+        # WebMock doesn't mock connection pools. If your code
+        # accesses the pool directly, you must add the URL to WebMock's allowlist.
+        # This patch is here because puppeteer-ruby -> async-websocket uses (client).pool.acquire
+        # $(bundle show async-websocket)/lib/async/websocket/client.rb:109
+        def pool
+          # WebMock's URI parser doesn't understand ws://, so we map it to http:// for the check
+          check_scheme = @scheme.to_s.sub(/^ws/, "http")
+          uri = WebMock::Util::URI.normalize_uri("#{check_scheme}://#{@authority}/")
+          if WebMock.net_connect_allowed?(uri)
+            @network_client.pool
+          else
+            raise WebMock::NetConnectNotAllowedError.new(WebMock::RequestSignature.new(:get, uri))
+          end
+        end
+
         private
 
         def build_request_signature(request)


### PR DESCRIPTION
Really this PR tries to allow puppeteer-ruby to connect to the browser via websocket. It happens to use `Async::HTTP::Client` that webmock patches for that, but uses pool directly, acquires connection from it and runs the request on it.

Code that I'm trying to run is essentially
```
Puppeteer.launch(headless: true, args: ["--no-sandbox"]) do |browser|
  page = browser.pages.first || browser.new_page
  page.goto("http://google.com", wait_until: "networkidle0")
end
```

with `puppeteer-ruby (0.51.0)`

This is a PoC to see if people who know way more than me say if it's a webmock or async-websocket problem at all. If it's the right place, I'll add test and cleanup comments somewhat. 

Thanks! 