### PR TITLE
Add proxy matching to adapters that support it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Features
 
 * Stubbing HTTP requests at low http client lib level (no need to change tests when you change HTTP library)
 * Setting and verifying expectations on HTTP requests
-* Matching requests based on method, URI, headers and body
+* Matching requests based on method, URI, headers, body and proxy
 * Smart matching of the same URIs in different representations (also encoded and non encoded forms)
 * Smart matching of the same headers in different representations.
 * Support for Test::Unit
@@ -212,6 +212,35 @@ req['Accept'] = ['image/png']
 req.add_field('Accept', 'image/jpeg')
 Net::HTTP.start("www.example.com") {|http| http.request(req) }    # ===> Success
 ```
+
+### Matching requests based on proxy
+
+```ruby
+stub_request(:get, "www.example.com").
+  with(proxy: { "host" => "proxy.example.com", "port" => 8080 })
+
+http = Net::HTTP.new("www.example.com", 80, "proxy.example.com", 8080)
+http.start { |h| h.get("/") }    # ===> Success
+```
+
+Proxy pattern supports Hash (partial matching), String (URI comparison), and Regexp:
+
+```ruby
+# Match by proxy URI string
+stub_request(:get, "www.example.com").
+  with(proxy: "http://proxy.example.com:8080")
+
+# Match by proxy URI regexp
+stub_request(:get, "www.example.com").
+  with(proxy: /proxy\.example/)
+
+# Match requests with no proxy
+stub_request(:get, "www.example.com").
+  with(proxy: nil)
+```
+
+Proxy matching is supported by Net::HTTP, Curb, Excon, Patron, and Typhoeus.
+Other adapters do not extract proxy information and will always have a nil proxy.
 
 ### Matching requests against provided block
 
@@ -796,6 +825,7 @@ An executed request matches stubbed request if it passes following criteria:
 - And request method is the same as stubbed request method or stubbed request method is :any
 - And request body is the same as stubbed request body or stubbed request body is not specified
 - And request headers match stubbed request headers, or stubbed request headers match a subset of request headers, or stubbed request headers are not specified
+- And request proxy matches stubbed request proxy pattern (Hash, String, Regexp, or nil), or stubbed request proxy is not specified
 - And request matches provided block or block is not provided
 
 ## Precedence of stubs

--- a/lib/webmock/http_lib_adapters/curb_adapter.rb
+++ b/lib/webmock/http_lib_adapters/curb_adapter.rb
@@ -122,9 +122,23 @@ if defined?(Curl)
           method,
           uri.to_s,
           body: request_body,
-          headers: headers
+          headers: headers,
+          proxy: proxy_from_curb
         )
         request_signature
+      end
+
+      def proxy_from_curb
+        return nil unless self.proxy_url
+        proxy_uri = URI.parse(self.proxy_url)
+        proxy = {
+          "host" => proxy_uri.host,
+          "port" => proxy_uri.port
+        }
+        proxy["username"] = proxy_uri.user if proxy_uri.user
+        proxy["password"] = proxy_uri.password if proxy_uri.password
+        proxy["scheme"] = proxy_uri.scheme if proxy_uri.scheme && proxy_uri.scheme != "http"
+        proxy
       end
 
       def headers_as_hash(headers)

--- a/lib/webmock/http_lib_adapters/excon_adapter.rb
+++ b/lib/webmock/http_lib_adapters/excon_adapter.rb
@@ -111,10 +111,35 @@ if defined?(Excon)
           params = params.dup
           params.delete(:user)
           params.delete(:password)
+          proxy = proxy_from_excon(params.delete(:proxy))
           method  = (params.delete(:method) || :get).to_s.downcase.to_sym
           params[:query] = to_query(params[:query]) if params[:query].is_a?(Hash)
           uri = Addressable::URI.new(params).to_s
-          WebMock::RequestSignature.new method, uri, body: body_from(params), headers: params[:headers]
+          WebMock::RequestSignature.new method, uri, body: body_from(params), headers: params[:headers], proxy: proxy
+        end
+
+        def self.proxy_from_excon(proxy_data)
+          return nil if proxy_data.nil?
+          if proxy_data.is_a?(String)
+            proxy_uri = URI.parse(proxy_data)
+            proxy = {
+              "host" => proxy_uri.host,
+              "port" => proxy_uri.port
+            }
+            proxy["username"] = proxy_uri.user if proxy_uri.user
+            proxy["password"] = proxy_uri.password if proxy_uri.password
+            proxy["scheme"] = proxy_uri.scheme if proxy_uri.scheme && proxy_uri.scheme != "http"
+            proxy
+          elsif proxy_data.is_a?(Hash)
+            proxy = {
+              "host" => proxy_data[:host],
+              "port" => proxy_data[:port]
+            }
+            proxy["username"] = proxy_data[:user] if proxy_data[:user]
+            proxy["password"] = proxy_data[:password] if proxy_data[:password]
+            proxy["scheme"] = proxy_data[:scheme] if proxy_data[:scheme] && proxy_data[:scheme] != "http"
+            proxy
+          end
         end
 
         def self.body_from(params)

--- a/lib/webmock/http_lib_adapters/net_http.rb
+++ b/lib/webmock/http_lib_adapters/net_http.rb
@@ -282,7 +282,18 @@ module WebMock
         request.set_body_internal body
       end
 
-      WebMock::RequestSignature.new(method, uri, body: request.body, headers: headers)
+      WebMock::RequestSignature.new(method, uri, body: request.body, headers: headers, proxy: proxy_from_net_http(net_http))
+    end
+
+    def self.proxy_from_net_http(net_http)
+      return nil unless net_http.proxy_address
+      proxy = {
+        "host" => net_http.proxy_address,
+        "port" => net_http.proxy_port
+      }
+      proxy["username"] = net_http.proxy_user if net_http.proxy_user
+      proxy["password"] = net_http.proxy_pass if net_http.proxy_pass
+      proxy
     end
 
     def self.get_uri(net_http, path = nil)

--- a/lib/webmock/http_lib_adapters/patron_adapter.rb
+++ b/lib/webmock/http_lib_adapters/patron_adapter.rb
@@ -94,9 +94,23 @@ if defined?(::Patron::Session)
             req.action,
             uri.to_s,
             body: request_body,
-            headers: headers
+            headers: headers,
+            proxy: proxy_from_patron(req)
           )
           request_signature
+        end
+
+        def self.proxy_from_patron(req)
+          return nil unless req.proxy && !req.proxy.empty?
+          proxy_uri = URI.parse(req.proxy)
+          proxy = {
+            "host" => proxy_uri.host,
+            "port" => proxy_uri.port
+          }
+          proxy["username"] = proxy_uri.user if proxy_uri.user
+          proxy["password"] = proxy_uri.password if proxy_uri.password
+          proxy["scheme"] = proxy_uri.scheme if proxy_uri.scheme && proxy_uri.scheme != "http"
+          proxy
         end
 
         def self.build_patron_response(webmock_response, default_response_charset)

--- a/lib/webmock/http_lib_adapters/typhoeus_hydra_adapter.rb
+++ b/lib/webmock/http_lib_adapters/typhoeus_hydra_adapter.rb
@@ -72,7 +72,8 @@ if defined?(Typhoeus)
             req.options[:method] || :get,
             uri.to_s,
             body: body,
-            headers: headers
+            headers: headers,
+            proxy: proxy_from_typhoeus(req)
           )
 
           req.instance_variable_set(:@__webmock_request_signature, request_signature)
@@ -80,6 +81,22 @@ if defined?(Typhoeus)
           request_signature
         end
 
+        def self.proxy_from_typhoeus(req)
+          proxy_url = req.options[:proxy]
+          return nil unless proxy_url && !proxy_url.empty?
+          proxy_uri = URI.parse(proxy_url)
+          proxy = {
+            "host" => proxy_uri.host,
+            "port" => proxy_uri.port
+          }
+          if req.options[:proxyuserpwd]
+            user, pass = req.options[:proxyuserpwd].split(":", 2)
+            proxy["username"] = user if user
+            proxy["password"] = pass if pass
+          end
+          proxy["scheme"] = proxy_uri.scheme if proxy_uri.scheme && proxy_uri.scheme != "http"
+          proxy
+        end
 
         def self.build_webmock_response(typhoeus_response)
           webmock_response = WebMock::Response.new

--- a/lib/webmock/request_pattern.rb
+++ b/lib/webmock/request_pattern.rb
@@ -14,13 +14,14 @@ module WebMock
 
   class RequestPattern
 
-    attr_reader :method_pattern, :uri_pattern, :body_pattern, :headers_pattern
+    attr_reader :method_pattern, :uri_pattern, :body_pattern, :headers_pattern, :proxy_pattern
 
     def initialize(method, uri, options = {})
       @method_pattern  = MethodPattern.new(method)
       @uri_pattern     = create_uri_pattern(uri)
       @body_pattern    = nil
       @headers_pattern = nil
+      @proxy_pattern   = nil
       @with_block      = nil
       assign_options(options)
     end
@@ -39,6 +40,7 @@ module WebMock
         @uri_pattern.matches?(request_signature.uri) &&
         (@body_pattern.nil? || @body_pattern.matches?(request_signature.body, content_type || "")) &&
         (@headers_pattern.nil? || @headers_pattern.matches?(request_signature.headers)) &&
+        (@proxy_pattern.nil? || @proxy_pattern.matches?(request_signature.proxy)) &&
         (@with_block.nil? || @with_block.call(request_signature))
     end
 
@@ -47,6 +49,7 @@ module WebMock
       string << " #{@uri_pattern.to_s}"
       string << " with body #{@body_pattern.to_s}" if @body_pattern
       string << " with headers #{@headers_pattern.to_s}" if @headers_pattern
+      string << " with proxy #{@proxy_pattern.to_s}" if @proxy_pattern
       string << " with given block" if @with_block
       string
     end
@@ -56,10 +59,11 @@ module WebMock
 
     def assign_options(options)
       options = WebMock::Util::HashKeysStringifier.stringify_keys!(options, deep: true)
-      HashValidator.new(options).validate_keys('body', 'headers', 'query', 'basic_auth')
+      HashValidator.new(options).validate_keys('body', 'headers', 'query', 'basic_auth', 'proxy')
       set_basic_auth_as_headers!(options)
       @body_pattern = BodyPattern.new(options['body']) if options.has_key?('body')
       @headers_pattern = HeadersPattern.new(options['headers']) if options.has_key?('headers')
+      @proxy_pattern = ProxyPattern.new(options['proxy']) if options.has_key?('proxy')
       @uri_pattern.add_query_params(options['query']) if options.has_key?('query')
     end
 
@@ -422,6 +426,48 @@ module WebMock
 
     def empty_headers?(headers)
       headers.nil? || headers == {}
+    end
+  end
+
+  class ProxyPattern
+    def initialize(pattern)
+      @pattern = pattern
+    end
+
+    def matches?(proxy)
+      case @pattern
+      when Hash
+        return false if proxy.nil?
+        normalized = normalize_keys(@pattern)
+        normalized.all? { |key, value| value === proxy[key] }
+      when String
+        proxy_to_uri_string(proxy) == @pattern
+      when Regexp
+        @pattern =~ proxy_to_uri_string(proxy).to_s
+      when NilClass
+        proxy.nil?
+      else
+        @pattern === proxy
+      end
+    end
+
+    def to_s
+      @pattern.inspect
+    end
+
+    private
+
+    def normalize_keys(hash)
+      hash.each_with_object({}) { |(k, v), h| h[k.to_s] = v }
+    end
+
+    def proxy_to_uri_string(proxy)
+      return nil if proxy.nil?
+      scheme = proxy["scheme"] || "http"
+      host = proxy["host"]
+      port = proxy["port"]
+      return nil unless host
+      port ? "#{scheme}://#{host}:#{port}" : "#{scheme}://#{host}"
     end
   end
 

--- a/lib/webmock/request_signature.rb
+++ b/lib/webmock/request_signature.rb
@@ -4,7 +4,7 @@ module WebMock
 
   class RequestSignature
 
-    attr_accessor :method, :uri, :body
+    attr_accessor :method, :uri, :body, :proxy
     attr_reader :headers
 
     def initialize(method, uri, options = {})
@@ -19,6 +19,9 @@ module WebMock
       string << " with body '#{body.to_s}'" if body && body.to_s != ''
       if headers && !headers.empty?
         string << " with headers #{WebMock::Util::Headers.sorted_headers_string(headers)}"
+      end
+      if proxy && !proxy.empty?
+        string << " with proxy #{proxy.inspect}"
       end
       string
     end
@@ -49,6 +52,7 @@ module WebMock
     def assign_options(options)
       self.body = options[:body] if options.has_key?(:body)
       self.headers = options[:headers] if options.has_key?(:headers)
+      self.proxy = options[:proxy] if options.has_key?(:proxy)
     end
 
   end

--- a/lib/webmock/request_stub.rb
+++ b/lib/webmock/request_stub.rb
@@ -128,6 +128,9 @@ module WebMock
       if (signature.headers && !signature.headers.empty?)
         stub.with(headers: signature.headers)
       end
+      if (signature.proxy && !signature.proxy.empty?)
+        stub.with(proxy: signature.proxy)
+      end
       stub
     end
   end

--- a/lib/webmock/stub_request_snippet.rb
+++ b/lib/webmock/stub_request_snippet.rb
@@ -26,6 +26,12 @@ module WebMock
 
         with << "\n    headers: #{request_pattern.headers_pattern.pp_to_s}"
       end
+
+      if (request_pattern.proxy_pattern)
+        with << "," unless with.empty?
+
+        with << "\n    proxy: #{request_pattern.proxy_pattern.to_s}"
+      end
       string << ".\n  with(#{with})" unless with.empty?
       if with_response
         if request_pattern.headers_pattern && request_pattern.headers_pattern.matches?({ 'Accept' => "application/json" })

--- a/spec/acceptance/curb/curb_spec.rb
+++ b/spec/acceptance/curb/curb_spec.rb
@@ -544,4 +544,51 @@ unless RUBY_PLATFORM =~ /java/
       end
     end
   end
+
+  describe "proxy matching" do
+    before(:each) do
+      WebMock.disable_net_connect!
+      WebMock.reset!
+    end
+
+    it "should match request with correct proxy" do
+      stub_request(:get, "www.example.com").with(
+        proxy: {"host" => "proxy.example.com", "port" => 8080}
+      ).to_return(body: "proxied")
+
+      curl = Curl::Easy.new("http://www.example.com/")
+      curl.proxy_url = "http://proxy.example.com:8080"
+      curl.http_get
+      expect(curl.body_str).to eq("proxied")
+    end
+
+    it "should not match request with wrong proxy" do
+      stub_request(:get, "www.example.com").with(
+        proxy: {"host" => "other-proxy.example.com", "port" => 8080}
+      )
+
+      curl = Curl::Easy.new("http://www.example.com/")
+      curl.proxy_url = "http://proxy.example.com:8080"
+      expect {
+        curl.http_get
+      }.to raise_error(WebMock::NetConnectNotAllowedError)
+    end
+
+    it "should match request without proxy when proxy pattern is nil" do
+      stub_request(:get, "www.example.com").with(proxy: nil).to_return(body: "direct")
+
+      curl = Curl::Easy.new("http://www.example.com/")
+      curl.http_get
+      expect(curl.body_str).to eq("direct")
+    end
+
+    it "should match request with proxy when no proxy pattern is specified" do
+      stub_request(:get, "www.example.com").to_return(body: "any")
+
+      curl = Curl::Easy.new("http://www.example.com/")
+      curl.proxy_url = "http://proxy.example.com:8080"
+      curl.http_get
+      expect(curl.body_str).to eq("any")
+    end
+  end
 end

--- a/spec/acceptance/excon/excon_spec.rb
+++ b/spec/acceptance/excon/excon_spec.rb
@@ -74,4 +74,44 @@ describe "Excon" do
 
   end
 
+  describe "proxy matching" do
+    before(:each) do
+      WebMock.disable_net_connect!
+      WebMock.reset!
+    end
+
+    it "should match request with correct proxy" do
+      stub_request(:get, "http://example.com/").with(
+        proxy: {"host" => "proxy.example.com", "port" => 8080}
+      ).to_return(body: "proxied")
+
+      response = Excon.new("http://example.com", proxy: "http://proxy.example.com:8080").get
+      expect(response.body).to eq("proxied")
+    end
+
+    it "should not match request with wrong proxy" do
+      stub_request(:get, "http://example.com/").with(
+        proxy: {"host" => "other-proxy.example.com", "port" => 8080}
+      )
+
+      expect {
+        Excon.new("http://example.com", proxy: "http://proxy.example.com:8080").get
+      }.to raise_error(WebMock::NetConnectNotAllowedError)
+    end
+
+    it "should match request without proxy when proxy pattern is nil" do
+      stub_request(:get, "http://example.com/").with(proxy: nil).to_return(body: "direct")
+
+      response = Excon.new("http://example.com").get
+      expect(response.body).to eq("direct")
+    end
+
+    it "should match request with proxy when no proxy pattern is specified" do
+      stub_request(:get, "http://example.com/").to_return(body: "any")
+
+      response = Excon.new("http://example.com", proxy: "http://proxy.example.com:8080").get
+      expect(response.body).to eq("any")
+    end
+  end
+
 end

--- a/spec/acceptance/net_http/net_http_spec.rb
+++ b/spec/acceptance/net_http/net_http_spec.rb
@@ -380,6 +380,96 @@ describe "Net:HTTP" do
     end
   end
 
+  describe "proxy matching" do
+    before(:each) do
+      WebMock.disable_net_connect!
+      WebMock.reset!
+    end
+
+    it "should match request with correct proxy" do
+      stub_request(:get, "www.example.com").with(
+        proxy: {"host" => "proxy.example.com", "port" => 8080}
+      ).to_return(body: "proxied")
+
+      http = Net::HTTP.new("www.example.com", 80, "proxy.example.com", 8080)
+      response = http.start { |h| h.get("/") }
+      expect(response.body).to eq("proxied")
+    end
+
+    it "should not match request with wrong proxy" do
+      stub_request(:get, "www.example.com").with(
+        proxy: {"host" => "other-proxy.example.com", "port" => 8080}
+      )
+
+      http = Net::HTTP.new("www.example.com", 80, "proxy.example.com", 8080)
+      expect {
+        http.start { |h| h.get("/") }
+      }.to raise_error(WebMock::NetConnectNotAllowedError)
+    end
+
+    it "should match request without proxy when proxy pattern is nil" do
+      stub_request(:get, "www.example.com").with(proxy: nil).to_return(body: "direct")
+
+      http = Net::HTTP.new("www.example.com", 80)
+      response = http.start { |h| h.get("/") }
+      expect(response.body).to eq("direct")
+    end
+
+    it "should not match request with proxy when proxy pattern is nil" do
+      stub_request(:get, "www.example.com").with(proxy: nil)
+
+      http = Net::HTTP.new("www.example.com", 80, "proxy.example.com", 8080)
+      expect {
+        http.start { |h| h.get("/") }
+      }.to raise_error(WebMock::NetConnectNotAllowedError)
+    end
+
+    it "should match request with proxy when no proxy pattern is specified" do
+      stub_request(:get, "www.example.com").to_return(body: "any")
+
+      http = Net::HTTP.new("www.example.com", 80, "proxy.example.com", 8080)
+      response = http.start { |h| h.get("/") }
+      expect(response.body).to eq("any")
+    end
+
+    it "should match proxy with string pattern" do
+      stub_request(:get, "www.example.com").with(
+        proxy: "http://proxy.example.com:8080"
+      ).to_return(body: "matched")
+
+      http = Net::HTTP.new("www.example.com", 80, "proxy.example.com", 8080)
+      response = http.start { |h| h.get("/") }
+      expect(response.body).to eq("matched")
+    end
+
+    it "should match proxy with regexp pattern" do
+      stub_request(:get, "www.example.com").with(
+        proxy: /proxy\.example/
+      ).to_return(body: "matched")
+
+      http = Net::HTTP.new("www.example.com", 80, "proxy.example.com", 8080)
+      response = http.start { |h| h.get("/") }
+      expect(response.body).to eq("matched")
+    end
+
+    it "should include proxy info in error message for unregistered request" do
+      http = Net::HTTP.new("www.example.com", 80, "proxy.example.com", 8080)
+      expect {
+        http.start { |h| h.get("/") }
+      }.to raise_error(WebMock::NetConnectNotAllowedError, /proxy.example.com/)
+    end
+
+    it "should capture proxy username and password" do
+      stub_request(:get, "www.example.com").with(
+        proxy: {"host" => "proxy.example.com", "port" => 8080, "username" => "user", "password" => "pass"}
+      ).to_return(body: "authed_proxy")
+
+      http = Net::HTTP.new("www.example.com", 80, "proxy.example.com", 8080, "user", "pass")
+      response = http.start { |h| h.get("/") }
+      expect(response.body).to eq("authed_proxy")
+    end
+  end
+
   describe "hostname handling" do
     it "should set brackets around the hostname if it is an IPv6 address" do
       net_http = Net::HTTP.new('b2dc:5bdf:4f0d::3014:e0ca', 80)

--- a/spec/acceptance/patron/patron_spec.rb
+++ b/spec/acceptance/patron/patron_spec.rb
@@ -115,5 +115,64 @@ unless RUBY_PLATFORM =~ /java/
         end
       end
     end
+
+    describe "proxy matching" do
+      before(:each) do
+        WebMock.disable_net_connect!
+        WebMock.reset!
+      end
+
+      it "should match request with correct proxy" do
+        stub_request(:get, "www.example.com").with(
+          proxy: {"host" => "proxy.example.com", "port" => 8080}
+        ).to_return(body: "proxied")
+
+        sess = Patron::Session.new
+        sess.base_url = "http://www.example.com"
+        sess.proxy = "http://proxy.example.com:8080"
+        sess.timeout = 10
+        sess.connect_timeout = 10
+        response = sess.get("/")
+        expect(response.body).to eq("proxied")
+      end
+
+      it "should not match request with wrong proxy" do
+        stub_request(:get, "www.example.com").with(
+          proxy: {"host" => "other-proxy.example.com", "port" => 8080}
+        )
+
+        sess = Patron::Session.new
+        sess.base_url = "http://www.example.com"
+        sess.proxy = "http://proxy.example.com:8080"
+        sess.timeout = 10
+        sess.connect_timeout = 10
+        expect {
+          sess.get("/")
+        }.to raise_error(WebMock::NetConnectNotAllowedError)
+      end
+
+      it "should match request without proxy when proxy pattern is nil" do
+        stub_request(:get, "www.example.com").with(proxy: nil).to_return(body: "direct")
+
+        sess = Patron::Session.new
+        sess.base_url = "http://www.example.com"
+        sess.timeout = 10
+        sess.connect_timeout = 10
+        response = sess.get("/")
+        expect(response.body).to eq("direct")
+      end
+
+      it "should match request with proxy when no proxy pattern is specified" do
+        stub_request(:get, "www.example.com").to_return(body: "any")
+
+        sess = Patron::Session.new
+        sess.base_url = "http://www.example.com"
+        sess.proxy = "http://proxy.example.com:8080"
+        sess.timeout = 10
+        sess.connect_timeout = 10
+        response = sess.get("/")
+        expect(response.body).to eq("any")
+      end
+    end
   end
 end

--- a/spec/acceptance/typhoeus/typhoeus_hydra_spec.rb
+++ b/spec/acceptance/typhoeus/typhoeus_hydra_spec.rb
@@ -153,5 +153,40 @@ unless RUBY_PLATFORM =~ /java/
         end
       end
     end
+
+    describe "proxy matching" do
+      it "should match request with correct proxy" do
+        stub_request(:get, "www.example.com").with(
+          proxy: {"host" => "proxy.example.com", "port" => 8080}
+        ).to_return(body: "proxied")
+
+        response = Typhoeus.get("http://www.example.com", proxy: "http://proxy.example.com:8080")
+        expect(response.body).to eq("proxied")
+      end
+
+      it "should not match request with wrong proxy" do
+        stub_request(:get, "www.example.com").with(
+          proxy: {"host" => "other-proxy.example.com", "port" => 8080}
+        )
+
+        expect {
+          Typhoeus.get("http://www.example.com", proxy: "http://proxy.example.com:8080")
+        }.to raise_error(WebMock::NetConnectNotAllowedError)
+      end
+
+      it "should match request without proxy when proxy pattern is nil" do
+        stub_request(:get, "www.example.com").with(proxy: nil).to_return(body: "direct")
+
+        response = Typhoeus.get("http://www.example.com")
+        expect(response.body).to eq("direct")
+      end
+
+      it "should match request with proxy when no proxy pattern is specified" do
+        stub_request(:get, "www.example.com").to_return(body: "any")
+
+        response = Typhoeus.get("http://www.example.com", proxy: "http://proxy.example.com:8080")
+        expect(response.body).to eq("any")
+      end
+    end
   end
 end

--- a/spec/unit/request_pattern_spec.rb
+++ b/spec/unit/request_pattern_spec.rb
@@ -36,6 +36,13 @@ describe WebMock::RequestPattern do
         "GET /.*example.*/ with body hash_including(#{{"a" => ["b", "c"]}})"
       )
     end
+
+    it "should report string describing itself with proxy" do
+      expect(WebMock::RequestPattern.new(:get, "www.example.com",
+      proxy: {"host" => "proxy.example.com", "port" => 8080}).to_s).to eq(
+        "GET http://www.example.com/ with proxy #{{"host" => "proxy.example.com", "port" => 8080}.inspect}"
+      )
+    end
   end
 
   describe "with" do
@@ -53,8 +60,13 @@ describe WebMock::RequestPattern do
       expect(@request_pattern.to_s).to eq(WebMock::RequestPattern.new(:get, "www.example.com", headers: {'A' => 'a'}).to_s)
     end
 
+    it "should have assigned proxy pattern" do
+      @request_pattern.with(proxy: {"host" => "proxy.example.com", "port" => 8080})
+      expect(@request_pattern.to_s).to eq(WebMock::RequestPattern.new(:get, "www.example.com", proxy: {"host" => "proxy.example.com", "port" => 8080}).to_s)
+    end
+
     it "should raise an error if options passed to `with` are invalid" do
-      expect { @request_pattern.with(foo: "bar") }.to raise_error('Unknown key: "foo". Valid keys are: "body", "headers", "query", "basic_auth"')
+      expect { @request_pattern.with(foo: "bar") }.to raise_error('Unknown key: "foo". Valid keys are: "body", "headers", "query", "basic_auth", "proxy"')
     end
 
     it "should raise an error if neither options or block is provided" do
@@ -784,6 +796,83 @@ describe WebMock::RequestPattern do
       signature = WebMock::RequestSignature.new(:get, "www.example.com")
       expect(WebMock::RequestPattern.new(:get, "www.example.com").with { |request| request == signature }).
         to match(signature)
+    end
+
+    describe "when proxy pattern" do
+      it "should match when proxy hash matches exactly" do
+        proxy = {"host" => "proxy.example.com", "port" => 8080}
+        expect(WebMock::RequestPattern.new(:get, "www.example.com", proxy: {"host" => "proxy.example.com", "port" => 8080})).
+          to match(WebMock::RequestSignature.new(:get, "www.example.com", proxy: proxy))
+      end
+
+      it "should match when proxy pattern is a subset of request proxy" do
+        proxy = {"host" => "proxy.example.com", "port" => 8080, "username" => "user"}
+        expect(WebMock::RequestPattern.new(:get, "www.example.com", proxy: {"host" => "proxy.example.com"})).
+          to match(WebMock::RequestSignature.new(:get, "www.example.com", proxy: proxy))
+      end
+
+      it "should not match when proxy hash does not match" do
+        proxy = {"host" => "other-proxy.example.com", "port" => 8080}
+        expect(WebMock::RequestPattern.new(:get, "www.example.com", proxy: {"host" => "proxy.example.com", "port" => 8080})).
+          not_to match(WebMock::RequestSignature.new(:get, "www.example.com", proxy: proxy))
+      end
+
+      it "should not match hash pattern when request has no proxy" do
+        expect(WebMock::RequestPattern.new(:get, "www.example.com", proxy: {"host" => "proxy.example.com"})).
+          not_to match(WebMock::RequestSignature.new(:get, "www.example.com"))
+      end
+
+      it "should match when proxy pattern is a string matching the proxy URI" do
+        proxy = {"host" => "proxy.example.com", "port" => 8080}
+        expect(WebMock::RequestPattern.new(:get, "www.example.com", proxy: "http://proxy.example.com:8080")).
+          to match(WebMock::RequestSignature.new(:get, "www.example.com", proxy: proxy))
+      end
+
+      it "should not match when proxy pattern is a string not matching the proxy URI" do
+        proxy = {"host" => "proxy.example.com", "port" => 8080}
+        expect(WebMock::RequestPattern.new(:get, "www.example.com", proxy: "http://other-proxy.example.com:8080")).
+          not_to match(WebMock::RequestSignature.new(:get, "www.example.com", proxy: proxy))
+      end
+
+      it "should match when proxy pattern is a regexp matching the proxy URI" do
+        proxy = {"host" => "proxy.example.com", "port" => 8080}
+        expect(WebMock::RequestPattern.new(:get, "www.example.com", proxy: /proxy\.example/)).
+          to match(WebMock::RequestSignature.new(:get, "www.example.com", proxy: proxy))
+      end
+
+      it "should not match when proxy pattern is a regexp not matching the proxy URI" do
+        proxy = {"host" => "proxy.example.com", "port" => 8080}
+        expect(WebMock::RequestPattern.new(:get, "www.example.com", proxy: /other-proxy/)).
+          not_to match(WebMock::RequestSignature.new(:get, "www.example.com", proxy: proxy))
+      end
+
+      it "should match when proxy pattern is nil and request has no proxy" do
+        expect(WebMock::RequestPattern.new(:get, "www.example.com", proxy: nil)).
+          to match(WebMock::RequestSignature.new(:get, "www.example.com"))
+      end
+
+      it "should not match when proxy pattern is nil but request has a proxy" do
+        proxy = {"host" => "proxy.example.com", "port" => 8080}
+        expect(WebMock::RequestPattern.new(:get, "www.example.com", proxy: nil)).
+          not_to match(WebMock::RequestSignature.new(:get, "www.example.com", proxy: proxy))
+      end
+
+      it "should match any request when no proxy pattern is specified" do
+        proxy = {"host" => "proxy.example.com", "port" => 8080}
+        expect(WebMock::RequestPattern.new(:get, "www.example.com")).
+          to match(WebMock::RequestSignature.new(:get, "www.example.com", proxy: proxy))
+      end
+
+      it "should match request without proxy when no proxy pattern is specified" do
+        expect(WebMock::RequestPattern.new(:get, "www.example.com")).
+          to match(WebMock::RequestSignature.new(:get, "www.example.com"))
+      end
+
+      it "should match when proxy pattern uses symbol keys" do
+        proxy = {"host" => "proxy.example.com", "port" => 8080}
+        expect(WebMock::RequestPattern.new(:get, "www.example.com", proxy: {host: "proxy.example.com", port: 8080})).
+          to match(WebMock::RequestSignature.new(:get, "www.example.com", proxy: proxy))
+      end
     end
 
   end

--- a/spec/unit/request_signature_spec.rb
+++ b/spec/unit/request_signature_spec.rb
@@ -28,6 +28,15 @@ describe WebMock::RequestSignature do
       expect(WebMock::RequestSignature.new(:get, "www.example.com", body: "abc").body).to eq("abc")
     end
 
+    it "assigns proxy" do
+      proxy = {"host" => "proxy.example.com", "port" => 8080}
+      expect(WebMock::RequestSignature.new(:get, "www.example.com", proxy: proxy).proxy).to eq(proxy)
+    end
+
+    it "leaves proxy nil when not provided" do
+      expect(WebMock::RequestSignature.new(:get, "www.example.com").proxy).to be_nil
+    end
+
     it "symbolizes the method" do
       expect(WebMock::RequestSignature.new('get', "www.example.com", body: "abc").method).to eq(:get)
     end
@@ -39,6 +48,17 @@ describe WebMock::RequestSignature do
         body: "abc", headers: {'A' => 'a', 'B' => 'b'}).to_s).to eq(
       "GET http://www.example.com/ with body 'abc' with headers {'A'=>'a', 'B'=>'b'}"
       )
+    end
+
+    it "includes proxy info when present" do
+      proxy = {"host" => "proxy.example.com", "port" => 8080}
+      expect(WebMock::RequestSignature.new(:get, "www.example.com", proxy: proxy).to_s).to eq(
+        "GET http://www.example.com/ with proxy #{proxy.inspect}"
+      )
+    end
+
+    it "does not include proxy info when nil" do
+      expect(WebMock::RequestSignature.new(:get, "www.example.com").to_s).not_to include("proxy")
     end
   end
 
@@ -75,6 +95,21 @@ describe WebMock::RequestSignature do
       signature2 = WebMock::RequestSignature.new(:get, "www.example.com",
         headers: {'A' => 'A'})
       expect(signature1.hash).not_to eq(signature2.hash)
+    end
+
+    it "reports different hash for two signatures with different proxy" do
+      signature1 = WebMock::RequestSignature.new(:get, "www.example.com",
+        proxy: {"host" => "proxy1.example.com", "port" => 8080})
+      signature2 = WebMock::RequestSignature.new(:get, "www.example.com",
+        proxy: {"host" => "proxy2.example.com", "port" => 8080})
+      expect(signature1.hash).not_to eq(signature2.hash)
+    end
+
+    it "reports same hash for two signatures with same proxy" do
+      proxy = {"host" => "proxy.example.com", "port" => 8080}
+      signature1 = WebMock::RequestSignature.new(:get, "www.example.com", proxy: proxy)
+      signature2 = WebMock::RequestSignature.new(:get, "www.example.com", proxy: proxy)
+      expect(signature1.hash).to eq(signature2.hash)
     end
   end
 


### PR DESCRIPTION
This is a very-brainless implementation of matching on `proxy` for Webmock. Not all the supported Webmock adapters supported proxy config in an easy way, so I implemented these ones only (the other ones ignore the argument):
- Net::HTTP
- Excon
- Patron
- Typhoeus
- Curb

It's really, really similar to how Webmock implements headers. I added examples to the README, and made sure to cover my work thoroughly (which is why this PR is 500 lines).