### PR TITLE
Confirm to work with curb 1.3.7

### DIFF
--- a/lib/webmock/http_lib_adapters/curb_adapter.rb
+++ b/lib/webmock/http_lib_adapters/curb_adapter.rb
@@ -7,7 +7,7 @@ rescue LoadError
 end
 
 if defined?(Curl)
-  WebMock::VersionChecker.new('Curb', Curl::CURB_VERSION, '0.7.16', '1.2.2', ['0.8.7']).check_version!
+  WebMock::VersionChecker.new('Curb', Curl::CURB_VERSION, '0.7.16', '1.3.5', ['0.8.7']).check_version!
 
   module WebMock
     module HttpLibAdapters


### PR DESCRIPTION
The 1.3.x line is primarily Ruby 4.0 support plus Curl::Multi/Fiber-scheduler bugfixes, no public API of Curl::Easy changed, so the WebMock adapter is unaffected.